### PR TITLE
fix reading of labels general of images for FB

### DIFF
--- a/.devcontainer/.vscode/launch.json
+++ b/.devcontainer/.vscode/launch.json
@@ -41,7 +41,7 @@
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/devel/bin/seerep-server_server",
-            "args": [],
+            "args": ["-c/seerep/src/seerep.cfg"],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/seerep-data",
             "environment": [],

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-image.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-image.cpp
@@ -187,7 +187,7 @@ std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> Hdf5FbImage::readIm
   readLabelsGeneral(HDF5_GROUP_IMAGE, id, labelsGeneral, labelsGeneralInstances);
 
   std::vector<flatbuffers::Offset<seerep::fb::LabelWithInstance>> labelGeneralVector;
-  labelGeneralVector.resize(labelsGeneral.size());
+  labelGeneralVector.reserve(labelsGeneral.size());
   for (long unsigned int i = 0; i < labelsGeneral.size(); i++)
   {
     auto labelOffset = builder.CreateString(labelsGeneral.at(i));

--- a/seerep-srv/seerep-server/src/fb-image-service.cpp
+++ b/seerep-srv/seerep-server/src/fb-image-service.cpp
@@ -15,16 +15,23 @@ grpc::Status FbImageService::GetImage(grpc::ServerContext* context,
   auto requestRoot = request->GetRoot();
 
   std::stringstream debuginfo;
-  debuginfo << "sending images in bounding box min(" << requestRoot->boundingbox()->point_min()->x() << "/"
-            << requestRoot->boundingbox()->point_min()->y() << "/" << requestRoot->boundingbox()->point_min()->z()
-            << "), max(" << requestRoot->boundingbox()->point_max()->x() << "/"
-            << requestRoot->boundingbox()->point_max()->y() << "/" << requestRoot->boundingbox()->point_max()->z()
-            << ")"
-            << " and time interval (" << requestRoot->timeinterval()->time_min()->seconds() << "/"
-            << requestRoot->timeinterval()->time_max()->seconds() << ")";
+  debuginfo << "sending images with this query parameters:";
+  if (requestRoot->boundingbox() != NULL)
+  {
+    debuginfo << "bounding box min(" << requestRoot->boundingbox()->point_min()->x() << "/"
+              << requestRoot->boundingbox()->point_min()->y() << "/" << requestRoot->boundingbox()->point_min()->z()
+              << "), max(" << requestRoot->boundingbox()->point_max()->x() << "/"
+              << requestRoot->boundingbox()->point_max()->y() << "/" << requestRoot->boundingbox()->point_max()->z()
+              << ")";
+  }
+  if (requestRoot->timeinterval() != NULL)
+  {
+    debuginfo << "time interval (" << requestRoot->timeinterval()->time_min()->seconds() << "/"
+              << requestRoot->timeinterval()->time_max()->seconds() << ")";
+  }
   if (requestRoot->label() != NULL)
   {
-    debuginfo << " and labels general";
+    debuginfo << "labels general";
     for (auto label : *requestRoot->label())
     {
       debuginfo << "'" << label->str() << "' ";

--- a/util/gRPC/images/gRPC_fb_queryImage.py
+++ b/util/gRPC/images/gRPC_fb_queryImage.py
@@ -23,8 +23,9 @@ from seerep.fb import metaOperations_grpc_fb as metaOperations
 # import numpy as np
 
 
-# # server with certs
-# __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+# server with certs
+# __location__ = os.path.realpath(
+#     os.path.join(os.getcwd(), os.path.dirname(__file__)))
 # with open(os.path.join(__location__, 'tls.pem'), 'rb') as f:
 #     root_cert = f.read()
 # server = "seerep.robot.10.249.3.13.nip.io:32141"
@@ -118,7 +119,7 @@ buf = builder.Output()
 for responseBuf in stub.GetImage(bytes(buf)):
     response = Image.Image.GetRootAs(responseBuf)
     print("uuidmsg: " + response.Header().UuidMsgs().decode("utf-8"))
-    print("first label: " + response.LabelsBb(0).Label().decode("utf-8"))
+    print("first label: " + response.LabelsBb(0).LabelWithInstance().Label().decode("utf-8"))
     print(
         "first BoundingBox (Xmin,Ymin,Xmax,Ymax): "
         + str(response.LabelsBb(0).BoundingBox().PointMin().X())

--- a/util/gRPC/images/gRPC_pb_sendLabeledImage.py
+++ b/util/gRPC/images/gRPC_pb_sendLabeledImage.py
@@ -8,6 +8,7 @@ import boundingbox2d_labeled_pb2 as bb
 import grpc
 import image_pb2 as image
 import image_service_pb2_grpc as imageService
+import label_with_instance_pb2 as labelWithInstance
 import meta_operations_pb2_grpc as metaOperations
 import numpy as np
 import projectCreation_pb2 as projectCreation
@@ -78,7 +79,7 @@ for n in range(10):
 
     bb1 = bb.BoundingBox2DLabeled()
     for i in range(0, 10):
-        bb1.label = "testlabel" + str(i)
+        bb1.labelWithInstance.label = "testlabel" + str(i)
         bb1.boundingBox.point_min.x = 0.01 + i / 10
         bb1.boundingBox.point_min.y = 0.02 + i / 10
         bb1.boundingBox.point_max.x = 0.03 + i / 10
@@ -86,7 +87,9 @@ for n in range(10):
         theImage.labels_bb.append(bb1)
 
     for i in range(0, 10):
-        theImage.labels_general.append("testlabelgeneral" + str(i))
+        label = labelWithInstance.LabelWithInstance()
+        label.label = "testlabelgeneral" + str(i)
+        theImage.labels_general.append(label)
 
     uuidImg = stub.TransferImage(theImage)
 


### PR DESCRIPTION
use reserve instead of resize for std::vector<flatbuffers::Offset<T>>

fixes #68 