### PR TITLE
fix protoc incompatibility with latest protobuf python package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,13 +71,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      # check if Dockerfile has changed
+      # check if files have changed
       - name: Get changed files
         id: changed-files-specific-docker-base
         uses: tj-actions/changed-files@v34
         with:
           files: |
             docker/base/Dockerfile
+            docker/base/requirements.txt
       -
         name: Set up Docker Buildx
         if: github.ref_type == 'tag' || steps.changed-files-specific-docker-base.outputs.any_changed == 'true'

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -4,7 +4,7 @@ ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV HDF5_REL="https://github.com/BlueBrain/HighFive"
 ENV PB_REL="https://github.com/protocolbuffers/protobuf/releases"
-ENV PB_VER="3.15.6"
+ENV PB_VER="21.12"
 ENV DOX_REL="https://github.com/doxygen/doxygen/archive/refs/tags"
 ENV DOX_VER="Release_1_9_3"
 
@@ -47,7 +47,6 @@ RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends -y \
         && rm -rf /var/lib/apt/lists/*
 
 #Install pre-commit hooks to /root/.cache/pre-commit/
-RUN pip3 install pre-commit
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
 RUN add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main"
 RUN apt-get update -qq && apt-get -qq install -y --no-install-recommends \
@@ -85,23 +84,6 @@ RUN git clone --depth 1 -b v2.4.0 $HDF5_REL.git \
         && rm -rf HighFive
 
 ####################################################
-#Install protobuf via precompiled binaries from github
-####################################################
-RUN curl -LO $PB_REL/download/v$PB_VER/protobuf-cpp-$PB_VER.zip \
-        && unzip protobuf-cpp-$PB_VER.zip \
-        && cd /protobuf-$PB_VER/ \
-        && ./configure --prefix=/usr \
-        && make -j"$(nproc)" -C /protobuf-$PB_VER/ \
-        && make check -j"$(nproc)" -C /protobuf-$PB_VER/ \
-        && make install -C /protobuf-$PB_VER/ \
-        && ldconfig \
-        && cd .. \
-        && rm protobuf-cpp-$PB_VER.zip \
-        && rm -rf protobuf-$PB_VER
-#Updating python proto stuff
-RUN pip3 install --upgrade protobuf
-
-####################################################
 #Install flatbuffer
 ####################################################
 RUN wget https://github.com/google/flatbuffers/archive/refs/tags/v2.0.0.tar.gz \
@@ -113,7 +95,6 @@ RUN wget https://github.com/google/flatbuffers/archive/refs/tags/v2.0.0.tar.gz \
         && make install -C /flatbuffers-2.0.0/build \
         && cd ../.. \
         && rm -rf flatbuffers-2.0.0 v2.0.0.tar.gz
-RUN pip3 install flatbuffers
 
 ####################################################
 #Install gRPC
@@ -130,6 +111,21 @@ RUN git clone --recurse-submodules --depth 1 -b v1.35.0 https://github.com/grpc/
         && rm -rf grpc
 
 ####################################################
+#Install protobuf from github
+####################################################
+RUN curl -LO $PB_REL/download/v$PB_VER/protobuf-cpp-3.$PB_VER.zip \
+        && unzip protobuf-cpp-3.$PB_VER.zip \
+        && cd /protobuf-3.$PB_VER/ \
+        && mkdir -p build \
+        && cd build \
+        && cmake .. -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        && make -j"$(nproc)" \
+        && make install \
+        && cd ../.. \
+        && rm protobuf-cpp-3.$PB_VER.zip \
+        && rm -rf protobuf-$3.PB_VER
+
+####################################################
 #Install current googletest release
 ####################################################
 
@@ -143,18 +139,9 @@ RUN git clone https://github.com/google/googletest.git -b release-1.12.0 \
         && cd ../../ \
         && rm -rf googletest
 
-#Install python3 grpcio_tools'
-RUN pip3 install grpcio-tools
-
-# Install python imgeio
-RUN pip3 install imageio==2.20.0 numpy-quaternion
-
 ####################################################
 #Install documentation dependencies
 ####################################################
-
-#Install mkdocs and material theme
-RUN pip3 install mkdocs==1.3.0 && pip3 install mkdocs-material
 
 #Install doxygen
 RUN wget ${DOX_REL}/${DOX_VER}.tar.gz \

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -38,8 +38,12 @@ RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends -y \
         bison \
         && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --upgrade pip
-#Install seerep dependencies from apt
+COPY docker/base/requirements.txt /tmp/requirements.txt
+RUN pip3 install --upgrade pip \
+        && pip3 install -r /tmp/requirements.txt \
+        && rm /tmp/requirements.txt
+
+        #Install seerep dependencies from apt
 RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends -y \
         ros-noetic-tf \
         ros-noetic-vision-msgs \

--- a/docker/base/requirements.txt
+++ b/docker/base/requirements.txt
@@ -1,0 +1,10 @@
+pre-commit==2.21.0
+flatbuffers==22.12.6
+protobuf== 4.21.12
+grpcio-tools==1.51.1
+grpcio==1.51.1
+imageio==2.20.0
+numpy==1.17.4
+numpy-quaternion==2022.4.2
+mkdocs==1.4.2
+mkdocs-material==9.0.2


### PR DESCRIPTION
- fixing incompatibly of the `protobuf==4.21.0` python package with `protoc<3.19.9`, by bumping protoc to `3.21.12`. Related: https://github.com/protocolbuffers/protobuf/issues/10051#
- Set versions for python packages in added `requirements.txt`, to prevent automatic updating