### PR TITLE
save and load data of images in raw bytes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -58,6 +58,7 @@ SpaceBeforeAssignmentOperators: true
 
 # Configure each individual brace in BraceWrapping
 BreakBeforeBraces: Custom
+InsertBraces: true
 
 # Control of individual brace wrapping cases
 BraceWrapping:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,7 +87,7 @@ repos:
       - id: clang-format
         name: clang-format
         description: Format files with ClangFormat.
-        entry: clang-format-10
+        entry: clang-format-15
         language: system
         files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|m|proto|vert)$
         args: [ "-fallback-style=none", "-i" ]

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,5 +1,6 @@
 FROM ros:noetic
 
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV HDF5_REL="https://github.com/BlueBrain/HighFive"
 ENV PB_REL="https://github.com/protocolbuffers/protobuf/releases"
@@ -14,6 +15,7 @@ RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends -y \
         autoconf \
         automake \
         libtool \
+        wget \
         curl \
         make \
         g++ \
@@ -45,10 +47,10 @@ RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends -y \
         && rm -rf /var/lib/apt/lists/*
 
 #Install pre-commit hooks to /root/.cache/pre-commit/
-RUN pip3 install pre-commit \
-        && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add - \
-        && add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main" \
-        && apt-get update -qq && apt-get -qq install -y --no-install-recommends \
+RUN pip3 install pre-commit
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+RUN add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main"
+RUN apt-get update -qq && apt-get -qq install -y --no-install-recommends \
                 ruby shellcheck \
                 clang-format-15 \
                 python3-catkin-lint \

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -9,6 +9,7 @@ ENV DOX_VER="Release_1_9_3"
 
 #Install general required tools
 RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends -y \
+        software-properties-common \
         bash-completion \
         autoconf \
         automake \
@@ -45,9 +46,11 @@ RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends -y \
 
 #Install pre-commit hooks to /root/.cache/pre-commit/
 RUN pip3 install pre-commit \
+        && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add - \
+        && add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main" \
         && apt-get update -qq && apt-get -qq install -y --no-install-recommends \
                 ruby shellcheck \
-                clang-format-10 \
+                clang-format-15 \
                 python3-catkin-lint \
         && rm -rf /var/lib/apt/lists/*
 

--- a/examples/cpp/seerep_ros_communication/include/seerep_ros_communication/types.h
+++ b/examples/cpp/seerep_ros_communication/include/seerep_ros_communication/types.h
@@ -88,7 +88,9 @@ std::string names()
 {
   std::string s;
   for (auto name : MessageTypeNames)
+  {
     s += name + ", ";
+  }
   return s;
 }
 

--- a/examples/python/gRPC/images/gRPC_pb_queryImage.py
+++ b/examples/python/gRPC/images/gRPC_pb_queryImage.py
@@ -5,6 +5,7 @@ import sys
 
 import image_service_pb2_grpc as imageService
 import meta_operations_pb2_grpc as metaOperations
+import numpy as np
 import query_pb2 as query
 from google.protobuf import empty_pb2
 
@@ -71,3 +72,7 @@ for img in stub.GetImage(theQuery):
         + str(img.labels_bb[0].boundingBox.point_max.y)
         + "\n"
     )
+
+    print("---Data--")
+    if img.data:
+        print(np.array([i for i in img.data]).reshape(img.height, img.width, 3))

--- a/examples/python/gRPC/images/gRPC_pb_queryImage.py
+++ b/examples/python/gRPC/images/gRPC_pb_queryImage.py
@@ -5,7 +5,6 @@ import sys
 
 import image_service_pb2_grpc as imageService
 import meta_operations_pb2_grpc as metaOperations
-import numpy as np
 import query_pb2 as query
 from google.protobuf import empty_pb2
 
@@ -72,7 +71,3 @@ for img in stub.GetImage(theQuery):
         + str(img.labels_bb[0].boundingBox.point_max.y)
         + "\n"
     )
-
-    print("---Data--")
-    if img.data:
-        print(np.array([i for i in img.data]).reshape(img.height, img.width, 3))

--- a/examples/python/gRPC/images/gRPC_pb_queryImageGrid.py
+++ b/examples/python/gRPC/images/gRPC_pb_queryImageGrid.py
@@ -32,10 +32,10 @@ if projectuuid == "":
 
 theQuery = query.Query()
 theQuery.projectuuid.append(projectuuid)
-theQuery.boundingboxstamped.header.frame_id = "map"
+theQuery.boundingboxStamped.header.frame_id = "map"
 
-theQuery.boundingboxstamped.boundingbox.point_min.z = -1.0
-theQuery.boundingboxstamped.boundingbox.point_max.z = 1.0
+theQuery.boundingboxStamped.boundingbox.point_min.z = -1.0
+theQuery.boundingboxStamped.boundingbox.point_max.z = 1.0
 
 # since epoche
 theQuery.timeinterval.time_min.seconds = 1638549273
@@ -48,9 +48,9 @@ theQuery.label.extend(["testlabel1"])
 
 for x in range(3):
     for y in range(3):
-        theQuery.boundingboxstamped.boundingbox.point_min.x = x - 0.5
-        theQuery.boundingboxstamped.boundingbox.point_min.y = y - 0.5
-        theQuery.boundingboxstamped.boundingbox.point_max.x = x + 0.5
-        theQuery.boundingboxstamped.boundingbox.point_max.y = y + 0.5
+        theQuery.boundingboxStamped.boundingbox.point_min.x = x - 0.5
+        theQuery.boundingboxStamped.boundingbox.point_min.y = y - 0.5
+        theQuery.boundingboxStamped.boundingbox.point_max.x = x + 0.5
+        theQuery.boundingboxStamped.boundingbox.point_max.y = y + 0.5
         for img in stub.GetImage(theQuery):
             print("General label of transferred img: " + img.labels_general[0].label)

--- a/examples/python/gRPC/images/gRPC_pb_sendLabeledImage.py
+++ b/examples/python/gRPC/images/gRPC_pb_sendLabeledImage.py
@@ -68,6 +68,8 @@ for n in range(10):
             rgb.append(g)
             rgb.append(b)
 
+    print(str(np.array(rgb).reshape(lim, lim, 3)) + "\n")
+
     # Add image meta-data
     theImage.header.frame_id = "camera"
     theImage.header.stamp.seconds = theTime + n

--- a/examples/python/gRPC/images/gRPC_pb_sendLabeledImage.py
+++ b/examples/python/gRPC/images/gRPC_pb_sendLabeledImage.py
@@ -68,8 +68,6 @@ for n in range(10):
             rgb.append(g)
             rgb.append(b)
 
-    print(str(np.array(rgb).reshape(lim, lim, 3)) + "\n")
-
     # Add image meta-data
     theImage.header.frame_id = "camera"
     theImage.header.stamp.seconds = theTime + n

--- a/seerep-hdf5/seerep-hdf5-core/include/seerep-hdf5-core/hdf5-core-general.h
+++ b/seerep-hdf5/seerep-hdf5-core/include/seerep-hdf5-core/hdf5-core-general.h
@@ -119,9 +119,9 @@ private:
 
 public:
   // header attribute keys
-  inline static const std::string HEADER_STAMP_SECONDS = "header_stamp_seconds";
-  inline static const std::string HEADER_STAMP_NANOS = "header_stamp_nanos";
-  inline static const std::string HEADER_FRAME_ID = "header_frame_id";
+  inline static const std::string HEADER_STAMP_SECONDS = "stamp_seconds";
+  inline static const std::string HEADER_STAMP_NANOS = "stamp_nanos";
+  inline static const std::string HEADER_FRAME_ID = "frame_id";
   inline static const std::string HEADER_SEQ = "header_seq";
 
   inline static const std::string AABB_FIELD = "AABB";

--- a/seerep-hdf5/seerep-hdf5-core/include/seerep-hdf5-core/hdf5-core-general.h
+++ b/seerep-hdf5/seerep-hdf5-core/include/seerep-hdf5-core/hdf5-core-general.h
@@ -28,9 +28,9 @@ public:
   std::vector<std::string> getGroupDatasets(const std::string& id);
   void checkExists(const std::string& id);
   std::optional<std::string> readFrameId(const std::string& datatypeGroup, const std::string& uuid);
-  //################
-  // Attributes
-  //################
+  // ################
+  //  Attributes
+  // ################
   template <typename T, class C>
   T readAttributeFromHdf5(const std::string& id, const HighFive::AnnotateTraits<C>& object, std::string attributeField);
 
@@ -38,9 +38,9 @@ public:
   void writeAttributeToHdf5(HighFive::AnnotateTraits<C>& object, std::string attributeField, T attributeValue);
 
   void deleteAttribute(const std::shared_ptr<HighFive::DataSet> dataSetPtr, std::string attributeField);
-  //################
-  // AABB
-  //################
+  // ################
+  //  AABB
+  // ################
   void writeAABB(
       const std::string& datatypeGroup, const std::string& uuid,
       const boost::geometry::model::box<boost::geometry::model::point<float, 3, boost::geometry::cs::cartesian>>& aabb);
@@ -51,9 +51,9 @@ public:
 
   bool hasAABB(const std::string& datatypeGroup, const std::string& uuid);
 
-  //################
-  // Time
-  //################
+  // ################
+  //  Time
+  // ################
   void readTimeFromRaw(const std::string& datatypeGroup, const std::string& uuid, int64_t& secs, int64_t& nanos);
   void readTime(const std::string& datatypeGroup, const std::string& uuid, int64_t& secs, int64_t& nanos);
   template <class T>
@@ -80,18 +80,18 @@ public:
                          std::vector<std::string>& instances);
   void writeLabelsGeneral(const std::string& datatypeGroup, const std::string& uuid,
                           const std::vector<std::string>& labels, const std::vector<std::string>& instances);
-  //################
-  // Project
-  //################
+  // ################
+  //  Project
+  // ################
   void writeProjectname(const std::string& projectname);
   std::string readProjectname();
 
   void writeProjectFrameId(const std::string& frameId);
   std::string readProjectFrameId();
 
-  //################
-  // Hdf5
-  //################
+  // ################
+  //  Hdf5
+  // ################
   /**
    * @brief Get a shared pointer to a hdf5 group
    *

--- a/seerep-hdf5/seerep-hdf5-core/include/seerep-hdf5-core/hdf5-core-general.h
+++ b/seerep-hdf5/seerep-hdf5-core/include/seerep-hdf5-core/hdf5-core-general.h
@@ -26,7 +26,20 @@ public:
   Hdf5CoreGeneral(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& write_mtx);
 
   std::vector<std::string> getGroupDatasets(const std::string& id);
+  /**
+   * @brief Checks if a DataSet or DataGroup exists in the file
+   * @deprecated see exists()
+   * @param id The id of the DataSet or DataGroup
+   */
   void checkExists(const std::string& id);
+
+  /**
+   * @brief Checks if a DataSet or DataGroup exists in the file
+   * @param id The id of the DataSet or DataGroup
+   * @return true if the DataSet or DataGroup exists
+   */
+  bool exists(const std::string& id);
+
   std::optional<std::string> readFrameId(const std::string& datatypeGroup, const std::string& uuid);
   // ################
   //  Attributes
@@ -110,6 +123,8 @@ public:
    */
   template <class T>
   std::shared_ptr<HighFive::DataSet> getHdf5DataSet(const std::string& hdf5DataSetPath, HighFive::DataSpace& dataSpace);
+
+  std::shared_ptr<HighFive::DataSet> getHdf5DataSet(const std::string& hdf5DataSetPath);
 
 private:
   void readLabel(const std::string& id, const std::string labelType, std::vector<std::string>& labels);

