### PR TITLE
remove auto return type in seerep_hdf5_fb tests

### DIFF
--- a/seerep-hdf5/seerep-hdf5-fb/test/fb-write-load-test.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/test/fb-write-load-test.cpp
@@ -19,15 +19,19 @@ propagate the data through all components. This should be changed in the future
 to improve the quality of the tests.
 */
 
-auto createTimeStamp(flatbuffers::FlatBufferBuilder& fbb)
+namespace seerep_hdf5_fb
+{
+namespace tests
+{
+flatbuffers::Offset<seerep::fb::Timestamp> createTimeStamp(flatbuffers::FlatBufferBuilder& fbb)
 {
   auto timeStampMsgOffset = seerep::fb::CreateTimestamp(fbb, std::time(0), 0);
   fbb.Finish(timeStampMsgOffset);
   return timeStampMsgOffset;
 }
 
-auto createHeader(flatbuffers::FlatBufferBuilder& fbb, const std::string& frameId, const std::string& projectUUID,
-                  const std::string& messageUUID)
+flatbuffers::Offset<seerep::fb::Header> createHeader(flatbuffers::FlatBufferBuilder& fbb, const std::string& frameId,
+                                                     const std::string& projectUUID, const std::string& messageUUID)
 {
   auto frameIdOffset = fbb.CreateString(frameId);
   auto projectUUIDOffset = fbb.CreateString(projectUUID);
@@ -39,14 +43,15 @@ auto createHeader(flatbuffers::FlatBufferBuilder& fbb, const std::string& frameI
   return headerMsgOffset;
 }
 
-auto createPoint(flatbuffers::FlatBufferBuilder& fbb, const double x, const double y)
+flatbuffers::Offset<seerep::fb::Point2D> createPoint(flatbuffers::FlatBufferBuilder& fbb, const double x, const double y)
 {
   auto pointOffset = seerep::fb::CreatePoint2D(fbb, x, y);
   fbb.Finish(pointOffset);
   return pointOffset;
 }
 
-auto createImageData(flatbuffers::FlatBufferBuilder& fbb, const unsigned int imageHeight, const unsigned int imageWidth)
+flatbuffers::Offset<flatbuffers::Vector<uint8_t>>
+createImageData(flatbuffers::FlatBufferBuilder& fbb, const unsigned int imageHeight, const unsigned int imageWidth)
 {
   std::vector<u_int8_t> data;
   for (size_t i = 0; i < imageWidth; i++)
@@ -71,7 +76,7 @@ auto createImageData(flatbuffers::FlatBufferBuilder& fbb, const unsigned int ima
   return fbImageDataOffset;
 }
 
-auto createLabelWithInstance(flatbuffers::FlatBufferBuilder& fbb)
+flatbuffers::Offset<seerep::fb::LabelWithInstance> createLabelWithInstance(flatbuffers::FlatBufferBuilder& fbb)
 {
   boost::uuids::uuid instanceUUID = boost::uuids::random_generator()();
   auto instanceUUIDOffset = fbb.CreateString(boost::lexical_cast<std::string>(instanceUUID));
@@ -81,8 +86,8 @@ auto createLabelWithInstance(flatbuffers::FlatBufferBuilder& fbb)
   return labelWithInstanceOffset;
 }
 
-auto createBB2DLabeled(flatbuffers::FlatBufferBuilder& fbb, const std::string& projectUUID,
-                       const std::string& messageUUID)
+flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<seerep::fb::BoundingBox2DLabeled>>>
+createBB2DLabeled(flatbuffers::FlatBufferBuilder& fbb, const std::string& projectUUID, const std::string& messageUUID)
 {
   std::vector<flatbuffers::Offset<seerep::fb::BoundingBox2DLabeled>> bbLabeled;
   for (size_t i = 0; i < 10; i++)
@@ -107,8 +112,9 @@ auto createBB2DLabeled(flatbuffers::FlatBufferBuilder& fbb, const std::string& p
   return labelsBBOffset;
 }
 
-auto createImageMessage(flatbuffers::FlatBufferBuilder& fbb, const unsigned int imageHeight, const unsigned imageWidth,
-                        const std::string& projectUUID, const std::string& messageUUID)
+const seerep::fb::Image* createImageMessage(flatbuffers::FlatBufferBuilder& fbb, const unsigned int imageHeight,
+                                            const unsigned imageWidth, const std::string& projectUUID,
+                                            const std::string& messageUUID)
 {
   auto encodingOffset = fbb.CreateString("rgb8");
   auto headerOffset = createHeader(fbb, "camera", projectUUID, messageUUID);
@@ -290,3 +296,6 @@ int main(int argc, char** argv)
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
+
+}  // namespace tests
+}  // namespace seerep_hdf5_fb


### PR DESCRIPTION
- Removed auto return types
- Added `seerep_hdf5_fb` and `tests` namespace

Closes #166 