### PR TITLE
Bump NumPy to fix vulnerabilities

### DIFF
--- a/docker/base/requirements.txt
+++ b/docker/base/requirements.txt
@@ -4,7 +4,7 @@ protobuf== 4.21.12
 grpcio-tools==1.51.1
 grpcio==1.51.1
 imageio==2.20.0
-numpy==1.17.4
+numpy==1.22.0
 numpy-quaternion==2022.4.2
 mkdocs==1.4.2
 mkdocs-material==9.0.2


### PR DESCRIPTION
Simple PR which bumps the NumPy version, to remove the [Dependabot alerts](https://github.com/agri-gaia/seerep/security/dependabot). Maybe you noticed the warnings in the git cli :sweat_smile: 