--- a/seerep-hdf5/seerep-hdf5-core/include/seerep-hdf5-core/hdf5-core-image.h
+++ b/seerep-hdf5/seerep-hdf5-core/include/seerep-hdf5-core/hdf5-core-image.h
@@ -24,7 +24,16 @@
 
 namespace seerep_hdf5_core
 {
-class Hdf5CoreImage : public Hdf5CoreGeneral, public Hdf5CoreDatatypeInterface
+struct ImageAttributes
+{
+  uint32_t height;
+  uint32_t width;
+  uint32_t step;
+  std::string encoding;
+  bool isBigendian;
+};
+
+class Hdf5CoreImage : public virtual Hdf5CoreGeneral, public Hdf5CoreDatatypeInterface
 {
 public:
   Hdf5CoreImage(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& write_mtx);
@@ -37,11 +46,18 @@ public:
   void writeLabelsGeneral(const std::string& uuid, const std::vector<std::string>& labels,
                           const std::vector<std::string>& instances);
 
+  void writeImageAttributes(const std::string& id, const ImageAttributes& attributes);
+
+  ImageAttributes readImageAttributes(const std::string& id);
+
+  const std::string getHdf5GroupPath(const std::string& id) const;
+  const std::string getHdf5DataSetPath(const std::string& id) const;
+
 public:
   inline static const std::string SIZE = "size";
   inline static const std::string CLASS = "CLASS";
 
-  // image / pointcloud attribute keys
+  // image attribute keys
   inline static const std::string HEIGHT = "height";
   inline static const std::string WIDTH = "width";
   inline static const std::string ENCODING = "encoding";

--- a/seerep-hdf5/seerep-hdf5-core/include/seerep-hdf5-core/hdf5-core-image.h
+++ b/seerep-hdf5/seerep-hdf5-core/include/seerep-hdf5-core/hdf5-core-image.h
@@ -46,8 +46,7 @@ public:
   inline static const std::string WIDTH = "width";
   inline static const std::string ENCODING = "encoding";
   inline static const std::string IS_BIGENDIAN = "is_bigendian";
-  inline static const std::string ROW_STEP = "row_step";
-  inline static const std::string POINT_STEP = "point_step";
+  inline static const std::string STEP = "step";
   inline static const std::string IS_DENSE = "is_dense";
 
   inline static const std::string RAWDATA = "rawdata";

--- a/seerep-hdf5/seerep-hdf5-core/include/seerep-hdf5-core/hdf5-core-image.h
+++ b/seerep-hdf5/seerep-hdf5-core/include/seerep-hdf5-core/hdf5-core-image.h
@@ -24,6 +24,10 @@
 
 namespace seerep_hdf5_core
 {
+/**
+ * @brief Helper struct to summarize the general attributes of an image
+ *
+ */
 struct ImageAttributes
 {
   uint32_t height;
@@ -33,30 +37,91 @@ struct ImageAttributes
   bool isBigendian;
 };
 
+/**
+ * @brief This class encompasses all hdf5-io functions which are message type independent
+ *
+ * This means that the functions can currently be used for flatbuffers and protocol buffers
+ *
+ */
 class Hdf5CoreImage : public virtual Hdf5CoreGeneral, public Hdf5CoreDatatypeInterface
 {
 public:
+  /**
+   * @brief Construct a new Hdf 5 Core Image object
+   *
+   * @param file
+   * @param write_mtx
+   */
   Hdf5CoreImage(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& write_mtx);
 
+  /**
+   * @brief Get the indices for the seerep core from an image data group
+   *
+   * @param uuid the uuid of the image data group
+   * @return std::optional<seerep_core_msgs::DatasetIndexable> the seerep core message with the indices
+   */
   std::optional<seerep_core_msgs::DatasetIndexable> readDataset(const boost::uuids::uuid& uuid);
+
+  /**
+   * @brief Get the indices for the seerep core from an image data group
+   *
+   * Used when recreating the indices on a server restart
+   *
+   * @param uuid the uuid of the image data group
+   * @return std::optional<seerep_core_msgs::DatasetIndexable> the seerep core message with the indices
+   */
   std::optional<seerep_core_msgs::DatasetIndexable> readDataset(const std::string& uuid);
 
+  /**
+   * @brief Get all of the data set UUIDs in an image data group
+   *
+   * @return std::vector<std::string> vector of UUIDs (strings)
+   */
   std::vector<std::string> getDatasetUuids();
 
+  /**
+   * @brief Write generals labels based on C++ data structures to HdF5
+   *
+   * @param uuid uuid of the image data group
+   * @param labels vector of labels
+   * @param instances vector of instances (string UUIDs)
+   */
   void writeLabelsGeneral(const std::string& uuid, const std::vector<std::string>& labels,
                           const std::vector<std::string>& instances);
 
+  /**
+   * @brief Write the general attributes of an image to hdf5
+   *
+   * @param id uuid of the image data group
+   * @param attributes struct with the general attributes
+   */
   void writeImageAttributes(const std::string& id, const ImageAttributes& attributes);
 
+  /**
+   * @brief Read general attributes of an image from hdf5
+   *
+   * @param id uuid of the image data group
+   * @return ImageAttributes struct with the general attributes
+   */
   ImageAttributes readImageAttributes(const std::string& id);
 
+  /**
+   * @brief Get the path to the hdf5 group of an image
+   *
+   * @param id uuid of the image data group
+   * @return const std::string the path to the image group
+   */
   const std::string getHdf5GroupPath(const std::string& id) const;
+
+  /**
+   * @brief Get the path to the image raw data dataset based on the data group uuid
+   *
+   * @param id uuid of the image data group
+   * @return const std::string path to the image dataset
+   */
   const std::string getHdf5DataSetPath(const std::string& id) const;
 
 public:
-  inline static const std::string SIZE = "size";
-  inline static const std::string CLASS = "CLASS";
-
   // image attribute keys
   inline static const std::string HEIGHT = "height";
   inline static const std::string WIDTH = "width";
@@ -67,7 +132,7 @@ public:
 
   inline static const std::string RAWDATA = "rawdata";
 
-  // datatype group names in hdf5
+  // datatype group name in hdf5
   inline static const std::string HDF5_GROUP_IMAGE = "images";
 };
 

--- a/seerep-hdf5/seerep-hdf5-core/include/seerep-hdf5-core/impl/hdf5-core-general.hpp
+++ b/seerep-hdf5/seerep-hdf5-core/include/seerep-hdf5-core/impl/hdf5-core-general.hpp
@@ -79,4 +79,5 @@ std::shared_ptr<HighFive::DataSet> Hdf5CoreGeneral::getHdf5DataSet(const std::st
     return std::make_shared<HighFive::DataSet>(m_file->createDataSet<T>(hdf5DataSetPath, dataSpace));
   }
 }
+
 }  // namespace seerep_hdf5_core

--- a/seerep-hdf5/seerep-hdf5-core/src/hdf5-core-general.cpp
+++ b/seerep-hdf5/seerep-hdf5-core/src/hdf5-core-general.cpp
@@ -271,9 +271,13 @@ void Hdf5CoreGeneral::writeAABB(
 
   BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace) << "write AABB as attribute";
   if (!group.hasAttribute(AABB_FIELD))
+  {
     group.createAttribute(AABB_FIELD, aabbPoints);
+  }
   else
+  {
     group.getAttribute(AABB_FIELD).write(aabbPoints);
+  }
 
   m_file->flush();
 }

--- a/seerep-hdf5/seerep-hdf5-core/src/hdf5-core-general.cpp
+++ b/seerep-hdf5/seerep-hdf5-core/src/hdf5-core-general.cpp
@@ -367,6 +367,17 @@ void Hdf5CoreGeneral::checkExists(const std::string& id)
   }
 }
 
+bool Hdf5CoreGeneral::exists(const std::string& id)
+{
+  if (!m_file->exist(id))
+  {
+    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::warning)
+        << "id " << id << " does not exist in file " << m_file->getName();
+    return false;
+  }
+  return true;
+}
+
 void Hdf5CoreGeneral::readLabel(const std::string& id, const std::string labelType, std::vector<std::string>& labels)
 {
   checkExists(id + "/" + labelType);
@@ -409,6 +420,18 @@ std::shared_ptr<HighFive::Group> Hdf5CoreGeneral::getHdf5Group(const std::string
     {
       return nullptr;
     }
+  }
+}
+
+std::shared_ptr<HighFive::DataSet> Hdf5CoreGeneral::getHdf5DataSet(const std::string& hdf5DataSetPath)
+{
+  if (exists(hdf5DataSetPath))
+  {
+    return std::make_shared<HighFive::DataSet>(m_file->getDataSet(hdf5DataSetPath));
+  }
+  else
+  {
+    return nullptr;
   }
 }
 

--- a/seerep-hdf5/seerep-hdf5-core/src/hdf5-core-image.cpp
+++ b/seerep-hdf5/seerep-hdf5-core/src/hdf5-core-image.cpp
@@ -18,22 +18,24 @@ std::optional<seerep_core_msgs::DatasetIndexable> Hdf5CoreImage::readDataset(con
 {
   const std::scoped_lock lock(*m_write_mtx);
 
-  std::string hdf5DatasetPath = HDF5_GROUP_IMAGE + "/" + uuid;
-  std::string hdf5DatasetRawDataPath = hdf5DatasetPath + "/" + seerep_hdf5_core::Hdf5CoreImage::RAWDATA;
+  std::string hdf5DataGroupPath = getHdf5GroupPath(uuid);
 
-  if (!m_file->exist(hdf5DatasetPath) || !m_file->exist(hdf5DatasetRawDataPath))
+  auto dataGroupPtr = getHdf5Group(hdf5DataGroupPath);
+
+  if (!dataGroupPtr)
+  {
     return std::nullopt;
-
-  std::shared_ptr<HighFive::DataSet> data_set_ptr =
-      std::make_shared<HighFive::DataSet>(m_file->getDataSet(hdf5DatasetRawDataPath));
+  }
 
   seerep_core_msgs::DatasetIndexable data;
 
-  data.header.frameId = readAttributeFromHdf5<std::string>(hdf5DatasetRawDataPath, *data_set_ptr,
+  data.header.datatype = seerep_core_msgs::Datatype::Image;
+
+  data.header.frameId = readAttributeFromHdf5<std::string>(hdf5DataGroupPath, *dataGroupPtr,
                                                            seerep_hdf5_core::Hdf5CoreImage::HEADER_FRAME_ID);
-  data.header.timestamp.seconds = readAttributeFromHdf5<int64_t>(hdf5DatasetRawDataPath, *data_set_ptr,
+  data.header.timestamp.seconds = readAttributeFromHdf5<int64_t>(hdf5DataGroupPath, *dataGroupPtr,
                                                                  seerep_hdf5_core::Hdf5CoreImage::HEADER_STAMP_SECONDS);
-  data.header.timestamp.nanos = readAttributeFromHdf5<int64_t>(hdf5DatasetRawDataPath, *data_set_ptr,
+  data.header.timestamp.nanos = readAttributeFromHdf5<int64_t>(hdf5DataGroupPath, *dataGroupPtr,
                                                                seerep_hdf5_core::Hdf5CoreImage::HEADER_STAMP_NANOS);
 
   boost::uuids::string_generator gen;

--- a/seerep-hdf5/seerep-hdf5-core/src/hdf5-core-image.cpp
+++ b/seerep-hdf5/seerep-hdf5-core/src/hdf5-core-image.cpp
@@ -100,4 +100,54 @@ void Hdf5CoreImage::writeLabelsGeneral(const std::string& uuid, const std::vecto
   Hdf5CoreGeneral::writeLabelsGeneral(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, uuid, labels, instances);
 }
 
+void Hdf5CoreImage::writeImageAttributes(const std::string& id, const ImageAttributes& attributes)
+{
+  std::string hdf5GroupPath = getHdf5GroupPath(id);
+  std::string hdf5DatasetPath = getHdf5DataSetPath(id);
+
+  auto dataGroupPtr = getHdf5Group(hdf5GroupPath, false);
+  auto dataSetPtr = getHdf5DataSet(hdf5DatasetPath);
+
+  if (dataGroupPtr && dataSetPtr)
+  {
+    writeAttributeToHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::HEIGHT, attributes.height);
+    writeAttributeToHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::WIDTH, attributes.width);
+    writeAttributeToHdf5<std::string>(*dataSetPtr, seerep_hdf5_core::Hdf5CoreImage::ENCODING, attributes.encoding);
+    writeAttributeToHdf5<bool>(*dataSetPtr, seerep_hdf5_core::Hdf5CoreImage::IS_BIGENDIAN, attributes.isBigendian);
+    writeAttributeToHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::STEP, attributes.step);
+  }
+}
+
+ImageAttributes Hdf5CoreImage::readImageAttributes(const std::string& id)
+{
+  std::string hdf5GroupPath = getHdf5GroupPath(id);
+  std::string hdf5DatasetPath = getHdf5DataSetPath(id);
+
+  auto dataGroupPtr = getHdf5Group(hdf5GroupPath, false);
+  auto dataSetPtr = getHdf5DataSet(hdf5DatasetPath);
+
+  ImageAttributes attributes;
+
+  if (dataGroupPtr && dataSetPtr)
+  {
+    attributes.height = readAttributeFromHdf5<uint32_t>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::HEIGHT);
+    attributes.width = readAttributeFromHdf5<uint32_t>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::WIDTH);
+    attributes.encoding =
+        readAttributeFromHdf5<std::string>(id, *dataSetPtr, seerep_hdf5_core::Hdf5CoreImage::ENCODING);
+    attributes.isBigendian =
+        readAttributeFromHdf5<bool>(id, *dataSetPtr, seerep_hdf5_core::Hdf5CoreImage::IS_BIGENDIAN);
+    attributes.step = readAttributeFromHdf5<uint32_t>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::STEP);
+  }
+  return attributes;
+}
+
+const std::string Hdf5CoreImage::getHdf5GroupPath(const std::string& id) const
+{
+  return HDF5_GROUP_IMAGE + "/" + id;
+}
+
+const std::string Hdf5CoreImage::getHdf5DataSetPath(const std::string& id) const
+{
+  return getHdf5GroupPath(id) + "/" + RAWDATA;
+}
 }  // namespace seerep_hdf5_core

