### PR TITLE
Removed Duplicate Message

### DIFF
--- a/seerep-msgs/fbs/point.fbs
+++ b/seerep-msgs/fbs/point.fbs
@@ -1,6 +1,10 @@
 
 namespace seerep.fb;
 
+table Point2d {
+  x:double;
+  y:double;
+}
 table Point {
   x:double;
   y:double;

--- a/seerep-msgs/fbs/point2d.fbs
+++ b/seerep-msgs/fbs/point2d.fbs
@@ -1,7 +1,0 @@
-
-namespace seerep.fb;
-
-table Point2D {
-  x:double;
-  y:double;
-}


### PR DESCRIPTION
To remove the Duplicate Message Definition i combine the point.fb and point2d.fb file together and remove the duplicated namespace seerep.fb; line. Here's how the code look like:

```
namespace seerep.fb;

table Point2D {
  x: double;
  y: double;
}

table Point {
  x: double;
  y: double;
  z: double;
}