### PR TITLE
update fb to use hdf5 definitions from seerep-hdf5-core

### DIFF
--- a/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-image.h
+++ b/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-image.h
@@ -5,6 +5,8 @@
 #include <highfive/H5File.hpp>
 
 // seerep-hdf5
+#include <seerep-hdf5-core/hdf5-core-image.h>
+
 #include "seerep-hdf5-fb/hdf5-fb-general.h"
 
 // seerep-msgs
@@ -34,25 +36,6 @@ public:
 
   std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> readImage(const std::string& id,
                                                                          const bool withoutData = false);
-
-private:
-  const std::string SIZE = "size";
-  const std::string CLASS = "CLASS";
-
-  // image / pointcloud attribute keys
-  inline static const std::string HEIGHT = "height";
-  inline static const std::string WIDTH = "width";
-  inline static const std::string ENCODING = "encoding";
-  inline static const std::string IS_BIGENDIAN = "is_bigendian";
-  inline static const std::string ROW_STEP = "row_step";
-  inline static const std::string POINT_STEP = "point_step";
-  inline static const std::string IS_DENSE = "is_dense";
-
-  inline static const std::string RAWDATA = "rawdata";
-
-public:
-  // datatype group names in hdf5
-  inline static const std::string HDF5_GROUP_IMAGE = "images";
 };
 
 }  // namespace seerep_hdf5_fb

--- a/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-point.h
+++ b/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-point.h
@@ -5,18 +5,18 @@
 #include <highfive/H5File.hpp>
 
 // seerep-hdf5
-#include "seerep-hdf5-fb/hdf5-fb-general.h"
+#include <seerep-hdf5-core/hdf5-core-point.h>
+#include <seerep-hdf5-fb/hdf5-fb-general.h>
 
 // seerep-com
 #include <seerep-com/point_service.grpc.fb.h>
 
 // std
+#include <flatbuffers/grpc.h>
 #include <grpcpp/grpcpp.h>
 
 #include <boost/geometry.hpp>
 #include <optional>
-
-#include "flatbuffers/grpc.h"
 
 namespace seerep_hdf5_fb
 {
@@ -32,12 +32,6 @@ public:
 
 private:
   std::string getHdf5DatasetRawDataPath(const std::string& id);
-  // Point
-  inline static const std::string RAWDATA = "rawdata";
-
-public:
-  // datatype group names in hdf5
-  inline static const std::string HDF5_GROUP_POINT = "points";
 };
 
 }  // namespace seerep_hdf5_fb

--- a/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-tf.h
+++ b/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-tf.h
@@ -5,7 +5,8 @@
 #include <highfive/H5File.hpp>
 
 // seerep-hdf5
-#include "seerep-hdf5-fb/hdf5-fb-general.h"
+#include <seerep-hdf5-core/hdf5-core-tf.h>
+#include <seerep-hdf5-fb/hdf5-fb-general.h>
 
 // seerep-msgs
 #include <seerep-msgs/transform_stamped_generated.h>
@@ -26,12 +27,6 @@ public:
   std::optional<std::vector<flatbuffers::Offset<seerep::fb::TransformStamped>>>
   readTransformStamped(const std::string& id);
   std::optional<std::vector<std::string>> readTransformStampedFrames(const std::string& id);
-
-private:
-  // datatype group names in hdf5
-  inline static const std::string HDF5_GROUP_TF = "tf";
-
-  inline static const std::string SIZE = "size";
 };
 
 }  // namespace seerep_hdf5_fb

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-image.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-image.cpp
@@ -13,8 +13,9 @@ void Hdf5FbImage::writeImage(const std::string& id, const seerep::fb::Image& ima
 {
   const std::scoped_lock lock(*m_write_mtx);
 
-  std::string hdf5DatasetPath = HDF5_GROUP_IMAGE + "/" + id;
-  std::string hdf5DatasetRawDataPath = hdf5DatasetPath + "/" + RAWDATA;
+  std::string hdf5DatasetPath = seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE + "/" + id;
+  std::string hdf5DatasetRawDataPath =
+      seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE + "/" + seerep_hdf5_core::Hdf5CoreImage::RAWDATA;
 
   std::shared_ptr<HighFive::DataSet> data_set_ptr;
   HighFive::DataSpace data_space({ image.height(), image.width(), image.step() / image.width() });
@@ -34,23 +35,23 @@ void Hdf5FbImage::writeImage(const std::string& id, const seerep::fb::Image& ima
         std::make_shared<HighFive::DataSet>(m_file->createDataSet<uint8_t>(hdf5DatasetRawDataPath, data_space));
   }
 
-  writeAttributeToHdf5<uint32_t>(*data_set_ptr, HEIGHT, image.height());
-  writeAttributeToHdf5<uint32_t>(*data_set_ptr, WIDTH, image.width());
-  writeAttributeToHdf5<std::string>(*data_set_ptr, ENCODING, image.encoding()->str());
-  writeAttributeToHdf5<bool>(*data_set_ptr, IS_BIGENDIAN, image.is_bigendian());
-  writeAttributeToHdf5<uint32_t>(*data_set_ptr, POINT_STEP, image.step());
-  writeAttributeToHdf5<uint32_t>(*data_set_ptr, ROW_STEP, image.row_step());
+  writeAttributeToHdf5<uint32_t>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::HEIGHT, image.height());
+  writeAttributeToHdf5<uint32_t>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::WIDTH, image.width());
+  writeAttributeToHdf5<std::string>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::ENCODING, image.encoding()->str());
+  writeAttributeToHdf5<bool>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::IS_BIGENDIAN, image.is_bigendian());
+  writeAttributeToHdf5<uint32_t>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::POINT_STEP, image.step());
+  writeAttributeToHdf5<uint32_t>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::ROW_STEP, image.row_step());
 
   if (image.encoding()->str() == "rgb8" || image.encoding()->str() == "8UC3")
   {
-    writeAttributeToHdf5<std::string>(*data_set_ptr, CLASS, "IMAGE");
+    writeAttributeToHdf5<std::string>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::CLASS, "IMAGE");
     writeAttributeToHdf5<std::string>(*data_set_ptr, "IMAGE_VERSION", "1.2");
     writeAttributeToHdf5<std::string>(*data_set_ptr, "IMAGE_SUBCLASS", "IMAGE_TRUECOLOR");
     writeAttributeToHdf5<std::string>(*data_set_ptr, "INTERLACE_MODE", "INTERLACE_PIXEL");
   }
   else
   {
-    deleteAttribute(data_set_ptr, CLASS);
+    deleteAttribute(data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::CLASS);
     deleteAttribute(data_set_ptr, "IMAGE_VERSION");
     deleteAttribute(data_set_ptr, "IMAGE_SUBCLASS");
     deleteAttribute(data_set_ptr, "INTERLACE_MODE");
@@ -75,8 +76,8 @@ void Hdf5FbImage::writeImage(const std::string& id, const seerep::fb::Image& ima
   data_set_ptr->write(tmp);
   writeHeaderAttributes(*data_set_ptr, *image.header());
 
-  writeBoundingBox2DLabeled(HDF5_GROUP_IMAGE, id, image.labels_bb());
-  writeLabelsGeneral(HDF5_GROUP_IMAGE, id, image.labels_general());
+  writeBoundingBox2DLabeled(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id, image.labels_bb());
+  writeLabelsGeneral(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id, image.labels_general());
 
   m_file->flush();
 }
@@ -86,7 +87,7 @@ void Hdf5FbImage::writeImageBoundingBox2DLabeled(const std::string& id,
 {
   const std::scoped_lock lock(*m_write_mtx);
 
-  writeBoundingBox2DLabeled(HDF5_GROUP_IMAGE, id, bb2dLabeledStamped.labels_bb());
+  writeBoundingBox2DLabeled(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id, bb2dLabeledStamped.labels_bb());
 }
 
 std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> Hdf5FbImage::readImage(const std::string& id,
@@ -94,7 +95,7 @@ std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> Hdf5FbImage::readIm
 {
   const std::scoped_lock lock(*m_write_mtx);
 
-  std::string hdf5DatasetPath = HDF5_GROUP_IMAGE + "/" + id;
+  std::string hdf5DatasetPath = seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE + "/" + id;
   std::string hdf5DatasetRawDataPath = hdf5DatasetPath + "/" + RAWDATA;
 
   if (!m_file->exist(hdf5DatasetRawDataPath))
@@ -116,12 +117,13 @@ std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> Hdf5FbImage::readIm
   try
   {
     BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace) << "loading attributes";
-    height = readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, HEIGHT);
-    width = readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, WIDTH);
-    encoding = builder.CreateString(readAttributeFromHdf5<std::string>(id, *data_set_ptr, ENCODING));
-    isBigendian = readAttributeFromHdf5<bool>(id, *data_set_ptr, IS_BIGENDIAN);
-    step = readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, POINT_STEP);
-    rowStep = readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, ROW_STEP);
+    height = readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::HEIGHT);
+    width = readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::WIDTH);
+    encoding = builder.CreateString(
+        readAttributeFromHdf5<std::string>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::ENCODING));
+    isBigendian = readAttributeFromHdf5<bool>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::IS_BIGENDIAN);
+    step = readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::POINT_STEP);
+    rowStep = readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::ROW_STEP);
   }
   catch (const std::invalid_argument& e)
   {
@@ -159,7 +161,8 @@ std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> Hdf5FbImage::readIm
   std::vector<std::string> boundingBoxesLabels;
   std::vector<std::vector<double>> boundingBoxes;
   std::vector<std::string> boundingBoxesInstances;
-  readBoundingBoxLabeled(HDF5_GROUP_IMAGE, id, boundingBoxesLabels, boundingBoxes, boundingBoxesInstances);
+  readBoundingBoxLabeled(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id, boundingBoxesLabels, boundingBoxes,
+                         boundingBoxesInstances);
 
   BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace)
       << "creating the bounding boxes 2d with label fb msgs";
@@ -192,7 +195,7 @@ std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> Hdf5FbImage::readIm
 
   std::vector<std::string> labelsGeneral;
   std::vector<std::string> labelsGeneralInstances;
-  readLabelsGeneral(HDF5_GROUP_IMAGE, id, labelsGeneral, labelsGeneralInstances);
+  readLabelsGeneral(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id, labelsGeneral, labelsGeneralInstances);
 
   BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace) << "creating the label general fb msgs";
   std::vector<flatbuffers::Offset<seerep::fb::LabelWithInstance>> labelGeneralVector;

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-image.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-image.cpp
@@ -14,8 +14,7 @@ void Hdf5FbImage::writeImage(const std::string& id, const seerep::fb::Image& ima
   const std::scoped_lock lock(*m_write_mtx);
 
   std::string hdf5DatasetPath = seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE + "/" + id;
-  std::string hdf5DatasetRawDataPath =
-      seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE + "/" + seerep_hdf5_core::Hdf5CoreImage::RAWDATA;
+  std::string hdf5DatasetRawDataPath = hdf5DatasetPath + "/" + seerep_hdf5_core::Hdf5CoreImage::RAWDATA;
 
   std::shared_ptr<HighFive::DataSet> data_set_ptr;
   HighFive::DataSpace data_space({ image.height(), image.width(), image.step() / image.width() });
@@ -100,7 +99,7 @@ std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> Hdf5FbImage::readIm
 
   if (!m_file->exist(hdf5DatasetRawDataPath))
   {
-    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace) << hdf5DatasetRawDataPath << "does not exist";
+    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace) << hdf5DatasetRawDataPath << " does not exist";
     return std::nullopt;
   }
 

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-point.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-point.cpp
@@ -43,7 +43,7 @@ void Hdf5FbPoint::writePoint(const std::string& id, const seerep::fb::PointStamp
 
   writeAttributeMap(data_set_ptr, point->attribute());
 
-  writeLabelsGeneral(HDF5_GROUP_POINT, id, point->labels_general());
+  writeLabelsGeneral(seerep_hdf5_core::Hdf5CorePoint::HDF5_GROUP_POINT, id, point->labels_general());
 
   m_file->flush();
 }
@@ -99,7 +99,7 @@ std::optional<flatbuffers::grpc::Message<seerep::fb::PointStamped>> Hdf5FbPoint:
 
   std::vector<std::string> labelsGeneral;
   std::vector<std::string> labelsGeneralInstances;
-  readLabelsGeneral(HDF5_GROUP_POINT, id, labelsGeneral, labelsGeneralInstances);
+  readLabelsGeneral(seerep_hdf5_core::Hdf5CorePoint::HDF5_GROUP_POINT, id, labelsGeneral, labelsGeneralInstances);
 
   std::vector<flatbuffers::Offset<seerep::fb::LabelWithInstance>> labelGeneralVector;
   labelGeneralVector.reserve(labelsGeneral.size());
@@ -132,7 +132,7 @@ std::optional<flatbuffers::grpc::Message<seerep::fb::PointStamped>> Hdf5FbPoint:
 
 std::string Hdf5FbPoint::getHdf5DatasetRawDataPath(const std::string& id)
 {
-  return HDF5_GROUP_POINT + "/" + id + "/" + RAWDATA;
+  return seerep_hdf5_core::Hdf5CorePoint::HDF5_GROUP_POINT + "/" + id + "/" + seerep_hdf5_core::Hdf5CorePoint::RAWDATA;
 }
 
 }  // namespace seerep_hdf5_fb

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-tf.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-tf.cpp
@@ -13,7 +13,8 @@ void Hdf5FbTf::writeTransformStamped(const seerep::fb::TransformStamped& tf)
 {
   const std::scoped_lock lock(*m_write_mtx);
 
-  std::string hdf5DatasetPath = HDF5_GROUP_TF + "/" + tf.header()->frame_id()->str() + "_" + tf.child_frame_id()->str();
+  std::string hdf5DatasetPath = seerep_hdf5_core::Hdf5CoreTf::HDF5_GROUP_TF + "/" + tf.header()->frame_id()->str() +
+                                "_" + tf.child_frame_id()->str();
   std::string hdf5DatasetTimePath = hdf5DatasetPath + "/" + "time";
   std::string hdf5DatasetTransPath = hdf5DatasetPath + "/" + "translation";
   std::string hdf5DatasetRotPath = hdf5DatasetPath + "/" + "rotation";
@@ -65,7 +66,7 @@ void Hdf5FbTf::writeTransformStamped(const seerep::fb::TransformStamped& tf)
     data_set_rot_ptr = std::make_shared<HighFive::DataSet>(m_file->getDataSet(hdf5DatasetRotPath));
 
     HighFive::Group group = m_file->getGroup(hdf5DatasetPath);
-    group.getAttribute(SIZE).read(size);
+    group.getAttribute(seerep_hdf5_core::Hdf5CoreTf::SIZE).read(size);
 
     // Resize the dataset to a larger size
     data_set_time_ptr->resize({ size + 1, 2 });
@@ -96,10 +97,10 @@ void Hdf5FbTf::writeTransformStamped(const seerep::fb::TransformStamped& tf)
 
   // write the size as group attribute
   HighFive::Group group = m_file->getGroup(hdf5DatasetPath);
-  if (!group.hasAttribute(SIZE))
-    group.createAttribute(SIZE, ++size);
+  if (!group.hasAttribute(seerep_hdf5_core::Hdf5CoreTf::SIZE))
+    group.createAttribute(seerep_hdf5_core::Hdf5CoreTf::SIZE, ++size);
   else
-    group.getAttribute(SIZE).write(++size);
+    group.getAttribute(seerep_hdf5_core::Hdf5CoreTf::SIZE).write(++size);
 
   m_file->flush();
 }
@@ -109,7 +110,7 @@ Hdf5FbTf::readTransformStamped(const std::string& id)
 {
   const std::scoped_lock lock(*m_write_mtx);
 
-  std::string hdf5GroupPath = HDF5_GROUP_TF + "/" + id;
+  std::string hdf5GroupPath = seerep_hdf5_core::Hdf5CoreTf::HDF5_GROUP_TF + "/" + id;
   std::string hdf5DatasetTimePath = hdf5GroupPath + "/" + "time";
   std::string hdf5DatasetTransPath = hdf5GroupPath + "/" + "translation";
   std::string hdf5DatasetRotPath = hdf5GroupPath + "/" + "rotation";
@@ -125,7 +126,7 @@ Hdf5FbTf::readTransformStamped(const std::string& id)
   // read size
   std::shared_ptr<HighFive::Group> group_ptr = std::make_shared<HighFive::Group>(m_file->getGroup(hdf5GroupPath));
   long unsigned int size;
-  group_ptr->getAttribute(SIZE).read(size);
+  group_ptr->getAttribute(seerep_hdf5_core::Hdf5CoreTf::SIZE).read(size);
   if (size == 0)
   {
     BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::warning) << "tf data has size 0.";
@@ -188,7 +189,7 @@ std::optional<std::vector<std::string>> Hdf5FbTf::readTransformStampedFrames(con
 {
   const std::scoped_lock lock(*m_write_mtx);
 
-  std::string hdf5GroupPath = HDF5_GROUP_TF + "/" + id;
+  std::string hdf5GroupPath = seerep_hdf5_core::Hdf5CoreTf::HDF5_GROUP_TF + "/" + id;
 
   if (!m_file->exist(hdf5GroupPath))
   {


### PR DESCRIPTION
Since I just changed the locations of the hdf5 definitions, everything should work as bevor. 

Closes #183 