--- a/seerep-hdf5/seerep-hdf5-core/src/hdf5-core-point-cloud.cpp
+++ b/seerep-hdf5/seerep-hdf5-core/src/hdf5-core-point-cloud.cpp
@@ -21,7 +21,9 @@ std::optional<seerep_core_msgs::DatasetIndexable> Hdf5CorePointCloud::readDatase
   std::string hdf5DatasetPath = HDF5_GROUP_POINTCLOUD + "/" + uuid;
 
   if (!m_file->exist(hdf5DatasetPath))
+  {
     return std::nullopt;
+  }
 
   std::shared_ptr<HighFive::Group> group_ptr = std::make_shared<HighFive::Group>(m_file->getGroup(hdf5DatasetPath));
 

--- a/seerep-hdf5/seerep-hdf5-core/src/hdf5-core-point.cpp
+++ b/seerep-hdf5/seerep-hdf5-core/src/hdf5-core-point.cpp
@@ -22,7 +22,9 @@ std::optional<seerep_core_msgs::DatasetIndexable> Hdf5CorePoint::readDataset(con
   std::string hdf5DatasetRawDataPath = hdf5DatasetPath + "/" + seerep_hdf5_core::Hdf5CorePoint::RAWDATA;
 
   if (!m_file->exist(hdf5DatasetPath) || !m_file->exist(hdf5DatasetRawDataPath))
+  {
     return std::nullopt;
+  }
 
   std::shared_ptr<HighFive::DataSet> data_set_ptr =
       std::make_shared<HighFive::DataSet>(m_file->getDataSet(hdf5DatasetRawDataPath));

--- a/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-general.h
+++ b/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-general.h
@@ -29,19 +29,23 @@
 #include <boost/log/trivial.hpp>
 namespace seerep_hdf5_fb
 {
+// make nested flatbuffers readable
+typedef flatbuffers::Vector<flatbuffers::Offset<seerep::fb::BoundingBoxLabeled>> BoundingBoxesLabeledFb;
+typedef flatbuffers::Vector<flatbuffers::Offset<seerep::fb::BoundingBox2DLabeled>> BoundingBoxes2dLabeledFb;
+typedef flatbuffers::Vector<flatbuffers::Offset<seerep::fb::LabelWithInstance>> GeneralLabelsFb;
+typedef flatbuffers::Vector<flatbuffers::Offset<seerep::fb::UnionMapEntry>> AttributeMapsFb;
+
 class Hdf5FbGeneral : public virtual seerep_hdf5_core::Hdf5CoreGeneral
 {
 protected:
   Hdf5FbGeneral(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& write_mtx);
 
-  //################
-  // Attributes
-  //################
-  void writeAttributeMap(const std::shared_ptr<HighFive::DataSet> dataSetPtr,
-                         const flatbuffers::Vector<flatbuffers::Offset<seerep::fb::UnionMapEntry>>* attributes);
+  // Attributes can be written to DataSets or DataGroups
+  void writeAttributeMap(const std::shared_ptr<HighFive::DataSet> dataSetPtr, const AttributeMapsFb* attributes);
+
   template <class T>
-  flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<seerep::fb::UnionMapEntry>>>
-  readAttributeMap(HighFive::AnnotateTraits<T>& object, flatbuffers::grpc::MessageBuilder& builder);
+  flatbuffers::Offset<AttributeMapsFb> readAttributeMap(HighFive::AnnotateTraits<T>& object,
+                                                        flatbuffers::grpc::MessageBuilder& builder);
 
   template <class T>
   void writeHeaderAttributes(HighFive::AnnotateTraits<T>& object, const seerep::fb::Header* header);
@@ -51,22 +55,22 @@ protected:
                                                                HighFive::AnnotateTraits<T>& object,
                                                                std::string uuidMsg);
 
-  //################
-  // BoundingBoxes
-  //################
-  void writeBoundingBoxLabeled(
-      const std::string& datatypeGroup, const std::string& uuid,
-      const flatbuffers::Vector<flatbuffers::Offset<seerep::fb::BoundingBoxLabeled>>* boundingboxLabeled);
+  // Bounding boxes are stored as a DataSet
+  void writeBoundingBoxLabeled(const std::string& datatypeGroup, const std::string& uuid,
+                               const BoundingBoxesLabeledFb* boundingboxLabeled);
 
-  void writeBoundingBox2DLabeled(
-      const std::string& datatypeGroup, const std::string& uuid,
-      const flatbuffers::Vector<flatbuffers::Offset<seerep::fb::BoundingBox2DLabeled>>* boundingbox2DLabeled);
+  void writeBoundingBox2DLabeled(const std::string& datatypeGroup, const std::string& uuid,
+                                 const BoundingBoxes2dLabeledFb* boundingbox2dLabeled);
 
-  //################
-  // Labels General
-  //################
-  void writeLabelsGeneral(const std::string& datatypeGroup, const std::string& uuid,
-                          const flatbuffers::Vector<flatbuffers::Offset<seerep::fb::LabelWithInstance>>* labelsGeneral);
+  flatbuffers::Offset<BoundingBoxes2dLabeledFb> readBoundingBoxes2DLabeled(const std::string& datatypeGroup,
+                                                                           const std::string& id,
+                                                                           flatbuffers::grpc::MessageBuilder& builder);
+  // General Labels are stored as a DataSet
+  void writeLabelsGeneral(const std::string& datatypeGroup, const std::string& sid,
+                          const GeneralLabelsFb* labelsGeneral);
+
+  flatbuffers::Offset<GeneralLabelsFb> readGeneralLabels(const std::string& datatypeGroup, const std::string& id,
+                                                         flatbuffers::grpc::MessageBuilder& builder);
 };
 
 }  // namespace seerep_hdf5_fb

--- a/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-general.h
+++ b/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-general.h
@@ -29,7 +29,7 @@
 #include <boost/log/trivial.hpp>
 namespace seerep_hdf5_fb
 {
-class Hdf5FbGeneral : public seerep_hdf5_core::Hdf5CoreGeneral
+class Hdf5FbGeneral : public virtual seerep_hdf5_core::Hdf5CoreGeneral
 {
 protected:
   Hdf5FbGeneral(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& write_mtx);

--- a/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-general.h
+++ b/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-general.h
@@ -35,40 +35,109 @@ typedef flatbuffers::Vector<flatbuffers::Offset<seerep::fb::BoundingBox2DLabeled
 typedef flatbuffers::Vector<flatbuffers::Offset<seerep::fb::LabelWithInstance>> GeneralLabelsFb;
 typedef flatbuffers::Vector<flatbuffers::Offset<seerep::fb::UnionMapEntry>> AttributeMapsFb;
 
+/**
+ * @brief This class encompasses all read and write operations for the hdf5-fb-io which can be used by different data types
+ *
+ */
 class Hdf5FbGeneral : public virtual seerep_hdf5_core::Hdf5CoreGeneral
 {
 protected:
+  /**
+   * @brief Construct a new general hdf5-fb-io object
+   *
+   * @param file shared pointer to the hdf5 file
+   * @param write_mtx mutex to ensure thread safety
+   */
   Hdf5FbGeneral(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& write_mtx);
 
-  // Attributes can be written to DataSets or DataGroups
+  /**
+   * @brief Write a flatbuffers attribute map message to a dataset
+   *
+   * @param dataSetPtr shared pointer to the dataset, where the attributes should be written to
+   * @param attributes pointer to the flatbuffers attribute map message
+   */
   void writeAttributeMap(const std::shared_ptr<HighFive::DataSet> dataSetPtr, const AttributeMapsFb* attributes);
 
+  /**
+   * @brief Read a attribute map from a data set or data group and receive it as a flatbuffers message
+   *
+   * @param object the HighFive data set ot data group to read from
+   * @param builder the flatbuffers message builder
+   * @return flatbuffers::Offset<AttributeMapsFb> the flatbuffers attribute map message
+   */
   template <class T>
   flatbuffers::Offset<AttributeMapsFb> readAttributeMap(HighFive::AnnotateTraits<T>& object,
                                                         flatbuffers::grpc::MessageBuilder& builder);
-
+  /**
+   * @brief Write a flatbuffers header message to a data set or data group
+   *
+   * @param object the HighFive data set ot data group to write to
+   * @param header pointer to the flatbuffers header message
+   */
   template <class T>
   void writeHeaderAttributes(HighFive::AnnotateTraits<T>& object, const seerep::fb::Header* header);
 
+  /**
+   * @brief Read a header from a data set or data group and receive it as a flatbuffers message
+   *
+   * @param builder the flatbuffers message builder
+   * @param object the HighFive data set ot data group to read from
+   * @param uuidMsg the uuid of the message, the header belongs to (for logging purposes)
+   * @return flatbuffers::Offset<seerep::fb::Header> the flatbuffers header message
+   */
   template <class T>
   flatbuffers::Offset<seerep::fb::Header> readHeaderAttributes(flatbuffers::grpc::MessageBuilder& builder,
                                                                HighFive::AnnotateTraits<T>& object,
                                                                std::string uuidMsg);
 
-  // Bounding boxes are stored as a DataSet
+  /**
+   * @brief Write a flatbuffers 3D bounding box message to hdf5
+   *
+   * @param datatypeGroup the data type the bounding box should be written to e.g point cloud, image
+   * @param uuid the uuid of the data group, the bounding box should be written to
+   * @param boundingboxLabeled the flatbuffers 3D bounding box message
+   */
   void writeBoundingBoxLabeled(const std::string& datatypeGroup, const std::string& uuid,
                                const BoundingBoxesLabeledFb* boundingboxLabeled);
 
+  /**
+   * @brief Write a flatbuffers 2D bounding box message to hdf5
+   *
+   * @param datatypeGroup the data type the bounding box should be written to e.g image
+   * @param uuid the uuid of the data group, the bounding box should be written to
+   * @param boundingbox2dLabeled the flatbuffers 2D bounding box message
+   */
   void writeBoundingBox2DLabeled(const std::string& datatypeGroup, const std::string& uuid,
                                  const BoundingBoxes2dLabeledFb* boundingbox2dLabeled);
 
+  /**
+   * @brief Read a 2D bounding box from hdf5 and receive it as a flatbuffers message
+   *
+   * @param datatypeGroup the data type the bounding box should be written to e.g image
+   * @param id uuid of the data group, the bounding box should be written to
+   * @param builder the flatbuffers message builder
+   * @return flatbuffers::Offset<BoundingBoxes2dLabeledFb> the flatbuffers 2D bounding box message
+   */
   flatbuffers::Offset<BoundingBoxes2dLabeledFb> readBoundingBoxes2DLabeled(const std::string& datatypeGroup,
                                                                            const std::string& id,
                                                                            flatbuffers::grpc::MessageBuilder& builder);
-  // General Labels are stored as a DataSet
+  /**
+   * @brief Write a flatbuffers general labels message to hdf5
+   *
+   * @param datatypeGroup the data type the general labels should be written to e.g point cloud, image
+   * @param sid the uuid of the data group, the general labels should be written to
+   * @param labelsGeneral the flatbuffers general labels message
+   */
   void writeLabelsGeneral(const std::string& datatypeGroup, const std::string& sid,
                           const GeneralLabelsFb* labelsGeneral);
-
+  /**
+   * @brief Read general labels from hdf5 and receive it as a flatbuffers message
+   *
+   * @param datatypeGroup the data type the general labels should be written to e.g point cloud, image
+   * @param id the id of the data group, the general labels should be written to
+   * @param builder the flatbuffers message builder
+   * @return flatbuffers::Offset<GeneralLabelsFb> the flatbuffers general labels message
+   */
   flatbuffers::Offset<GeneralLabelsFb> readGeneralLabels(const std::string& datatypeGroup, const std::string& id,
                                                          flatbuffers::grpc::MessageBuilder& builder);
 };

--- a/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-image.h
+++ b/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-image.h
@@ -30,7 +30,7 @@ typedef flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<seerep::fb::
 
 namespace seerep_hdf5_fb
 {
-class Hdf5FbImage : public Hdf5FbGeneral
+class Hdf5FbImage : public Hdf5FbGeneral, public seerep_hdf5_core::Hdf5CoreImage
 {
 public:
   Hdf5FbImage(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& write_mtx);
@@ -43,9 +43,6 @@ public:
                                                                          const bool withoutData = false);
 
 private:
-  const std::string getHdf5GroupPath(const std::string& id) const;
-  const std::string getHdf5DataSetPath(const std::string& id) const;
-
   BoundingBoxes2DLabeledOffset readBoundingBoxes2DLabeled(flatbuffers::grpc::MessageBuilder& builder,
                                                           const std::string& id);
   GeneralLabelsOffset readGeneralLabels(flatbuffers::grpc::MessageBuilder& builder, const std::string& id);

--- a/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-image.h
+++ b/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-image.h
@@ -23,6 +23,11 @@
 
 #include "flatbuffers/grpc.h"
 
+// make nested flatbuffers readable
+typedef flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<seerep::fb::BoundingBox2DLabeled>>>
+    BoundingBoxes2DLabeledOffset;
+typedef flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<seerep::fb::LabelWithInstance>>> GeneralLabelsOffset;
+
 namespace seerep_hdf5_fb
 {
 class Hdf5FbImage : public Hdf5FbGeneral
@@ -40,6 +45,10 @@ public:
 private:
   const std::string getHdf5GroupPath(const std::string& id) const;
   const std::string getHdf5DataSetPath(const std::string& id) const;
+
+  BoundingBoxes2DLabeledOffset readBoundingBoxes2DLabeled(flatbuffers::grpc::MessageBuilder& builder,
+                                                          const std::string& id);
+  GeneralLabelsOffset readGeneralLabels(flatbuffers::grpc::MessageBuilder& builder, const std::string& id);
 };
 
 }  // namespace seerep_hdf5_fb

--- a/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-image.h
+++ b/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-image.h
@@ -28,15 +28,47 @@ namespace seerep_hdf5_fb
 // make nested flatbuffers readable
 typedef flatbuffers::Vector<uint8_t> ByteArrayFb;
 
+/**
+ * @brief The class Hdf5FbImage is used to write and read flatbuffers image messages to/from hdf5 files
+ *
+ */
 class Hdf5FbImage : public Hdf5FbGeneral, public seerep_hdf5_core::Hdf5CoreImage
 {
 public:
+  /**
+   * @brief Construct a new Hdf5FbImage object
+   *
+   * @param file shared pointer to the hdf5 file, to write the images to
+   * @param write_mtx mutex to ensure thread safety
+   */
   Hdf5FbImage(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& write_mtx);
 
+  /**
+   * @brief Write a flatbuffers image message to hdf5
+   *
+   * @param id
+   * @param image the flatbuffers image message
+   */
   void writeImage(const std::string& id, const seerep::fb::Image& image);
+
+  /**
+   * @brief Write a BoundingBoxes2D flatbuffers message to hdf5
+   *
+   * Currently only used by the ROS dumper
+   *
+   * @param id the uuid of the image data group
+   * @param bb2dLabeledStamped the flatbuffers BoundingBoxes2D message
+   */
   void writeImageBoundingBox2DLabeled(const std::string& id,
                                       const seerep::fb::BoundingBoxes2DLabeledStamped& bb2dLabeledStamped);
-
+  /**
+   * @brief Read an image from hdf5 and receive it as a flatbuffers message
+   *
+   * @param id the uuid of the image data group
+   * @param withoutData should the image data be excluded from the message?
+   * @return std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> the flatbuffers image message, can be empty if
+   * an error occurred
+   */
   std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> readImage(const std::string& id,
                                                                          const bool withoutData = false);
 };

--- a/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-image.h
+++ b/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-image.h
@@ -36,6 +36,10 @@ public:
 
   std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> readImage(const std::string& id,
                                                                          const bool withoutData = false);
+
+private:
+  const std::string getHdf5GroupPath(const std::string& id) const;
+  const std::string getHdf5DataSetPath(const std::string& id) const;
 };
 
 }  // namespace seerep_hdf5_fb

--- a/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-image.h
+++ b/seerep-hdf5/seerep-hdf5-fb/include/seerep-hdf5-fb/hdf5-fb-image.h
@@ -23,13 +23,11 @@
 
 #include "flatbuffers/grpc.h"
 
-// make nested flatbuffers readable
-typedef flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<seerep::fb::BoundingBox2DLabeled>>>
-    BoundingBoxes2DLabeledOffset;
-typedef flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<seerep::fb::LabelWithInstance>>> GeneralLabelsOffset;
-
 namespace seerep_hdf5_fb
 {
+// make nested flatbuffers readable
+typedef flatbuffers::Vector<uint8_t> ByteArrayFb;
+
 class Hdf5FbImage : public Hdf5FbGeneral, public seerep_hdf5_core::Hdf5CoreImage
 {
 public:
@@ -41,11 +39,6 @@ public:
 
   std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> readImage(const std::string& id,
                                                                          const bool withoutData = false);
-
-private:
-  BoundingBoxes2DLabeledOffset readBoundingBoxes2DLabeled(flatbuffers::grpc::MessageBuilder& builder,
-                                                          const std::string& id);
-  GeneralLabelsOffset readGeneralLabels(flatbuffers::grpc::MessageBuilder& builder, const std::string& id);
 };
 
 }  // namespace seerep_hdf5_fb

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-general.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-general.cpp
@@ -49,9 +49,8 @@ void Hdf5FbGeneral::writeAttributeMap(
   }
 }
 
-void Hdf5FbGeneral::writeBoundingBoxLabeled(
-    const std::string& datatypeGroup, const std::string& uuid,
-    const flatbuffers::Vector<flatbuffers::Offset<seerep::fb::BoundingBoxLabeled>>* boundingboxLabeled)
+void Hdf5FbGeneral::writeBoundingBoxLabeled(const std::string& datatypeGroup, const std::string& uuid,
+                                            const BoundingBoxesLabeledFb* boundingboxLabeled)
 {
   if (boundingboxLabeled && boundingboxLabeled->size() != 0)
   {
@@ -87,9 +86,8 @@ void Hdf5FbGeneral::writeBoundingBoxLabeled(
   }
 }
 
-void Hdf5FbGeneral::writeBoundingBox2DLabeled(
-    const std::string& datatypeGroup, const std::string& uuid,
-    const flatbuffers::Vector<flatbuffers::Offset<seerep::fb::BoundingBox2DLabeled>>* boundingbox2DLabeled)
+void Hdf5FbGeneral::writeBoundingBox2DLabeled(const std::string& datatypeGroup, const std::string& uuid,
+                                              const BoundingBoxes2dLabeledFb* boundingbox2DLabeled)
 {
   std::string id = datatypeGroup + "/" + uuid;
 
@@ -133,9 +131,48 @@ void Hdf5FbGeneral::writeBoundingBox2DLabeled(
   }
 }
 
-void Hdf5FbGeneral::writeLabelsGeneral(
-    const std::string& datatypeGroup, const std::string& uuid,
-    const flatbuffers::Vector<flatbuffers::Offset<seerep::fb::LabelWithInstance>>* labelsGeneral)
+flatbuffers::Offset<BoundingBoxes2dLabeledFb>
+Hdf5FbGeneral::readBoundingBoxes2DLabeled(const std::string& datatypeGroup, const std::string& id,
+                                          flatbuffers::grpc::MessageBuilder& builder)
+{
+  // get message type independent representation from seerep-core
+  std::vector<std::string> labels;
+  std::vector<std::vector<double>> boxes2D;
+  std::vector<std::string> instances;
+
+  Hdf5CoreGeneral::readBoundingBoxLabeled(datatypeGroup, id, labels, boxes2D, instances);
+
+  // convert into flatbuffers message
+  std::vector<flatbuffers::Offset<seerep::fb::BoundingBox2DLabeled>> bblabeledVector;
+  for (long unsigned int i = 0; i < boxes2D.size(); i++)
+  {
+    auto InstanceOffset = builder.CreateString(instances.at(i));
+    auto labelOffset = builder.CreateString(labels.at(i));
+
+    seerep::fb::LabelWithInstanceBuilder labelBuilder(builder);
+    labelBuilder.add_instanceUuid(InstanceOffset);
+    labelBuilder.add_label(labelOffset);
+    auto labelWithInstanceOffset = labelBuilder.Finish();
+
+    auto pointMin = seerep::fb::CreatePoint2D(builder, boxes2D.at(i).at(0), boxes2D.at(i).at(1));
+    auto pointMax = seerep::fb::CreatePoint2D(builder, boxes2D.at(i).at(2), boxes2D.at(i).at(3));
+
+    seerep::fb::Boundingbox2DBuilder bbBuilder(builder);
+    bbBuilder.add_point_min(pointMin);
+    bbBuilder.add_point_max(pointMax);
+    auto bb = bbBuilder.Finish();
+
+    seerep::fb::BoundingBox2DLabeledBuilder bblabeledBuilder(builder);
+    bblabeledBuilder.add_bounding_box(bb);
+    bblabeledBuilder.add_labelWithInstance(labelWithInstanceOffset);
+
+    bblabeledVector.push_back(bblabeledBuilder.Finish());
+  }
+  return builder.CreateVector(bblabeledVector);
+}
+
+void Hdf5FbGeneral::writeLabelsGeneral(const std::string& datatypeGroup, const std::string& uuid,
+                                       const GeneralLabelsFb* labelsGeneral)
 {
   if (labelsGeneral && labelsGeneral->size() != 0)
   {
@@ -149,6 +186,33 @@ void Hdf5FbGeneral::writeLabelsGeneral(
     }
     Hdf5CoreGeneral::writeLabelsGeneral(datatypeGroup, uuid, labels, instances);
   }
+}
+
+flatbuffers::Offset<GeneralLabelsFb> Hdf5FbGeneral::readGeneralLabels(const std::string& datatypeGroup,
+                                                                      const std::string& id,
+                                                                      flatbuffers::grpc::MessageBuilder& builder)
+{
+  // get message type independent representation from seerep-core
+  std::vector<std::string> labels;
+  std::vector<std::string> instances;
+
+  Hdf5CoreGeneral::readLabelsGeneral(datatypeGroup, id, labels, instances);
+
+  // convert into flatbuffers message
+  std::vector<flatbuffers::Offset<seerep::fb::LabelWithInstance>> labelGeneralVector;
+  labelGeneralVector.reserve(labels.size());
+  for (long unsigned int i = 0; i < labels.size(); i++)
+  {
+    auto labelOffset = builder.CreateString(labels.at(i));
+    auto instanceOffset = builder.CreateString(instances.at(i));
+
+    seerep::fb::LabelWithInstanceBuilder labelBuilder(builder);
+    labelBuilder.add_label(labelOffset);
+    labelBuilder.add_instanceUuid(instanceOffset);
+    labelGeneralVector.push_back(labelBuilder.Finish());
+  }
+
+  return builder.CreateVector<flatbuffers::Offset<seerep::fb::LabelWithInstance>>(labelGeneralVector);
 }
 
 }  // namespace seerep_hdf5_fb

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-image.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-image.cpp
@@ -89,7 +89,9 @@ std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> Hdf5FbImage::readIm
   imageBuilder.add_is_bigendian(imageAttributes.isBigendian);
   imageBuilder.add_step(imageAttributes.step);
   if (!withoutData)
+  {
     imageBuilder.add_data(imageDataOffset);
+  }
   imageBuilder.add_header(headerOffset);
   imageBuilder.add_labels_bb(boxes2DLabeledOffset);
   imageBuilder.add_labels_general(generalLabelsOffset);

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-image.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-image.cpp
@@ -38,8 +38,7 @@ void Hdf5FbImage::writeImage(const std::string& id, const seerep::fb::Image& ima
   writeAttributeToHdf5<uint32_t>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::WIDTH, image.width());
   writeAttributeToHdf5<std::string>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::ENCODING, image.encoding()->str());
   writeAttributeToHdf5<bool>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::IS_BIGENDIAN, image.is_bigendian());
-  writeAttributeToHdf5<uint32_t>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::POINT_STEP, image.step());
-  writeAttributeToHdf5<uint32_t>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::ROW_STEP, image.row_step());
+  writeAttributeToHdf5<uint32_t>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::STEP, image.step());
 
   if (image.encoding()->str() == "rgb8" || image.encoding()->str() == "8UC3")
   {
@@ -110,7 +109,7 @@ std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> Hdf5FbImage::readIm
 
   flatbuffers::grpc::MessageBuilder builder;
 
-  uint32_t step, height, width, rowStep;
+  uint32_t step, height, width;
   flatbuffers::Offset<flatbuffers::String> encoding;
   bool isBigendian;
   try
@@ -121,8 +120,7 @@ std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> Hdf5FbImage::readIm
     encoding = builder.CreateString(
         readAttributeFromHdf5<std::string>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::ENCODING));
     isBigendian = readAttributeFromHdf5<bool>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::IS_BIGENDIAN);
-    step = readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::POINT_STEP);
-    rowStep = readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::ROW_STEP);
+    step = readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::STEP);
   }
   catch (const std::invalid_argument& e)
   {
@@ -220,7 +218,6 @@ std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> Hdf5FbImage::readIm
   imageBuilder.add_encoding(encoding);
   imageBuilder.add_is_bigendian(isBigendian);
   imageBuilder.add_step(step);
-  imageBuilder.add_row_step(rowStep);
 
   if (!withoutData)
   {

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-image.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-image.cpp
@@ -16,107 +16,81 @@ void Hdf5FbImage::writeImage(const std::string& id, const seerep::fb::Image& ima
   std::string hdf5GroupPath = getHdf5GroupPath(id);
   std::string hdf5DatasetRawDataPath = getHdf5DataSetPath(id);
 
-  std::shared_ptr<HighFive::Group> dataGroupPtr = getHdf5Group(hdf5GroupPath, true);
+  HighFive::DataSpace dataSpace(image.height() * image.step());
+  auto dataGroupPtr = getHdf5Group(hdf5GroupPath, true);
+  auto dataSetPtr = getHdf5DataSet<uint8_t>(hdf5DatasetRawDataPath, dataSpace);
 
-  HighFive::DataSpace dataSpace({ image.height() * image.step() });
-  std::shared_ptr<HighFive::DataSet> dataSetPtr = getHdf5DataSet<uint8_t>(hdf5DatasetRawDataPath, dataSpace);
-
-  writeAttributeToHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::HEIGHT, image.height());
-  writeAttributeToHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::WIDTH, image.width());
-  writeAttributeToHdf5<std::string>(*dataSetPtr, seerep_hdf5_core::Hdf5CoreImage::ENCODING, image.encoding()->str());
-  writeAttributeToHdf5<bool>(*dataSetPtr, seerep_hdf5_core::Hdf5CoreImage::IS_BIGENDIAN, image.is_bigendian());
-  writeAttributeToHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::STEP, image.step());
-
-  const uint8_t* dataPtr = image.data()->Data();
-  dataSetPtr->write(std::vector<uint8_t>(dataPtr, dataPtr + image.data()->size()));
   writeHeaderAttributes(*dataGroupPtr, image.header());
 
+  seerep_hdf5_core::ImageAttributes imageAttributes = { image.height(), image.width(), image.step(),
+                                                        image.encoding()->str(), image.is_bigendian() };
+  writeImageAttributes(id, imageAttributes);
+
+  const uint8_t* arrayStartPtr = image.data()->Data();
+  // use pointers from start and end of the array as iterators
+  dataSetPtr->write(std::vector<uint8_t>(arrayStartPtr, arrayStartPtr + image.data()->size()));
+
   writeBoundingBox2DLabeled(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id, image.labels_bb());
-  // name is ambiguous
-  // writeLabelsGeneral(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id, image.labels_general());
+  // name is currently ambiguous, use fully qualified name
+  seerep_hdf5_fb::Hdf5FbGeneral::writeLabelsGeneral(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id,
+                                                    image.labels_general());
 
   m_file->flush();
-}
-
-void Hdf5FbImage::writeImageBoundingBox2DLabeled(const std::string& id,
-                                                 const seerep::fb::BoundingBoxes2DLabeledStamped& bb2dLabeledStamped)
-{
-  const std::scoped_lock lock(*m_write_mtx);
-
-  writeBoundingBox2DLabeled(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id, bb2dLabeledStamped.labels_bb());
 }
 
 std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> Hdf5FbImage::readImage(const std::string& id,
                                                                                     const bool withoutData)
 {
   const std::scoped_lock lock(*m_write_mtx);
+  flatbuffers::grpc::MessageBuilder builder;
 
   std::string hdf5GroupPath = getHdf5GroupPath(id);
   std::string hdf5DatasetPath = getHdf5DataSetPath(id);
 
-  try
+  if (!exists(hdf5DatasetPath))
   {
-    checkExists(hdf5GroupPath);
-    checkExists(hdf5DatasetPath);
+    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::error) << "DataSet: " << id << " does not exist";
+    return std::nullopt;
   }
-  catch (const std::invalid_argument& e)
+  else if (!exists(hdf5GroupPath))
   {
-    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace) << "dataset or data group does not exist";
+    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::error) << "DataGroup: " << id << " does not exist";
     return std::nullopt;
   }
 
-  std::shared_ptr<HighFive::DataSet> dataSetPtr =
-      std::make_shared<HighFive::DataSet>(m_file->getDataSet(hdf5DatasetPath));
+  // read all data from hdf5 and if possible convert into flatbuffers objects
 
-  uint32_t step, height, width;
-  bool isBigendian;
-  std::string encoding;
+  auto imageAttributes = readImageAttributes(id);
 
-  try
-  {
-    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace) << "loading attributes";
-    height = readAttributeFromHdf5<uint32_t>(id, *dataSetPtr, seerep_hdf5_core::Hdf5CoreImage::HEIGHT);
-    width = readAttributeFromHdf5<uint32_t>(id, *dataSetPtr, seerep_hdf5_core::Hdf5CoreImage::WIDTH);
-    encoding = readAttributeFromHdf5<std::string>(id, *dataSetPtr, seerep_hdf5_core::Hdf5CoreImage::ENCODING);
-    isBigendian = readAttributeFromHdf5<bool>(id, *dataSetPtr, seerep_hdf5_core::Hdf5CoreImage::IS_BIGENDIAN);
-    step = readAttributeFromHdf5<uint32_t>(id, *dataSetPtr, seerep_hdf5_core::Hdf5CoreImage::STEP);
-  }
-  catch (const std::invalid_argument& e)
-  {
-    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::error) << "error: " << e.what();
-    return std::nullopt;
-  }
+  auto dataSetPtr = getHdf5DataSet(hdf5DatasetPath);
+  auto dataGroupPtr = getHdf5Group(hdf5GroupPath);
 
-  flatbuffers::grpc::MessageBuilder builder;
+  auto headerOffset = readHeaderAttributes(builder, *dataGroupPtr, id);
+  auto boxes2DLabeledOffset =
+      readBoundingBoxes2DLabeled(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id, builder);
+  auto generalLabelsOffset = readGeneralLabels(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id, builder);
+  auto encodingStringOffset = builder.CreateString(imageAttributes.encoding);
+
   std::vector<uint8_t> data;
-  flatbuffers::Offset<flatbuffers::Vector<uint8_t>> readDataOffset;
+  flatbuffers::Offset<ByteArrayFb> imageDataOffset;
   if (!withoutData)
   {
+    data.resize(imageAttributes.height * imageAttributes.width);
     dataSetPtr->read(data);
-    readDataOffset = builder.CreateVector(data);
   }
+  imageDataOffset = builder.CreateVector(data);
 
-  auto headerOffset = readHeaderAttributes(builder, *dataSetPtr, id);
-
-  auto boxes2DLabeledOffset = readBoundingBoxes2DLabeled(builder, id);
-
-  auto generalLabelsOffset = readGeneralLabels(builder, id);
-
-  auto encodingStringOffset = builder.CreateString(encoding);
+  // construct flatbuffers image message
 
   seerep::fb::ImageBuilder imageBuilder(builder);
-  imageBuilder.add_height(height);
-  imageBuilder.add_width(width);
+  imageBuilder.add_height(imageAttributes.height);
+  imageBuilder.add_width(imageAttributes.width);
   imageBuilder.add_encoding(encodingStringOffset);
-  imageBuilder.add_is_bigendian(isBigendian);
-  imageBuilder.add_step(step);
-
+  imageBuilder.add_is_bigendian(imageAttributes.isBigendian);
+  imageBuilder.add_step(imageAttributes.step);
   if (!withoutData)
-  {
-    imageBuilder.add_data(readDataOffset);
-  }
+    imageBuilder.add_data(imageDataOffset);
   imageBuilder.add_header(headerOffset);
-
   imageBuilder.add_labels_bb(boxes2DLabeledOffset);
   imageBuilder.add_labels_general(generalLabelsOffset);
 
@@ -126,67 +100,11 @@ std::optional<flatbuffers::grpc::Message<seerep::fb::Image>> Hdf5FbImage::readIm
   return grpcImage;
 }
 
-BoundingBoxes2DLabeledOffset Hdf5FbImage::readBoundingBoxes2DLabeled(flatbuffers::grpc::MessageBuilder& builder,
-                                                                     const std::string& id)
+void Hdf5FbImage::writeImageBoundingBox2DLabeled(const std::string& id,
+                                                 const seerep::fb::BoundingBoxes2DLabeledStamped& bb2dLabeledStamped)
 {
-  // get message type independent representation from seerep-core
-  std::vector<std::string> labels;
-  std::vector<std::vector<double>> boxes2D;
-  std::vector<std::string> instances;
+  const std::scoped_lock lock(*m_write_mtx);
 
-  readBoundingBoxLabeled(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id, labels, boxes2D, instances);
-
-  // convert into flatbuffers message
-  std::vector<flatbuffers::Offset<seerep::fb::BoundingBox2DLabeled>> bblabeledVector;
-  for (long unsigned int i = 0; i < boxes2D.size(); i++)
-  {
-    auto InstanceOffset = builder.CreateString(instances.at(i));
-    auto labelOffset = builder.CreateString(labels.at(i));
-
-    seerep::fb::LabelWithInstanceBuilder labelBuilder(builder);
-    labelBuilder.add_instanceUuid(InstanceOffset);
-    labelBuilder.add_label(labelOffset);
-    auto labelWithInstanceOffset = labelBuilder.Finish();
-
-    auto pointMin = seerep::fb::CreatePoint2D(builder, boxes2D.at(i).at(0), boxes2D.at(i).at(1));
-    auto pointMax = seerep::fb::CreatePoint2D(builder, boxes2D.at(i).at(2), boxes2D.at(i).at(3));
-
-    seerep::fb::Boundingbox2DBuilder bbBuilder(builder);
-    bbBuilder.add_point_min(pointMin);
-    bbBuilder.add_point_max(pointMax);
-    auto bb = bbBuilder.Finish();
-
-    seerep::fb::BoundingBox2DLabeledBuilder bblabeledBuilder(builder);
-    bblabeledBuilder.add_bounding_box(bb);
-    bblabeledBuilder.add_labelWithInstance(labelWithInstanceOffset);
-
-    bblabeledVector.push_back(bblabeledBuilder.Finish());
-  }
-  return builder.CreateVector(bblabeledVector);
-}
-
-GeneralLabelsOffset Hdf5FbImage::readGeneralLabels(flatbuffers::grpc::MessageBuilder& builder, const std::string& id)
-{
-  // get message type independent representation from seerep-core
-  std::vector<std::string> labels;
-  std::vector<std::string> instances;
-
-  readLabelsGeneral(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id, labels, instances);
-
-  // convert into flatbuffers message
-  std::vector<flatbuffers::Offset<seerep::fb::LabelWithInstance>> labelGeneralVector;
-  labelGeneralVector.reserve(labels.size());
-  for (long unsigned int i = 0; i < labels.size(); i++)
-  {
-    auto labelOffset = builder.CreateString(labels.at(i));
-    auto instanceOffset = builder.CreateString(instances.at(i));
-
-    seerep::fb::LabelWithInstanceBuilder labelBuilder(builder);
-    labelBuilder.add_label(labelOffset);
-    labelBuilder.add_instanceUuid(instanceOffset);
-    labelGeneralVector.push_back(labelBuilder.Finish());
-  }
-
-  return builder.CreateVector<flatbuffers::Offset<seerep::fb::LabelWithInstance>>(labelGeneralVector);
+  writeBoundingBox2DLabeled(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id, bb2dLabeledStamped.labels_bb());
 }
 }  // namespace seerep_hdf5_fb

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-point.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-point.cpp
@@ -5,7 +5,7 @@
 namespace seerep_hdf5_fb
 {
 Hdf5FbPoint::Hdf5FbPoint(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& write_mtx)
-  : Hdf5FbGeneral(file, write_mtx)
+  : Hdf5CoreGeneral(file, write_mtx), Hdf5FbGeneral(file, write_mtx)
 {
 }
 

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-point.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-point.cpp
@@ -76,7 +76,9 @@ std::optional<flatbuffers::grpc::Message<seerep::fb::PointStamped>> Hdf5FbPoint:
 
   std::string hdf5DatasetRawDataPath = getHdf5DatasetRawDataPath(id);
   if (!m_file->exist(hdf5DatasetRawDataPath))
+  {
     return std::nullopt;
+  }
 
   BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::info) << "loading " << hdf5DatasetRawDataPath;
 

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-pointcloud.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-pointcloud.cpp
@@ -60,19 +60,31 @@ void Hdf5FbPointCloud::computeBoundingBox(std::array<float, 3>& min, std::array<
                                           const float& y, const float& z)
 {
   if (x < min[0])
+  {
     min[0] = x;
+  }
   if (x > max[0])
+  {
     max[0] = x;
+  }
 
   if (y < min[1])
+  {
     min[1] = y;
+  }
   if (y > max[1])
+  {
     max[1] = y;
+  }
 
   if (z < min[2])
+  {
     min[2] = z;
+  }
   if (z > max[2])
+  {
     max[2] = z;
+  }
 }
 
 void Hdf5FbPointCloud::writePoints(const std::string& id, const std::vector<uint32_t>& offsets, const uint8_t* data,
@@ -529,20 +541,34 @@ Hdf5FbPointCloud::CloudInfo Hdf5FbPointCloud::getCloudInfo(const seerep::fb::Poi
   {
     const std::string& fieldName = cloud.fields()->Get(i)->name()->str();
     if (fieldName == "x")
+    {
       hasFieldx = true;
+    }
     else if (fieldName == "y")
+    {
       hasFieldy = true;
+    }
     else if (fieldName == "z")
+    {
       hasFieldz = true;
+    }
     else if (fieldName == "rgb")
+    {
       info.has_rgb = true;
+    }
     else if (fieldName == "rgba")
+    {
       info.has_rgba = true;
+    }
     else if (fieldName.find("normal") == 0)
+    {
       info.has_normals = true;
+    }
   }
   if (hasFieldx && hasFieldy && hasFieldz)
+  {
     info.has_points = true;
+  }
   return info;
 }
 
@@ -557,20 +583,34 @@ Hdf5FbPointCloud::CloudInfo Hdf5FbPointCloud::getCloudInfo(const std::vector<std
   for (auto fieldName : fields)
   {
     if (fieldName == "x")
+    {
       hasFieldx = true;
+    }
     else if (fieldName == "y")
+    {
       hasFieldy = true;
+    }
     else if (fieldName == "z")
+    {
       hasFieldz = true;
+    }
     else if (fieldName == "rgb")
+    {
       info.has_rgb = true;
+    }
     else if (fieldName == "rgba")
+    {
       info.has_rgba = true;
+    }
     else if (fieldName.find("normal") == 0)
+    {
       info.has_normals = true;
+    }
   }
   if (hasFieldx && hasFieldy && hasFieldz)
+  {
     info.has_points = true;
+  }
   return info;
 }
 

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-pointcloud.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-pointcloud.cpp
@@ -5,7 +5,7 @@
 namespace seerep_hdf5_fb
 {
 Hdf5FbPointCloud::Hdf5FbPointCloud(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& writeMtx)
-  : Hdf5FbGeneral(file, writeMtx)
+  : Hdf5CoreGeneral(file, writeMtx), Hdf5FbGeneral(file, writeMtx)
 {
 }
 

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-tf.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-tf.cpp
@@ -98,9 +98,13 @@ void Hdf5FbTf::writeTransformStamped(const seerep::fb::TransformStamped& tf)
   // write the size as group attribute
   HighFive::Group group = m_file->getGroup(hdf5DatasetPath);
   if (!group.hasAttribute(seerep_hdf5_core::Hdf5CoreTf::SIZE))
+  {
     group.createAttribute(seerep_hdf5_core::Hdf5CoreTf::SIZE, ++size);
+  }
   else
+  {
     group.getAttribute(seerep_hdf5_core::Hdf5CoreTf::SIZE).write(++size);
+  }
 
   m_file->flush();
 }

--- a/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-tf.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/src/hdf5-fb-tf.cpp
@@ -5,7 +5,7 @@
 namespace seerep_hdf5_fb
 {
 Hdf5FbTf::Hdf5FbTf(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& write_mtx)
-  : Hdf5FbGeneral(file, write_mtx)
+  : Hdf5CoreGeneral(file, write_mtx), Hdf5FbGeneral(file, write_mtx)
 {
 }
 

--- a/seerep-hdf5/seerep-hdf5-fb/test/fb-write-load-test.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/test/fb-write-load-test.cpp
@@ -52,7 +52,8 @@ flatbuffers::Offset<seerep::fb::Point2D> createPoint(flatbuffers::FlatBufferBuil
 flatbuffers::Offset<flatbuffers::Vector<uint8_t>>
 createImageData(flatbuffers::FlatBufferBuilder& fbb, const unsigned int imageHeight, const unsigned int imageWidth)
 {
-  std::vector<u_int8_t> data;
+  std::vector<uint8_t> data;
+  data.reserve(imageHeight * imageWidth * 3);
   for (size_t i = 0; i < imageWidth; i++)
   {
     for (size_t j = 0; j < imageHeight; j++)
@@ -70,6 +71,7 @@ createImageData(flatbuffers::FlatBufferBuilder& fbb, const unsigned int imageHei
       data.push_back(b);
     }
   }
+
   auto fbImageDataOffset = fbb.CreateVector(data.data(), data.size());
   fbb.Finish(fbImageDataOffset);
   return fbImageDataOffset;

--- a/seerep-hdf5/seerep-hdf5-fb/test/fb-write-load-test.cpp
+++ b/seerep-hdf5/seerep-hdf5-fb/test/fb-write-load-test.cpp
@@ -127,7 +127,7 @@ const seerep::fb::Image* createImageMessage(flatbuffers::FlatBufferBuilder& fbb,
   auto bB2DLabeledOffset = createBB2DLabeled(fbb);
 
   auto imgMsgOffset = seerep::fb::CreateImage(fbb, headerOffset, imageHeight, imageWidth, encodingOffset, true,
-                                              3 * imageHeight, 0, imageOffset, generalLabelsOffset, bB2DLabeledOffset);
+                                              3 * imageHeight, imageOffset, generalLabelsOffset, bB2DLabeledOffset);
   fbb.Finish(imgMsgOffset);
   uint8_t* buf = fbb.GetBufferPointer();
   return flatbuffers::GetRoot<seerep::fb::Image>(buf);
@@ -224,7 +224,6 @@ TEST_F(fbWriteLoadTest, testImageBaseFields)
   EXPECT_STREQ(readImage->encoding()->c_str(), writeImage->encoding()->c_str());
   EXPECT_EQ(readImage->is_bigendian(), writeImage->is_bigendian());
   EXPECT_EQ(readImage->step(), writeImage->step());
-  EXPECT_EQ(readImage->row_step(), writeImage->row_step());
 }
 
 TEST_F(fbWriteLoadTest, testImageData)

--- a/seerep-hdf5/seerep-hdf5-pb/include/seerep-hdf5-pb/hdf5-pb-general.h
+++ b/seerep-hdf5/seerep-hdf5-pb/include/seerep-hdf5-pb/hdf5-pb-general.h
@@ -23,23 +23,19 @@
 
 namespace seerep_hdf5_pb
 {
-class Hdf5PbGeneral : public seerep_hdf5_core::Hdf5CoreGeneral
+class Hdf5PbGeneral : public virtual seerep_hdf5_core::Hdf5CoreGeneral
 {
 protected:
   Hdf5PbGeneral(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& write_mtx);
 
-  //################
-  // Attributes
-  //################
+  //  Attributes
   template <class T>
   void writeHeaderAttributes(HighFive::AnnotateTraits<T>& object, const seerep::Header& header);
 
   template <class T>
   seerep::Header readHeaderAttributes(HighFive::AnnotateTraits<T>& object, const std::string& id);
 
-  //################
-  // BoundingBoxes
-  //################
+  //  BoundingBoxes
   void
   writeBoundingBoxLabeled(const std::string& datatypeGroup, const std::string& uuid,
                           const google::protobuf::RepeatedPtrField<::seerep::BoundingBoxLabeled>& boundingboxLabeled);
@@ -51,9 +47,7 @@ protected:
   std::optional<google::protobuf::RepeatedPtrField<::seerep::BoundingBox2DLabeled>>
   readBoundingBox2DLabeled(const std::string& datatypeGroup, const std::string& uuid);
 
-  //################
-  // Labels General
-  //################
+  //  Labels General
   void
   writeLabelsGeneral(const std::string& datatypeGroup, const std::string& uuid,
                      const google::protobuf::RepeatedPtrField<seerep::LabelWithInstance>& labelsGeneralWithInstances);

--- a/seerep-hdf5/seerep-hdf5-pb/include/seerep-hdf5-pb/hdf5-pb-image.h
+++ b/seerep-hdf5/seerep-hdf5-pb/include/seerep-hdf5-pb/hdf5-pb-image.h
@@ -18,7 +18,7 @@
 
 namespace seerep_hdf5_pb
 {
-class Hdf5PbImage : public Hdf5PbGeneral
+class Hdf5PbImage : public seerep_hdf5_core::Hdf5CoreImage, public Hdf5PbGeneral
 {
 public:
   Hdf5PbImage(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& write_mtx);

--- a/seerep-hdf5/seerep-hdf5-pb/include/seerep-hdf5-pb/hdf5-pb-pointcloud.h
+++ b/seerep-hdf5/seerep-hdf5-pb/include/seerep-hdf5-pb/hdf5-pb-pointcloud.h
@@ -66,9 +66,13 @@ private:
 
     std::shared_ptr<HighFive::DataSet> dataset_ptr;
     if (!m_file->exist(id))
+    {
       dataset_ptr = std::make_shared<HighFive::DataSet>(m_file->createDataSet<T>(id, data_space));
+    }
     else
+    {
       dataset_ptr = std::make_shared<HighFive::DataSet>(m_file->getDataSet(id));
+    }
 
     PointCloud2ConstIterator<T> iter(cloud, field_name);
     std::vector<T> data;

--- a/seerep-hdf5/seerep-hdf5-pb/include/seerep-hdf5-pb/impl/hdf5-pb-general.hpp
+++ b/seerep-hdf5/seerep-hdf5-pb/include/seerep-hdf5-pb/impl/hdf5-pb-general.hpp
@@ -5,24 +5,40 @@ template <class T>
 void Hdf5PbGeneral::writeHeaderAttributes(HighFive::AnnotateTraits<T>& object, const seerep::Header& header)
 {
   if (!object.hasAttribute(seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_SECONDS))
+  {
     object.createAttribute(seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_SECONDS, header.stamp().seconds());
+  }
   else
+  {
     object.getAttribute(seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_SECONDS).write(header.stamp().seconds());
+  }
 
   if (!object.hasAttribute(seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_NANOS))
+  {
     object.createAttribute(seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_NANOS, header.stamp().nanos());
+  }
   else
+  {
     object.getAttribute(seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_NANOS).write(header.stamp().nanos());
+  }
 
   if (!object.hasAttribute(seerep_hdf5_core::Hdf5CoreGeneral::HEADER_FRAME_ID))
+  {
     object.createAttribute(seerep_hdf5_core::Hdf5CoreGeneral::HEADER_FRAME_ID, header.frame_id());
+  }
   else
+  {
     object.getAttribute(seerep_hdf5_core::Hdf5CoreGeneral::HEADER_FRAME_ID).write(header.frame_id());
+  }
 
   if (!object.hasAttribute(seerep_hdf5_core::Hdf5CoreGeneral::HEADER_SEQ))
+  {
     object.createAttribute(seerep_hdf5_core::Hdf5CoreGeneral::HEADER_SEQ, header.seq());
+  }
   else
+  {
     object.getAttribute(seerep_hdf5_core::Hdf5CoreGeneral::HEADER_SEQ).write(header.seq());
+  }
 }
 
 template <class T>

--- a/seerep-hdf5/seerep-hdf5-pb/src/hdf5-pb-image.cpp
+++ b/seerep-hdf5/seerep-hdf5-pb/src/hdf5-pb-image.cpp
@@ -35,8 +35,7 @@ void Hdf5PbImage::writeImage(const std::string& id, const seerep::Image& image)
   writeAttributeToHdf5<uint32_t>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::WIDTH, image.width());
   writeAttributeToHdf5<std::string>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::ENCODING, image.encoding());
   writeAttributeToHdf5<bool>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::IS_BIGENDIAN, image.is_bigendian());
-  writeAttributeToHdf5<uint32_t>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::POINT_STEP, image.step());
-  writeAttributeToHdf5<uint32_t>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::ROW_STEP, image.row_step());
+  writeAttributeToHdf5<uint32_t>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::STEP, image.step());
 
   if (image.encoding() == "rgb8" || image.encoding() == "8UC3")
   {
@@ -104,8 +103,7 @@ std::optional<seerep::Image> Hdf5PbImage::readImage(const std::string& id)
     image.set_encoding(readAttributeFromHdf5<std::string>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::ENCODING));
     image.set_is_bigendian(
         readAttributeFromHdf5<bool>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::IS_BIGENDIAN));
