### PR TITLE
fix: general label read from h5 file

### DIFF
--- a/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-general.h
+++ b/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-general.h
@@ -97,7 +97,7 @@ protected:
   void writeLabelsGeneral(const std::string& datatypeGroup, const std::string& uuid,
                           const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>* labelsGeneral);
 
-  void readLabelsGeneral(const std::string& datatypeGroup, const std::string& uuid, std::vector<std::string> labels);
+  void readLabelsGeneral(const std::string& datatypeGroup, const std::string& uuid, std::vector<std::string>& labels);
 
   //################
   // Project

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-general.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-general.cpp
@@ -445,7 +445,7 @@ void Hdf5FbGeneral::writeLabelsGeneral(const std::string& datatypeGroup, const s
 }
 
 void Hdf5FbGeneral::readLabelsGeneral(const std::string& datatypeGroup, const std::string& uuid,
-                                      std::vector<std::string> labels)
+                                      std::vector<std::string>& labels)
 {
   std::string id = datatypeGroup + "/" + uuid;
   if (!m_file->exist(id + "/" + LABELGENERAL))


### PR DESCRIPTION
`readLabelsGeneral(...)` used a copy instead of a reference as a parameter. As a consequence, none of the read labels could actually get out of the function. Small error with a big impact :grin: