### PR TITLE
fix example scripts

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -141,6 +141,9 @@ RUN git clone https://github.com/google/googletest.git -b release-1.12.0 \
 #Install python3 grpcio_tools'
 RUN pip3 install grpcio-tools
 
+# Install python imgeio
+RUN pip3 install imageio==2.20.0
+
 ####################################################
 #Install documentation dependencies
 ####################################################

--- a/examples/gRPC/images/gRPC_fb_queryImage.py
+++ b/examples/gRPC/images/gRPC_fb_queryImage.py
@@ -19,9 +19,6 @@ from fb import (
 from fb import image_service_grpc_fb as imageService
 from fb import meta_operations_grpc_fb as metaOperations
 
-# import numpy as np
-
-
 # server with certs
 # __location__ = os.path.realpath(
 #     os.path.join(os.getcwd(), os.path.dirname(__file__)))
@@ -49,17 +46,17 @@ response = ProjectInfos.ProjectInfos.GetRootAs(responseBuf)
 
 projectuuid = ""
 for i in range(response.ProjectsLength()):
-    print(response.Projects(i).Name().decode("utf-8") + " " + response.Projects(i).Uuid().decode("utf-8"))
-    if response.Projects(i).Name().decode("utf-8") == "agricultural_demonstator":
+    print(response.Projects(i).Name().decode("utf-8") + " " + response.Projects(i).Uuid().decode("utf-8") + "\n")
+    if response.Projects(i).Name().decode("utf-8") == "testproject":
         projectuuid = response.Projects(i).Uuid().decode("utf-8")
 
 if projectuuid == "":
     sys.exit()
 
 Point.Start(builder)
-Point.AddX(builder, -100.0)
-Point.AddY(builder, -100.0)
-Point.AddZ(builder, -100.0)
+Point.AddX(builder, 0.0)
+Point.AddY(builder, 0.0)
+Point.AddZ(builder, 0.0)
 pointMin = Point.End(builder)
 
 Point.Start(builder)
@@ -100,7 +97,7 @@ builder.PrependUOffsetTRelative(projectuuidString)
 projectuuidMsg = builder.EndVector()
 
 
-label = builder.CreateString("1")
+label = builder.CreateString("testlabel0")
 Query.StartLabelVector(builder, 1)
 builder.PrependUOffsetTRelative(label)
 labelMsg = builder.EndVector()
@@ -117,10 +114,11 @@ buf = builder.Output()
 
 for responseBuf in stub.GetImage(bytes(buf)):
     response = Image.Image.GetRootAs(responseBuf)
-    print("uuidmsg: " + response.Header().UuidMsgs().decode("utf-8"))
+
+    print(f"uuidmsg: {response.Header().UuidMsgs().decode('utf-8')}")
     print("first label: " + response.LabelsBb(0).LabelWithInstance().Label().decode("utf-8"))
     print(
-        "first BoundingBox (Xmin,Ymin,Xmax,Ymax): "
+        "first bounding box (Xmin,Ymin,Xmax,Ymax): "
         + str(response.LabelsBb(0).BoundingBox().PointMin().X())
         + " "
         + str(response.LabelsBb(0).BoundingBox().PointMin().Y())
@@ -128,4 +126,5 @@ for responseBuf in stub.GetImage(bytes(buf)):
         + str(response.LabelsBb(0).BoundingBox().PointMax().X())
         + " "
         + str(response.LabelsBb(0).BoundingBox().PointMax().Y())
+        + "\n"
     )

--- a/examples/gRPC/images/gRPC_pb_queryImage.py
+++ b/examples/gRPC/images/gRPC_pb_queryImage.py
@@ -59,7 +59,7 @@ theQuery.label.extend(["testlabel0"])
 for img in stub.GetImage(theQuery):
     # currently not implemented #103
     # print(f"uuidmsg: {img.header.uuid_msgs}")
-    print(f"first abel: {img.labels_bb[0].labelWithInstance.label}")
+    print(f"first label: {img.labels_bb[0].labelWithInstance.label}")
     print(
         "First bounding box (Xmin, Ymin, Xmax, Ymax): "
         + str(img.labels_bb[0].boundingBox.point_min.x)

--- a/examples/gRPC/images/gRPC_pb_queryImage.py
+++ b/examples/gRPC/images/gRPC_pb_queryImage.py
@@ -9,18 +9,16 @@ import meta_operations_pb2_grpc as metaOperations
 import query_pb2 as query
 from google.protobuf import empty_pb2
 
-# import numpy as np
-
 # server with certs
-__location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
-with open(os.path.join(__location__, '../tls.pem'), 'rb') as f:
-    root_cert = f.read()
-server = "seerep.robot.10.249.3.13.nip.io:32141"
-creds = grpc.ssl_channel_credentials(root_cert)
-channel = grpc.secure_channel(server, creds)
+# __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+# with open(os.path.join(__location__, '../tls.pem'), 'rb') as f:
+#     root_cert = f.read()
+# server = "seerep.robot.10.249.3.13.nip.io:32141"
+# creds = grpc.ssl_channel_credentials(root_cert)
+# channel = grpc.secure_channel(server, creds)
 
 # server without certs
-# channel = grpc.insecure_channel("localhost:9090")
+channel = grpc.insecure_channel("localhost:9090")
 
 stub = imageService.ImageServiceStub(channel)
 stubMeta = metaOperations.MetaOperationsStub(channel)
@@ -29,7 +27,7 @@ response = stubMeta.GetProjects(empty_pb2.Empty())
 
 projectuuid = ""
 for project in response.projects:
-    print(project.name + " " + project.uuid)
+    print(project.name + " " + project.uuid + "\n")
     if project.name == "testproject":
         projectuuid = project.uuid
 
@@ -59,4 +57,17 @@ theQuery.label.extend(["testlabel0"])
 
 
 for img in stub.GetImage(theQuery):
-    print("uuid of transfered img: " + img.labels_general[0])
+    # currently not implemented #103
+    # print(f"uuidmsg: {img.header.uuid_msgs}")
+    print(f"first abel: {img.labels_bb[0].labelWithInstance.label}")
+    print(
+        "First bounding box (Xmin, Ymin, Xmax, Ymax): "
+        + str(img.labels_bb[0].boundingBox.point_min.x)
+        + " "
+        + str(img.labels_bb[0].boundingBox.point_min.y)
+        + " "
+        + str(img.labels_bb[0].boundingBox.point_max.x)
+        + " "
+        + str(img.labels_bb[0].boundingBox.point_max.y)
+        + "\n"
+    )

--- a/examples/gRPC/images/gRPC_pb_queryImageGrid.py
+++ b/examples/gRPC/images/gRPC_pb_queryImageGrid.py
@@ -28,7 +28,7 @@ response = stubMeta.GetProjects(empty_pb2.Empty())
 projectuuid = ""
 for project in response.projects:
     print(project.name + " " + project.uuid)
-    if project.name == "testproject":
+    if project.name == "LabeledImagesInGrid":
         projectuuid = project.uuid
 
 if projectuuid == "":
@@ -39,12 +39,8 @@ theQuery = query.Query()
 theQuery.projectuuid.append(projectuuid)
 theQuery.boundingbox.header.frame_id = "map"
 
-theQuery.boundingbox.point_min.x = 0.0
-theQuery.boundingbox.point_min.y = 0.0
-theQuery.boundingbox.point_min.z = 0.0
-theQuery.boundingbox.point_max.x = 100.0
-theQuery.boundingbox.point_max.y = 100.0
-theQuery.boundingbox.point_max.z = 100.0
+theQuery.boundingbox.point_min.z = -1.0
+theQuery.boundingbox.point_max.z = 1.0
 
 # since epoche
 theQuery.timeinterval.time_min.seconds = 1638549273
@@ -53,7 +49,7 @@ theQuery.timeinterval.time_max.seconds = 1938549273
 theQuery.timeinterval.time_max.nanos = 0
 
 # labels
-theQuery.label.extend(["testlabel0"])
+theQuery.label.extend(["testlabel1"])
 
 for x in range(3):
     for y in range(3):
@@ -62,4 +58,4 @@ for x in range(3):
         theQuery.boundingbox.point_max.x = x + 0.5
         theQuery.boundingbox.point_max.y = y + 0.5
         for img in stub.GetImage(theQuery):
-            print("label general 0 of transfered img: " + img.labels_general[0].label)
+            print("General label of transferred img: " + img.labels_general[0].label)

--- a/examples/gRPC/images/gRPC_pb_queryImageGrid.py
+++ b/examples/gRPC/images/gRPC_pb_queryImageGrid.py
@@ -9,18 +9,16 @@ import meta_operations_pb2_grpc as metaOperations
 import query_pb2 as query
 from google.protobuf import empty_pb2
 
-# import numpy as np
-
-# # server with certs
-__location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
-with open(os.path.join(__location__, '../tls.pem'), 'rb') as f:
-    root_cert = f.read()
-server = "seerep.robot.10.249.3.13.nip.io:32141"
-creds = grpc.ssl_channel_credentials(root_cert)
-channel = grpc.secure_channel(server, creds)
+# server with certs
+# __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+# with open(os.path.join(__location__, '../tls.pem'), 'rb') as f:
+#     root_cert = f.read()
+# server = "seerep.robot.10.249.3.13.nip.io:32141"
+# creds = grpc.ssl_channel_credentials(root_cert)
+# channel = grpc.secure_channel(server, creds)
 
 # server without certs
-# channel = grpc.insecure_channel("localhost:9090")
+channel = grpc.insecure_channel("localhost:9090")
 
 stub = imageService.ImageServiceStub(channel)
 stubMeta = metaOperations.MetaOperationsStub(channel)
@@ -30,7 +28,7 @@ response = stubMeta.GetProjects(empty_pb2.Empty())
 projectuuid = ""
 for project in response.projects:
     print(project.name + " " + project.uuid)
-    if project.name == "LabeledImagesInGrid":
+    if project.name == "testproject":
         projectuuid = project.uuid
 
 if projectuuid == "":
@@ -41,8 +39,12 @@ theQuery = query.Query()
 theQuery.projectuuid.append(projectuuid)
 theQuery.boundingbox.header.frame_id = "map"
 
-theQuery.boundingbox.point_min.z = -1.0
-theQuery.boundingbox.point_max.z = 1.0
+theQuery.boundingbox.point_min.x = 0.0
+theQuery.boundingbox.point_min.y = 0.0
+theQuery.boundingbox.point_min.z = 0.0
+theQuery.boundingbox.point_max.x = 100.0
+theQuery.boundingbox.point_max.y = 100.0
+theQuery.boundingbox.point_max.z = 100.0
 
 # since epoche
 theQuery.timeinterval.time_min.seconds = 1638549273
@@ -51,7 +53,7 @@ theQuery.timeinterval.time_max.seconds = 1938549273
 theQuery.timeinterval.time_max.nanos = 0
 
 # labels
-theQuery.label.extend(["http://aims.fao.org/aos/agrovoc/c_24596"])
+theQuery.label.extend(["testlabel0"])
 
 for x in range(3):
     for y in range(3):

--- a/examples/gRPC/images/gRPC_pb_sendLabeledImage.py
+++ b/examples/gRPC/images/gRPC_pb_sendLabeledImage.py
@@ -62,7 +62,6 @@ for n in range(10):
             r = np.ubyte((x * 255.0 + n) % 255)
             g = np.ubyte((y * 255.0 + n) % 255)
             b = np.ubyte((z * 255.0 + n) % 255)
-            # print(r, g, b)
             rgb.append(r)
             rgb.append(g)
             rgb.append(b)

--- a/examples/gRPC/images/gRPC_pb_sendLabeledImageGrid.py
+++ b/examples/gRPC/images/gRPC_pb_sendLabeledImageGrid.py
@@ -79,7 +79,7 @@ for k in range(9):
         # write labeled bounding boxes
         bb1 = bb.BoundingBox2DLabeled()
         for i in range(1, n + 1):
-            bb1.labelWithInstance.label = "http://aims.fao.org/aos/agrovoc/c_24596"
+            bb1.labelWithInstance.label = "testlabel" + str(i)
             bb1.boundingBox.point_min.x = 0.01 + i / 10
             bb1.boundingBox.point_min.y = 0.02 + i / 10
             bb1.boundingBox.point_max.x = 0.03 + i / 10
@@ -87,13 +87,9 @@ for k in range(9):
             theImage.labels_bb.append(bb1)
 
         # write general labels
-        label1 = labelWithInstance.LabelWithInstance()
-        label1.label = "http://aims.fao.org/aos/agrovoc/c_2894"
-        theImage.labels_general.append(label1)
-
-        label2 = labelWithInstance.LabelWithInstance()
-        label2.label = "http://aims.fao.org/aos/agrovoc/c_7156"
-        theImage.labels_general.append(label2)
+        label = labelWithInstance.LabelWithInstance()
+        label.label = "testlabelgeneral"
+        theImage.labels_general.append(label)
 
         # transfer image
         uuidImg = stub.TransferImage(theImage)
@@ -103,11 +99,8 @@ for k in range(9):
 # create tf with data valid for all following tfs
 theTf = tf.TransformStamped()
 theTf.header.frame_id = "map"
-# theTf.header.stamp.seconds = theTime
 theTf.header.uuid_project = projectname
 theTf.child_frame_id = "camera"
-# theTf.transform.translation.x = 0
-# theTf.transform.translation.y = 0
 theTf.transform.translation.z = 0
 theTf.transform.rotation.x = 0
 theTf.transform.rotation.y = 0


### PR DESCRIPTION
The `gRPC/` and `meta/` example scripts now work with the `testproject`. Also closes #93 