-    image.set_step(readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::POINT_STEP));
-    image.set_row_step(readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::ROW_STEP));
+    image.set_step(readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::STEP));
   }
   catch (const std::invalid_argument& e)
   {

--- a/seerep-hdf5/seerep-hdf5-pb/src/hdf5-pb-image.cpp
+++ b/seerep-hdf5/seerep-hdf5-pb/src/hdf5-pb-image.cpp
@@ -5,7 +5,7 @@
 namespace seerep_hdf5_pb
 {
 Hdf5PbImage::Hdf5PbImage(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& write_mtx)
-  : Hdf5PbGeneral(file, write_mtx)
+  : Hdf5CoreGeneral(file, write_mtx), Hdf5CoreImage(file, write_mtx), Hdf5PbGeneral(file, write_mtx)
 {
 }
 
@@ -13,68 +13,26 @@ void Hdf5PbImage::writeImage(const std::string& id, const seerep::Image& image)
 {
   const std::scoped_lock lock(*m_write_mtx);
 
-  std::string hdf5DatasetPath = seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE + "/" + id;
-  std::string hdf5DatasetRawDataPath = hdf5DatasetPath + "/" + seerep_hdf5_core::Hdf5CoreImage::RAWDATA;
+  std::string hdf5GroupPath = getHdf5GroupPath(id);
+  std::string hdf5DataSetPath = getHdf5DataSetPath(id);
 
-  std::shared_ptr<HighFive::DataSet> data_set_ptr;
-  HighFive::DataSpace data_space({ image.height(), image.width(), image.step() / image.width() });
+  HighFive::DataSpace dataSpace({ image.height() * image.width() * 3 });
+  auto dataGroupPtr = getHdf5Group(hdf5GroupPath);
+  auto dataSetPtr = getHdf5DataSet<uint8_t>(hdf5DataSetPath, dataSpace);
 
-  if (!m_file->exist(hdf5DatasetRawDataPath))
-  {
-    std::cout << "data id " << hdf5DatasetRawDataPath << " does not exist! Creat new dataset in hdf5" << std::endl;
-    data_set_ptr =
-        std::make_shared<HighFive::DataSet>(m_file->createDataSet<uint8_t>(hdf5DatasetRawDataPath, data_space));
-  }
-  else
-  {
-    std::cout << "data id " << hdf5DatasetRawDataPath << " already exists!" << std::endl;
-    data_set_ptr = std::make_shared<HighFive::DataSet>(m_file->getDataSet(hdf5DatasetRawDataPath));
-  }
+  writeHeaderAttributes(*dataGroupPtr, image.header());
 
-  writeAttributeToHdf5<uint32_t>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::HEIGHT, image.height());
-  writeAttributeToHdf5<uint32_t>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::WIDTH, image.width());
-  writeAttributeToHdf5<std::string>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::ENCODING, image.encoding());
-  writeAttributeToHdf5<bool>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::IS_BIGENDIAN, image.is_bigendian());
-  writeAttributeToHdf5<uint32_t>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::STEP, image.step());
+  seerep_hdf5_core::ImageAttributes imageAttributes = { image.height(), image.width(), image.step(), image.encoding(),
+                                                        image.is_bigendian() };
 
-  if (image.encoding() == "rgb8" || image.encoding() == "8UC3")
-  {
-    writeAttributeToHdf5<std::string>(*data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::CLASS, "IMAGE");
-    writeAttributeToHdf5<std::string>(*data_set_ptr, "IMAGE_VERSION", "1.2");
-    writeAttributeToHdf5<std::string>(*data_set_ptr, "IMAGE_SUBCLASS", "IMAGE_TRUECOLOR");
-    writeAttributeToHdf5<std::string>(*data_set_ptr, "INTERLACE_MODE", "INTERLACE_PIXEL");
-  }
-  else
-  {
-    deleteAttribute(data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::CLASS);
-    deleteAttribute(data_set_ptr, "IMAGE_VERSION");
-    deleteAttribute(data_set_ptr, "IMAGE_SUBCLASS");
-    deleteAttribute(data_set_ptr, "INTERLACE_MODE");
-  }
+  writeImageAttributes(id, imageAttributes);
 
-  const uint8_t* begin = reinterpret_cast<const uint8_t*>(image.data().c_str());
-
-  std::vector<std::vector<std::vector<uint8_t>>> tmp;
-  tmp.resize(image.height());
-
-  int pixel_step = image.step() / image.width();
-
-  for (unsigned int row = 0; row < image.height(); row++)
-  {
-    tmp.at(row).resize(image.width());
-    for (unsigned int col = 0; col < image.width(); col++)
-    {
-      const uint8_t* pxl = begin + row * image.step() + col * pixel_step;
-      tmp.at(row).at(col).reserve(pixel_step);
-      std::copy_n(pxl, pixel_step, std::back_inserter(tmp.at(row).at(col)));
-    }
-  }
-
-  data_set_ptr->write(tmp);
-  writeHeaderAttributes(*data_set_ptr, image.header());
+  const uint8_t* arrayStartPtr = reinterpret_cast<const uint8_t*>(image.data().c_str());
+  dataSetPtr->write(std::vector<uint8_t>(arrayStartPtr, arrayStartPtr + image.data().size()));
 
   writeBoundingBox2DLabeled(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id, image.labels_bb());
-  writeLabelsGeneral(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id, image.labels_general());
+  seerep_hdf5_pb::Hdf5PbGeneral::writeLabelsGeneral(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id,
+                                                    image.labels_general());
 
   m_file->flush();
 }
@@ -83,58 +41,50 @@ std::optional<seerep::Image> Hdf5PbImage::readImage(const std::string& id)
 {
   const std::scoped_lock lock(*m_write_mtx);
 
-  std::string hdf5DatasetPath = seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE + "/" + id;
-  std::string hdf5DatasetRawDataPath = hdf5DatasetPath + "/" + seerep_hdf5_core::Hdf5CoreImage::RAWDATA;
+  std::string hdf5GroupPath = getHdf5GroupPath(id);
+  std::string hdf5DataSetPath = getHdf5DataSetPath(id);
 
-  if (!m_file->exist(hdf5DatasetRawDataPath))
+  // TODO add logging
+  if (!exists(hdf5DataSetPath))
+  {
     return std::nullopt;
+  }
+  else if (!exists(hdf5GroupPath))
+  {
+    return std::nullopt;
+  }
 
-  std::cout << "loading " << hdf5DatasetRawDataPath << std::endl;
+  // read data from hdf5
+  auto dataSetPtr = getHdf5DataSet(hdf5DataSetPath);
+  auto dataGroupPtr = getHdf5Group(hdf5GroupPath);
 
-  std::shared_ptr<HighFive::DataSet> data_set_ptr =
-      std::make_shared<HighFive::DataSet>(m_file->getDataSet(hdf5DatasetRawDataPath));
+  auto header = readHeaderAttributes(*dataGroupPtr, id);
 
+  auto ImageAttributes = readImageAttributes(id);
+
+  auto labelsBB = readBoundingBox2DLabeled(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id);
+  auto labelsGeneral = readLabelsGeneral(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id);
+
+  std::vector<uint8_t> data;
+  dataSetPtr->read(data);
+
+  // create pb image message
   seerep::Image image;
 
-  try
-  {
-    image.set_height(readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::HEIGHT));
-    image.set_width(readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::WIDTH));
-    image.set_encoding(readAttributeFromHdf5<std::string>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::ENCODING));
-    image.set_is_bigendian(
-        readAttributeFromHdf5<bool>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::IS_BIGENDIAN));
-    image.set_step(readAttributeFromHdf5<uint32_t>(id, *data_set_ptr, seerep_hdf5_core::Hdf5CoreImage::STEP));
-  }
-  catch (const std::invalid_argument& e)
-  {
-    std::cout << "error: " << e.what() << std::endl;
-    return std::nullopt;
-  }
-  std::vector<std::vector<std::vector<uint8_t>>> read_data;
-  data_set_ptr->read(read_data);
+  *image.mutable_header() = header;
 
-  int pixel_step = image.step() / image.width();
+  image.set_height(ImageAttributes.height);
+  image.set_width(ImageAttributes.width);
+  image.set_step(ImageAttributes.step);
+  image.set_encoding(ImageAttributes.encoding);
+  image.set_is_bigendian(ImageAttributes.isBigendian);
 
-  // TODO: write into protobuf data buffer
-  uint8_t data[image.height()][image.width()][pixel_step];
+  *image.mutable_data() = { data.begin(), data.end() };
 
-  for (unsigned int row = 0; row < image.height(); row++)
-  {
-    for (unsigned int col = 0; col < image.width(); col++)
-    {
-      std::copy(read_data.at(row).at(col).begin(), read_data.at(row).at(col).end(), data[row][col]);
-    }
-  }
-
-  image.set_data(data, sizeof(data));
-
-  *image.mutable_header() = readHeaderAttributes(*data_set_ptr, id);
-  auto labelsBB = readBoundingBox2DLabeled(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id);
   if (labelsBB)
   {
     *image.mutable_labels_bb() = labelsBB.value();
   }
