### PR TITLE
Correct time(zone) in docker containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,5 +28,8 @@
     "runArgs": [
         "--network=host"
     ],
+    "containerEnv": {
+        "TZ": "Europe/Berlin"
+    },
     "postStartCommand": "git -C ./src pull || git clone git@github.com:agri-gaia/seerep.git ./src; ./src/.devcontainer/postCreateCommand.sh"
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,5 +14,7 @@ services:
       # persist the data folder
       - seerep-data:/mnt/seerep-data #using docker volume
       #- /your/local/absolute/path:/mnt/seerep-data #using host folder
+    environment:
+      - TZ=Europe/Berlin
 volumes:
   seerep-data:

--- a/seerep-srv/seerep-server/include/seerep-server/server.h
+++ b/seerep-srv/seerep-server/include/seerep-server/server.h
@@ -79,6 +79,11 @@ private:
   void initLogging();
 
   /**
+   * @brief Logs the used time zone at server startup
+   */
+  void logTimeZone();
+
+  /**
    * @brief sets the severity level of the logging
    */
   void setSeverityLevel();

--- a/seerep-srv/seerep-server/src/server.cpp
+++ b/seerep-srv/seerep-server/src/server.cpp
@@ -8,6 +8,7 @@ server::server(int argc, char** argv)
   signal(SIGINT, signalHandler);
   parseProgramOptions(argc, argv);
   initLogging();
+  logTimeZone();
   createGrpcServer();
 }
 
@@ -109,6 +110,16 @@ void server::initLogging()
     initConsoleLogging();
     BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::error) << "file logging exeption: " << e.what();
   }
+}
+
+void server::logTimeZone()
+{
+  time_t time = 0;
+  struct tm timeStruct;
+  char buf[16];
+  localtime_r(&time, &timeStruct);
+  strftime(buf, sizeof(buf), "%Z", &timeStruct);
+  BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::info) << "Current timezone: " << buf;
 }
 
 void server::setSeverityLevel()


### PR DESCRIPTION
The time(zone) in the docker container was not properly set. With this PR, the time will be retrieved from the host system via mounting the respective files.  This will only work for Unix based systems, I thought this was the most versatile way. We could also set the timezone explicitly, e.g. in the `docker-compose.yml` without a dependency on the host operating system: 

```.yml
version: "3.6"
services:
  seerep:
    image: ghcr.io/agri-gaia/seerep_server:latest
    tty: true
    container_name: seerep_server
    command:
      # define data-dir for seerep-server
      - "--data-folder=/mnt/seerep-data"
    ports:
      # the gRPC port
      - 9090:9090
    volumes:
      # set a folder for seerep-data on your host system
      #- /your/local/absolute/path:/mnt/seerep-data
      - seerep-data:/mnt/seerep-data
    environment:
      - TZ=Europe/Berlin
volumes:
  seerep-data:
```