-  auto labelsGeneral = readLabelsGeneral(seerep_hdf5_core::Hdf5CoreImage::HDF5_GROUP_IMAGE, id);
   if (labelsGeneral)
   {
     *image.mutable_labels_general() = labelsGeneral.value();

--- a/seerep-hdf5/seerep-hdf5-pb/src/hdf5-pb-pointcloud.cpp
+++ b/seerep-hdf5/seerep-hdf5-pb/src/hdf5-pb-pointcloud.cpp
@@ -64,15 +64,23 @@ std::shared_ptr<HighFive::Group> Hdf5PbPointCloud::writePointCloud2(const std::s
   CloudInfo info = getCloudInfo(pointcloud2);
 
   if (info.has_points)
+  {
     writePoints(*data_group_ptr, uuid, pointcloud2);
+  }
   if (info.has_rgb)
+  {
     writeColorsRGB(uuid, pointcloud2);
+  }
   if (info.has_rgba)
+  {
     writeColorsRGBA(uuid, pointcloud2);
+  }
 
   // TODO normals
   if (!info.other_fields.empty())
+  {
     writeOtherFields(uuid, pointcloud2, info.other_fields);
+  }
 
   m_file->flush();
   return data_group_ptr;
@@ -85,9 +93,13 @@ void Hdf5PbPointCloud::writePoints(HighFive::Group& object, const std::string& u
 
   std::shared_ptr<HighFive::DataSet> points_dataset_ptr;
   if (!m_file->exist(points_id))
+  {
     points_dataset_ptr = std::make_shared<HighFive::DataSet>(m_file->createDataSet<float>(points_id, data_space));
+  }
   else
+  {
     points_dataset_ptr = std::make_shared<HighFive::DataSet>(m_file->getDataSet(points_id));
+  }
 
   std::vector<std::vector<std::vector<float>>> point_data;
   point_data.resize(cloud.height());
@@ -111,19 +123,31 @@ void Hdf5PbPointCloud::writePoints(HighFive::Group& object, const std::string& u
 
       // compute bounding box
       if (x < min[0])
+      {
         min[0] = x;
+      }
       if (x > max[0])
+      {
         max[0] = x;
+      }
 
       if (y < min[1])
+      {
         min[1] = y;
+      }
       if (y > max[1])
+      {
         max[1] = y;
+      }
 
       if (z < min[2])
+      {
         min[2] = z;
+      }
       if (z > max[2])
+      {
         max[2] = z;
+      }
 
       point_data[i].push_back(std::vector{ x, y, z });
 
@@ -147,9 +171,13 @@ void Hdf5PbPointCloud::writeColorsRGB(const std::string& uuid, const seerep::Poi
 
   std::shared_ptr<HighFive::DataSet> colors_dataset_ptr;
   if (!m_file->exist(colors_id))
+  {
     colors_dataset_ptr = std::make_shared<HighFive::DataSet>(m_file->createDataSet<uint8_t>(colors_id, data_space));
+  }
   else
+  {
     colors_dataset_ptr = std::make_shared<HighFive::DataSet>(m_file->getDataSet(colors_id));
+  }
 
   std::vector<std::vector<std::vector<uint8_t>>> colors_data;
   colors_data.resize(cloud.height());
@@ -178,9 +206,13 @@ void Hdf5PbPointCloud::writeColorsRGBA(const std::string& uuid, const seerep::Po
 
   std::shared_ptr<HighFive::DataSet> colors_dataset_ptr;
   if (!m_file->exist(colors_id))
+  {
     colors_dataset_ptr = std::make_shared<HighFive::DataSet>(m_file->createDataSet<uint8_t>(colors_id, data_space));
+  }
   else
+  {
     colors_dataset_ptr = std::make_shared<HighFive::DataSet>(m_file->getDataSet(colors_id));
+  }
 
   std::vector<std::vector<std::vector<uint8_t>>> colors_data;
   colors_data.resize(cloud.height());
@@ -255,22 +287,38 @@ Hdf5PbPointCloud::CloudInfo Hdf5PbPointCloud::getCloudInfo(const seerep::PointCl
   for (auto& field : cloud.fields())
   {
     if (field.name() == "x")
+    {
       hasFieldx = true;
+    }
     else if (field.name() == "y")
+    {
       hasFieldy = true;
+    }
     else if (field.name() == "z")
+    {
       hasFieldz = true;
+    }
     else if (field.name() == "rgb")
+    {
       info.has_rgb = true;
+    }
     else if (field.name() == "rgba")
+    {
       info.has_rgba = true;
+    }
     else if (field.name().find("normal") == 0)
+    {
       info.has_normals = true;
+    }
     else
+    {
       info.other_fields[field.name()] = field;
+    }
   }
   if (hasFieldx && hasFieldy && hasFieldz)
+  {
     info.has_points = true;
+  }
   return info;
 }
 
@@ -312,18 +360,26 @@ std::optional<seerep::PointCloud2> Hdf5PbPointCloud::readPointCloud2(const std::
   CloudInfo info = getCloudInfo(pointcloud2);
 
   if (info.has_points)
+  {
     readPoints(uuid, pointcloud2);
+  }
 
   if (info.has_rgb)
+  {
     readColorsRGB(uuid, pointcloud2);
+  }
 
   if (info.has_rgba)
+  {
     readColorsRGBA(uuid, pointcloud2);
+  }
 
   // TODO normals
 
   if (!info.other_fields.empty())
+  {
     readOtherFields(uuid, pointcloud2, info.other_fields);
+  }
 
   return pointcloud2;
 }

--- a/seerep-hdf5/seerep-hdf5-pb/src/hdf5-pb-pointcloud.cpp
+++ b/seerep-hdf5/seerep-hdf5-pb/src/hdf5-pb-pointcloud.cpp
@@ -5,7 +5,7 @@
 namespace seerep_hdf5_pb
 {
 Hdf5PbPointCloud::Hdf5PbPointCloud(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& write_mtx)
-  : Hdf5PbGeneral(file, write_mtx)
+  : Hdf5CoreGeneral(file, write_mtx), Hdf5PbGeneral(file, write_mtx)
 {
 }
 

--- a/seerep-hdf5/seerep-hdf5-pb/src/hdf5-pb-tf.cpp
+++ b/seerep-hdf5/seerep-hdf5-pb/src/hdf5-pb-tf.cpp
@@ -93,9 +93,13 @@ void Hdf5PbTf::writeTransformStamped(const seerep::TransformStamped& tf)
   // write the size as group attribute
   HighFive::Group group = m_file->getGroup(hdf5DatasetPath);
   if (!group.hasAttribute(SIZE))
+  {
     group.createAttribute(SIZE, ++size);
+  }
   else
+  {
     group.getAttribute(SIZE).write(++size);
+  }
 
   m_file->flush();
 }

--- a/seerep-hdf5/seerep-hdf5-pb/src/hdf5-pb-tf.cpp
+++ b/seerep-hdf5/seerep-hdf5-pb/src/hdf5-pb-tf.cpp
@@ -5,7 +5,7 @@
 namespace seerep_hdf5_pb
 {
 Hdf5PbTf::Hdf5PbTf(std::shared_ptr<HighFive::File>& file, std::shared_ptr<std::mutex>& write_mtx)
-  : Hdf5PbGeneral(file, write_mtx)
+  : Hdf5CoreGeneral(file, write_mtx), Hdf5PbGeneral(file, write_mtx)
 {
 }
 

--- a/seerep-hdf5/seerep-hdf5-pb/test/pb-write-load-test.cpp
+++ b/seerep-hdf5/seerep-hdf5-pb/test/pb-write-load-test.cpp
@@ -54,7 +54,8 @@ void createPoint(const double x, const double y, seerep::Point2D& point2D)
  * */
 void createImageData(const unsigned int imageHeight, const unsigned int imageWidth, seerep::Image& image)
 {
-  uint8_t data[imageHeight][imageWidth][3];
+  std::vector<uint8_t> data;
+  data.reserve(imageHeight * imageWidth * 3);
   for (size_t i = 0; i < imageWidth; i++)
   {
     for (size_t j = 0; j < imageHeight; j++)
@@ -67,13 +68,13 @@ void createImageData(const unsigned int imageHeight, const unsigned int imageWid
       uint8_t g = int((y * 255.0)) % 255;
       uint8_t b = int((z * 255.0)) % 255;
 
-      data[j][i][0] = r;
-      data[j][i][1] = g;
-      data[j][i][2] = b;
+      data.push_back(r);
+      data.push_back(g);
+      data.push_back(b);
     }
   }
 
-  image.set_data(data, sizeof(data));
+  *image.mutable_data() = { data.begin(), data.end() };
 }
 
 /**

--- a/seerep-msgs/fbs/image.fbs
+++ b/seerep-msgs/fbs/image.fbs
@@ -12,7 +12,6 @@ table Image {
   encoding:string;
   is_bigendian:bool;
   step:uint;
-  row_step:uint;
   data:[ubyte];
   labels_general:[LabelWithInstance];
   labels_bb:[seerep.fb.BoundingBox2DLabeled];

--- a/seerep-ros/seerep_ros_conversions_fb/src/seerep_ros_conversions_fb/conversions.cpp
+++ b/seerep-ros/seerep_ros_conversions_fb/src/seerep_ros_conversions_fb/conversions.cpp
@@ -158,7 +158,6 @@ flatbuffers::Offset<seerep::fb::Image> toFlat(const sensor_msgs::Image& image, s
   imagebuilder.add_encoding(encodingOffset);
   imagebuilder.add_is_bigendian(image.is_bigendian);
   imagebuilder.add_step(image.step);
-  imagebuilder.add_row_step(image.step * image.width);
   imagebuilder.add_data(dataVector);
 
   return imagebuilder.Finish();

--- a/seerep-ros/seerep_ros_conversions_fb/src/seerep_ros_conversions_fb/conversions.cpp
+++ b/seerep-ros/seerep_ros_conversions_fb/src/seerep_ros_conversions_fb/conversions.cpp
@@ -123,7 +123,9 @@ sensor_msgs::PointCloud2 toROS(const seerep::fb::PointCloud2& cloud)
   ret.height = cloud.height();
   ret.width = cloud.width();
   for (auto field : *cloud.fields())
+  {
     ret.fields.push_back(toROS(*field));
+  }
   ret.is_bigendian = cloud.is_bigendian();
   ret.point_step = cloud.point_step();
   ret.row_step = cloud.row_step();

--- a/seerep-ros/seerep_ros_conversions_pb/src/seerep_ros_conversions_pb/conversions.cpp
+++ b/seerep-ros/seerep_ros_conversions_pb/src/seerep_ros_conversions_pb/conversions.cpp
@@ -59,7 +59,9 @@ seerep::PointCloud2 toProto(const sensor_msgs::PointCloud2& cloud, std::string p
   ret.set_height(cloud.height);
   ret.set_width(cloud.width);
   for (auto field : cloud.fields)
+  {
     *ret.add_fields() = toProto(field);
+  }
   ret.set_is_bigendian(cloud.is_bigendian);
   ret.set_point_step(cloud.point_step);
   ret.set_row_step(cloud.row_step);
@@ -75,7 +77,9 @@ sensor_msgs::PointCloud2 toROS(const seerep::PointCloud2& cloud)
   ret.height = cloud.height();
   ret.width = cloud.width();
   for (auto field : cloud.fields())
+  {
     ret.fields.push_back(toROS(field));
+  }
   ret.is_bigendian = cloud.is_bigendian();
   ret.point_step = cloud.point_step();
   ret.row_step = cloud.row_step();

--- a/seerep-srv/seerep-core/src/core-tf.cpp
+++ b/seerep-srv/seerep-core/src/core-tf.cpp
@@ -25,8 +25,9 @@ void CoreTf::recreateDatasets()
       if (transforms)
       {
         for (auto& transform : transforms.value())
-
+        {
           addToTfBuffer(transform);
+        }
       }
     }
     catch (const std::runtime_error& e)


### PR DESCRIPTION
This PR changes:

- `hdf5-fb/pb-images` objects save and load images with their raw bytes. 
- some refactoring in the `seerep-hdf5`sub-packages
- fixes for two python scripts, which broke unnoticed

ToDo:

- [x]  Add Docs to `hdf5-fb-general`, `hdf5-fb-image`, `hdf5-core-image`

Closes #223 