### PR TITLE
Oriented bounding box

### DIFF
--- a/examples/python/gRPC/images/gRPC_pb_queryImageGrid.py
+++ b/examples/python/gRPC/images/gRPC_pb_queryImageGrid.py
@@ -20,7 +20,7 @@ response = stubMeta.GetProjects(empty_pb2.Empty())
 projectuuid = ""
 for project in response.projects:
     print(project.name + " " + project.uuid)
-    if project.name == "LabeledImagesInGrid":
+    if project.name == "testproject":
         projectuuid = project.uuid
 
 if projectuuid == "":
@@ -35,6 +35,12 @@ theQuery.boundingboxStamped.boundingbox.center_point.z = 0.0
 theQuery.boundingboxStamped.boundingbox.spatial_extent.z = 1.0
 theQuery.boundingboxStamped.boundingbox.spatial_extent.x = 1.0
 theQuery.boundingboxStamped.boundingbox.spatial_extent.y = 1.0
+
+# unit quaternion, causes no rotation
+theQuery.boundingboxStamped.boundingbox.rotation.w = 1
+theQuery.boundingboxStamped.boundingbox.rotation.x = 0
+theQuery.boundingboxStamped.boundingbox.rotation.y = 0
+theQuery.boundingboxStamped.boundingbox.rotation.z = 0
 
 # since epoche
 theQuery.timeinterval.time_min.seconds = 1638549273

--- a/examples/python/gRPC/pointcloud/gRPC_fb_queryPointCloud.py
+++ b/examples/python/gRPC/pointcloud/gRPC_fb_queryPointCloud.py
@@ -82,7 +82,7 @@ builder.Finish(query)
 buf = builder.Output()
 
 for responseBuf in stubPointCloud.GetPointCloud2(bytes(buf)):
-    response = PointCloud2.GetRootAs(responseBuf)
+    response = PointCloud2.PointCloud2.GetRootAs(responseBuf)
 
     print("---Header---")
     print(f"Message UUID: {response.Header().UuidMsgs().decode('utf-8')}")

--- a/examples/python/gRPC/pointcloud/gRPC_fb_queryPointCloud.py
+++ b/examples/python/gRPC/pointcloud/gRPC_fb_queryPointCloud.py
@@ -15,6 +15,7 @@ from seerep.util.fb_helper import (
     createLabelWithCategory,
     createLabelWithConfidence,
     createPoint,
+    createQuaternion,
     createQuery,
     createTimeInterval,
     createTimeStamp,
@@ -39,8 +40,9 @@ builder = flatbuffers.Builder(1024)
 # Create all necessary objects for the query
 header = createHeader(builder, frame="map")
 pointMin = createPoint(builder, 0.0, 0.0, 0.0)
-pointMax = createPoint(builder, 100.0, 100.0, 100.0)
-boundingboxStamped = createBoundingBoxStamped(builder, header, pointMin, pointMax)
+pointMax = createPoint(builder, 100.0, 50.0, 100.0)
+quaternion = createQuaternion(builder, 0, 0, 1, 0)
+boundingboxStamped = createBoundingBoxStamped(builder, header, pointMin, pointMax, quaternion)
 
 timeMin = createTimeStamp(builder, 1610549273, 0)
 timeMax = createTimeStamp(builder, 1938549273, 0)
@@ -74,6 +76,7 @@ query = createQuery(
     # instanceUuids=instanceUuids,
     # dataUuids=dataUuids,
     withoutData=True,
+    encapsulated=True,
 )
 builder.Finish(query)
 buf = builder.Output()

--- a/examples/python/gRPC/pointcloud/gRPC_fb_queryPointCloud.py
+++ b/examples/python/gRPC/pointcloud/gRPC_fb_queryPointCloud.py
@@ -10,7 +10,11 @@ from seerep.fb import PointCloud2
 from seerep.fb import point_cloud_service_grpc_fb as pointCloudService
 from seerep.util.common import get_gRPC_channel
 from seerep.util.fb_helper import (
+    createBoundingBoxStamped,
+    createHeader,
     createLabelWithCategory,
+    createLabelWithConfidence,
+    createPoint,
     createQuery,
     createTimeInterval,
     createTimeStamp,
@@ -23,27 +27,55 @@ stubPointCloud = pointCloudService.PointCloudServiceStub(channel)
 builder = flatbuffers.Builder(1024)
 
 PROJECTNAME = "testproject"
-projectUuid = getProject(builder, channel, PROJECTNAME)
+projectuuid = getProject(builder, channel, PROJECTNAME)
 
-if projectUuid is None:
+if projectuuid is None:
     print(f"Project: {PROJECTNAME} does not exist")
     sys.exit()
 
 
 builder = flatbuffers.Builder(1024)
 
+# Create all necessary objects for the query
+header = createHeader(builder, frame="map")
+pointMin = createPoint(builder, 0.0, 0.0, 0.0)
+pointMax = createPoint(builder, 100.0, 100.0, 100.0)
+boundingboxStamped = createBoundingBoxStamped(builder, header, pointMin, pointMax)
+
 timeMin = createTimeStamp(builder, 1610549273, 0)
 timeMax = createTimeStamp(builder, 1938549273, 0)
 timeInterval = createTimeInterval(builder, timeMin, timeMax)
 
-category = "0"
-labels = [[builder.CreateString("testlabel0"), builder.CreateString("BoundingBoxLabel0")]]
-labelCategory = createLabelWithCategory(builder, category, labels)
 
-queryMsg = createQuery(
-    builder, projectUuids=[builder.CreateString(projectUuid)], timeInterval=timeInterval, labels=labelCategory
+projectUuids = [builder.CreateString(projectuuid)]
+# list of categories
+category = ["0"]
+# list of labels per category
+labels = [
+    [
+        createLabelWithConfidence(builder, "testlabel0"),
+        createLabelWithConfidence(builder, "testlabelgeneral0"),
+    ]
+]
+labelCategory = createLabelWithCategory(builder, category, labels)
+dataUuids = [builder.CreateString("3e12e18d-2d53-40bc-a8af-c5cca3c3b248")]
+instanceUuids = [builder.CreateString("3e12e18d-2d53-40bc-a8af-c5cca3c3b248")]
+
+# 4. Create a query with parameters
+# all parameters are optional
+# with all parameters set (especially with the data and instance uuids set) the result of the query will be empty. Set the query parameters to adequate values or remove them from the query creation
+query = createQuery(
+    builder,
+    boundingBox=boundingboxStamped,
+    # timeInterval=timeInterval,
+    # labels=labelCategory,
+    # mustHaveAllLabels=True,
+    projectUuids=projectUuids,
+    # instanceUuids=instanceUuids,
+    # dataUuids=dataUuids,
+    withoutData=True,
 )
-builder.Finish(queryMsg)
+builder.Finish(query)
 buf = builder.Output()
 
 for responseBuf in stubPointCloud.GetPointCloud2(bytes(buf)):

--- a/examples/python/gRPC/util/fb_helper.py
+++ b/examples/python/gRPC/util/fb_helper.py
@@ -22,6 +22,7 @@ from seerep.fb import (
     ProjectCreation,
     ProjectInfo,
     ProjectInfos,
+    Quaternion,
     Query,
     QueryInstance,
     RegionOfInterest,
@@ -555,3 +556,12 @@ def createProjectInfo(builder, name, uuid):
     ProjectInfo.AddName(builder, nameStr)
     ProjectInfo.AddUuid(builder, uuidStr)
     return ProjectInfo.End(builder)
+
+
+def createQuaternion(builder, w, x, y, z):
+    Quaternion.Start(builder)
+    Quaternion.AddW(builder, w)
+    Quaternion.AddX(builder, x)
+    Quaternion.AddY(builder, y)
+    Quaternion.AddZ(builder, z)
+    return Quaternion.End(builder)

--- a/examples/python/gRPC/util/fb_helper.py
+++ b/examples/python/gRPC/util/fb_helper.py
@@ -388,6 +388,7 @@ def createQuery(
     instanceUuids=None,
     dataUuids=None,
     withoutData=False,
+    encapsulated=False,
 ):
     '''Create a query, all parameters are optional'''
 
@@ -427,6 +428,8 @@ def createQuery(
         Query.QueryAddDatauuid(builder, dataUuidOffset)
     # no if; has default value
     Query.AddWithoutdata(builder, withoutData)
+
+    Query.AddEncapsulated(builder, encapsulated)
 
     return Query.End(builder)
 

--- a/seerep_msgs/core/quaternion.h
+++ b/seerep_msgs/core/quaternion.h
@@ -5,10 +5,10 @@ namespace seerep_core_msgs
 {
 struct quaternion
 {
-  uint32_t x;
-  uint32_t y;
-  uint32_t z;
-  uint32_t w;
+  double x;
+  double y;
+  double z;
+  double w;
 };
 }  // namespace seerep_core_msgs
 

--- a/seerep_msgs/core/quaternion.h
+++ b/seerep_msgs/core/quaternion.h
@@ -1,0 +1,15 @@
+#ifndef SEEREP_CORE_MSGS_QUATERNION_H_
+#define SEEREP_CORE_MSGS_QUATERNION_H_
+
+namespace seerep_core_msgs
+{
+struct quaternion
+{
+  uint32_t x;
+  uint32_t y;
+  uint32_t z;
+  uint32_t w;
+};
+}  // namespace seerep_core_msgs
+
+#endif  // SEEREP_CORE_MSGS_QUATERNION_H_

--- a/seerep_msgs/core/query.h
+++ b/seerep_msgs/core/query.h
@@ -24,6 +24,7 @@ struct Query
   bool withoutData;                                          ///< do not return the data itself if set
   uint maxNumData;                                           ///< max number of datasets that should be returned
   quaternion rotation;
+  bool encapsulated;
 };
 
 } /* namespace seerep_core_msgs */

--- a/seerep_msgs/core/query.h
+++ b/seerep_msgs/core/query.h
@@ -23,7 +23,7 @@ struct Query
   std::optional<std::vector<boost::uuids::uuid>> dataUuids;  ///< only filter by data uuid if set
   bool withoutData;                                          ///< do not return the data itself if set
   uint maxNumData;                                           ///< max number of datasets that should be returned
-  quaternion rotation;
+  std::optional<quaternion> rotation;
   bool encapsulated;
 };
 

--- a/seerep_msgs/core/query.h
+++ b/seerep_msgs/core/query.h
@@ -6,6 +6,7 @@
 
 #include "aabb.h"
 #include "header.h"
+#include "quaternion.h"
 #include "timeinterval.h"
 
 namespace seerep_core_msgs
@@ -22,6 +23,7 @@ struct Query
   std::optional<std::vector<boost::uuids::uuid>> dataUuids;  ///< only filter by data uuid if set
   bool withoutData;                                          ///< do not return the data itself if set
   uint maxNumData;                                           ///< max number of datasets that should be returned
+  quaternion rotation;
 };
 
 } /* namespace seerep_core_msgs */

--- a/seerep_msgs/fbs/query.fbs
+++ b/seerep_msgs/fbs/query.fbs
@@ -15,4 +15,5 @@ table Query {
   datauuid:[string];
   withoutdata:bool;
   maxNumData:uint;
+  encapsulated:bool;
 }

--- a/seerep_msgs/protos/query.proto
+++ b/seerep_msgs/protos/query.proto
@@ -17,4 +17,5 @@ message Query
   repeated string datauuid = 7;
   bool withoutdata = 8;
   uint32 maxNumData = 9;
+  bool encapsulated = 10;
 }

--- a/seerep_srv/seerep_core/CMakeLists.txt
+++ b/seerep_srv/seerep_core/CMakeLists.txt
@@ -3,7 +3,7 @@ project(seerep_core VERSION 0.1)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -fPIC -DBOOST_LOG_DYN_LINK")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -fPIC -DBOOST_LOG_DYN_LINK ")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
@@ -28,6 +28,8 @@ find_package(
 )
 
 find_package(catkin REQUIRED COMPONENTS tf2)
+
+find_package(CGAL REQUIRED)
 
 configure_file(include/SeerepCoreConfig.h.in SeerepCoreConfig.h)
 
@@ -65,6 +67,7 @@ target_link_libraries(
   ${Boost_LOG_SETUP_LIBRARY}
   ${catkin_LIBRARIES}
   Eigen3::Eigen
+  CGAL::CGAL
 )
 
 set(INSTALL_HEADERS

--- a/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
@@ -1,6 +1,10 @@
 #ifndef SEEREP_CORE_CORE_DATASET_H_
 #define SEEREP_CORE_CORE_DATASET_H_
 
+#include <CGAL/Boolean_set_operations_2.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+
+#include <Eigen/Dense>
 #include <algorithm>
 #include <cstdint>
 #include <functional>
@@ -25,6 +29,17 @@
 #include <boost/uuid/uuid.hpp>             // uuid class
 #include <boost/uuid/uuid_generators.hpp>  // generators
 #include <boost/uuid/uuid_io.hpp>          // streaming operators etc.
+
+struct orientedBoundingBox
+{
+  seerep_core_msgs::Point2D bottom_right;
+  seerep_core_msgs::Point2D top_right;
+  seerep_core_msgs::Point2D bottom_left;
+  seerep_core_msgs::Point2D top_left;
+  float height;
+};
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel Kernel;
 
 namespace seerep_core
 {
@@ -121,38 +136,12 @@ public:
                      labelWithInstancePerCategory,
                  const boost::uuids::uuid& msgUuid);
 
-  /**
-   * @brief Get the minimum and maximum time interval for a dataset
-   * @param datatypes A vector of datatypes for which the time bound has to be computed
-   * @return seerep_core_msgs::AabbTime
-   */
-  seerep_core_msgs::AabbTime getTimeBounds(std::vector<seerep_core_msgs::Datatype> datatypes);
-
-  /**
-   * @brief Get the minimum and maximum spatial bound for a dataset
-   * @param datatypes A vector of datatypes for which the spatial bound has to be computed
-   * @return seerep_core_msgs::AABB
-   */
-  seerep_core_msgs::AABB getSpatialBounds(std::vector<seerep_core_msgs::Datatype> datatypes);
-
-  /**
-   * @brief Get the all categories saved in a project
-   *
-   * @param datatypes A vector of datatypes for which the categories have to be fetched
-   * @return std::vector<std::string> vector of categories
-   */
-  std::unordered_set<std::string> getAllCategories(std::vector<seerep_core_msgs::Datatype> datatypes);
-
-  /**
-   * @brief Get the all labels saved in a project
-   *
-   * @param datatypes datatypes across which this is determined
-   * @param category the category across which all labels have to be aggregated
-   * @return std::vector<std::string> vector of labels
-   */
-  std::unordered_set<std::string> getAllLabels(std::vector<seerep_core_msgs::Datatype> datatypes, std::string category);
-
 private:
+  orientedBoundingBox orientAABB(const seerep_core_msgs::AABB& aabb, const seerep_core_msgs::quaternion& quaternion);
+
+  void intersectionDegree(const seerep_core_msgs::AABB& aabb, const orientedBoundingBox& obb, bool fullEncapsulation,
+                          bool partialEncapsulation);
+
   /**
    * @brief fills the member variables based on the HDF5 file
    * @param datatype the datatype to consider

--- a/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
@@ -36,7 +36,8 @@ struct orientedBoundingBox
   seerep_core_msgs::Point2D top_right;
   seerep_core_msgs::Point2D bottom_left;
   seerep_core_msgs::Point2D top_left;
-  float height;
+  float z_min;
+  float z_max;
 };
 
 typedef CGAL::Exact_predicates_exact_constructions_kernel Kernel;
@@ -136,12 +137,65 @@ public:
                      labelWithInstancePerCategory,
                  const boost::uuids::uuid& msgUuid);
 
+  /**
+   * @brief Get the minimum and maximum time interval for a dataset
+   * @param datatypes A vector of datatypes for which the time bound has to be computed
+   * @return seerep_core_msgs::AabbTime
+   */
+  seerep_core_msgs::AabbTime getTimeBounds(std::vector<seerep_core_msgs::Datatype> datatypes);
+
+  /**
+   * @brief Get the minimum and maximum spatial bound for a dataset
+   * @param datatypes A vector of datatypes for which the spatial bound has to be computed
+   * @return seerep_core_msgs::AABB
+   */
+  seerep_core_msgs::AABB getSpatialBounds(std::vector<seerep_core_msgs::Datatype> datatypes);
+
+  /**
+   * @brief Get the all categories saved in a project
+   *
+   * @param datatypes A vector of datatypes for which the categories have to be fetched
+   * @return std::vector<std::string> vector of categories
+   */
+  std::unordered_set<std::string> getAllCategories(std::vector<seerep_core_msgs::Datatype> datatypes);
+
+  /**
+   * @brief Get the all labels saved in a project
+   *
+   * @param datatypes datatypes across which this is determined
+   * @param category the category across which all labels have to be aggregated
+   * @return std::vector<std::string> vector of labels
+   */
+  std::unordered_set<std::string> getAllLabels(std::vector<seerep_core_msgs::Datatype> datatypes, std::string category);
+
 private:
+  /**
+   * @brief orient an axis aligned bounding according to the quaternion
+   *
+   * @param aabb axis aligned bounding box
+   * @param quaternion quaternion for rotation
+   * @return orientedBoundingBox oriented bounding box
+   */
   orientedBoundingBox orientAABB(const seerep_core_msgs::AABB& aabb,
                                  const std::optional<seerep_core_msgs::quaternion>& quaternion);
 
+  /**
+   * @brief rotate a vector using the provided quaternion
+   *
+   * @param vec vector to rotate
+   * @param quaternion quaternion for rotation
+   * @return Eigen::Vector3d rotated vector
+   */
   Eigen::Vector3d rotateVector(const Eigen::Vector3d vec, const Eigen::Quaterniond quaternion);
 
+  /**
+   * @brief determine if the axis aligned bounding box is fully or paritally inside the oriented bounding box
+   *
+   * @param aabb axis aligned bounding box
+   * @param obb oriented bounding box
+   * @param fullEncapsulation boolean variable to denote if the aabb fully inside the obb
+   * @param partialEncapsulation boolean variable to denote if the aabb partially inside the obb
+   */
   void intersectionDegree(const seerep_core_msgs::AABB& aabb, const orientedBoundingBox& obb, bool& fullEncapsulation,
                           bool& partialEncapsulation);
 

--- a/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
@@ -137,10 +137,13 @@ public:
                  const boost::uuids::uuid& msgUuid);
 
 private:
-  orientedBoundingBox orientAABB(const seerep_core_msgs::AABB& aabb, const seerep_core_msgs::quaternion& quaternion);
+  orientedBoundingBox orientAABB(const seerep_core_msgs::AABB& aabb,
+                                 const std::optional<seerep_core_msgs::quaternion>& quaternion);
 
-  void intersectionDegree(const seerep_core_msgs::AABB& aabb, const orientedBoundingBox& obb, bool fullEncapsulation,
-                          bool partialEncapsulation);
+  Eigen::Vector3d rotateVector(const Eigen::Vector3d vec, const Eigen::Quaterniond quaternion);
+
+  void intersectionDegree(const seerep_core_msgs::AABB& aabb, const orientedBoundingBox& obb, bool& fullEncapsulation,
+                          bool& partialEncapsulation);
 
   /**
    * @brief fills the member variables based on the HDF5 file

--- a/seerep_srv/seerep_core/include/seerep_core/core_project.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_project.h
@@ -31,6 +31,7 @@
 // logging
 #include <boost/log/sources/severity_logger.hpp>
 #include <boost/log/trivial.hpp>
+
 namespace seerep_core
 {
 /**

--- a/seerep_srv/seerep_core/src/core_dataset.cpp
+++ b/seerep_srv/seerep_core/src/core_dataset.cpp
@@ -554,137 +554,46 @@ void CoreDataset::addLabels(const seerep_core_msgs::Datatype& datatype,
 }
 
 orientedBoundingBox CoreDataset::orientAABB(const seerep_core_msgs::AABB& aabb,
-                                            const seerep_core_msgs::quaternion& quaternion)
+                                            const std::optional<seerep_core_msgs::quaternion>& quaternion)
 {
-  // https://www.cc.gatech.edu/classes/AY2015/cs4496_spring/Eigen.html
-
-  float height = bg::get<bg::min_corner, 2>(aabb);
-
-  // A quaternion is made using the min and max points of the BB, such that the x, y and z coordinates make up the
-  // vector and the scalar is set to 0
-  Eigen::Quaterniond bottom_left = { bg::get<bg::min_corner, 0>(aabb), bg::get<bg::min_corner, 1>(aabb), height, 0 };
-  Eigen::Quaterniond top_left = { bg::get<bg::min_corner, 0>(aabb), bg::get<bg::max_corner, 1>(aabb), height, 0 };
-  Eigen::Quaterniond bottom_right = { bg::get<bg::max_corner, 0>(aabb), bg::get<bg::min_corner, 1>(aabb), height, 0 };
-  Eigen::Quaterniond top_right = { bg::get<bg::max_corner, 0>(aabb), bg::get<bg::max_corner, 1>(aabb), height, 0 };
-  Eigen::Quaterniond q = { quaternion.x, quaternion.y, quaternion.z, quaternion.w };
-
-  // rotate min point of AABB
-  Eigen::Quaterniond rotated_bottom_left = q * bottom_left * q.inverse();
-  Eigen::Quaterniond rotated_top_left = q * top_left * q.inverse();
-  Eigen::Quaterniond rotated_bottom_right = q * bottom_right * q.inverse();
-  Eigen::Quaterniond rotated_top_right = q * top_right * q.inverse();
-
-  orientedBoundingBox obb;
-  obb.bottom_left.set<0>(rotated_bottom_left.x());
-  obb.bottom_left.set<1>(rotated_bottom_left.y());
-  obb.top_left.set<0>(rotated_top_left.x());
-  obb.top_left.set<1>(rotated_top_left.y());
-  obb.top_right.set<0>(rotated_top_right.x());
-  obb.top_right.set<1>(rotated_top_right.y());
-  obb.bottom_right.set<0>(rotated_bottom_right.x());
-  obb.bottom_right.set<1>(rotated_bottom_right.y());
-
-  obb.height = height;
-
-  return obb;
-}
-
-void CoreDataset::intersectionDegree(const seerep_core_msgs::AABB& aabb, const orientedBoundingBox& obb,
-                                     bool fullEncapsulation, bool partialEncapsulation)
-{
-  // convert seerep core aabb to cgal polygon
-  CGAL::Polygon_2<Kernel> aabb_cgal;
-  aabb_cgal.push_back(
-      Kernel::Point_2(bg::get<bg::min_corner, 0>(aabb), bg::get<bg::min_corner, 1>(aabb)));  // bottom left
-  aabb_cgal.push_back(Kernel::Point_2(bg::get<bg::min_corner, 0>(aabb), bg::get<bg::max_corner, 1>(aabb)));  // top left
-  aabb_cgal.push_back(
-      Kernel::Point_2(bg::get<bg::max_corner, 0>(aabb), bg::get<bg::max_corner, 1>(aabb)));  // top right
-  aabb_cgal.push_back(
-      Kernel::Point_2(bg::get<bg::min_corner, 0>(aabb), bg::get<bg::max_corner, 1>(aabb)));  // bottom right
-
-  // convert seerep core obb to cgal polygon
-  CGAL::Polygon_2<Kernel> obb_cgal;
-  obb_cgal.push_back(Kernel::Point_2(obb.bottom_left.get<0>(), obb.bottom_left.get<1>()));
-  obb_cgal.push_back(Kernel::Point_2(obb.top_left.get<0>(), obb.top_left.get<1>()));
-  obb_cgal.push_back(Kernel::Point_2(obb.top_right.get<0>(), obb.top_right.get<1>()));
-  obb_cgal.push_back(Kernel::Point_2(obb.bottom_right.get<0>(), obb.bottom_right.get<1>()));
-
-  // intersect
-  std::list<CGAL::Polygon_with_holes_2<Kernel>> intersection;
-  CGAL::intersection(aabb_cgal, obb_cgal, std::back_inserter(intersection));
-
-  // if there is no intersection, the iterator will be empty
-  if (intersection.size() == 0)
+  if (quaternion)
   {
-    partialEncapsulation = false;
-    fullEncapsulation = false;
+    // https://gamedev.stackexchange.com/questions/28395/rotating-vector3-by-a-quaternion
 
-    return;
+    float height = bg::get<bg::max_corner, 2>(aabb) - bg::get<bg::min_corner, 2>(aabb);
+
+    // A quaternion is made using the min and max points of the BB, such that the x, y and z coordinates make up the
+    // vector and the scalar is set to 0
+    Eigen::Vector3d bottom_left(bg::get<bg::min_corner, 0>(aabb), bg::get<bg::min_corner, 1>(aabb), height);
+    Eigen::Vector3d top_left(bg::get<bg::min_corner, 0>(aabb), bg::get<bg::max_corner, 1>(aabb), height);
+    Eigen::Vector3d bottom_right(bg::get<bg::max_corner, 0>(aabb), bg::get<bg::min_corner, 1>(aabb), height);
+    Eigen::Vector3d top_right(bg::get<bg::max_corner, 0>(aabb), bg::get<bg::max_corner, 1>(aabb), height);
+    Eigen::Quaterniond q(quaternion.value().w, quaternion.value().x, quaternion.value().y, quaternion.value().z);
+
+    // rotate min point of AABB
+    Eigen::Vector3d rotated_bottom_left = rotateVector(bottom_left, q);
+    Eigen::Vector3d rotated_top_left = rotateVector(top_left, q);
+    Eigen::Vector3d rotated_bottom_right = rotateVector(bottom_right, q);
+    Eigen::Vector3d rotated_top_right = rotateVector(top_right, q);
+
+    orientedBoundingBox obb;
+    obb.bottom_left.set<0>(rotated_bottom_left.x());
+    obb.bottom_left.set<1>(rotated_bottom_left.y());
+    obb.top_left.set<0>(rotated_top_left.x());
+    obb.top_left.set<1>(rotated_top_left.y());
+    obb.top_right.set<0>(rotated_top_right.x());
+    obb.top_right.set<1>(rotated_top_right.y());
+    obb.bottom_right.set<0>(rotated_bottom_right.x());
+    obb.bottom_right.set<1>(rotated_bottom_right.y());
+
+    obb.height = height;  // height of the box is the same as the z-value of the box ground plane?
+
+    return obb;
   }
-
-  // for our use case there will only be one intersection polygon
-  CGAL::Polygon_2<Kernel> intersection_polygon = intersection.front().outer_boundary();
-
-  // are all the points of the intersection inside the obb
-  bool isInside;
-  // traverse the intersection
-  for (CGAL::Polygon_2<Kernel>::Vertex_iterator vi = intersection_polygon.vertices_begin();
-       vi != intersection_polygon.vertices_end(); ++vi)
+  else
   {
-    // check if this point is inside the obb
-    isInside = (obb_cgal.bounded_side(*vi) == CGAL::ON_BOUNDED_SIDE);
-
-    // if isInside is false even once then there is only partial encapsulation
-    if (!isInside)
-    {
-      partialEncapsulation = true;
-      fullEncapsulation = false;
-
-      return;
-    }
+    // return AABB in OBB format!
   }
-
-  // otherwise there is full encapsulation
-  partialEncapsulation = false;
-  fullEncapsulation = true;
-
-  return;
-}
-
-orientedBoundingBox CoreDataset::orientAABB(const seerep_core_msgs::AABB& aabb,
-                                            const seerep_core_msgs::quaternion& quaternion)
-{
-  // https://gamedev.stackexchange.com/questions/28395/rotating-vector3-by-a-quaternion
-
-  float height = bg::get<bg::max_corner, 2>(aabb) - bg::get<bg::min_corner, 2>(aabb);
-
-  // A quaternion is made using the min and max points of the BB, such that the x, y and z coordinates make up the
-  // vector and the scalar is set to 0
-  Eigen::Vector3d bottom_left(bg::get<bg::min_corner, 0>(aabb), bg::get<bg::min_corner, 1>(aabb), height);
-  Eigen::Vector3d top_left(bg::get<bg::min_corner, 0>(aabb), bg::get<bg::max_corner, 1>(aabb), height);
-  Eigen::Vector3d bottom_right(bg::get<bg::max_corner, 0>(aabb), bg::get<bg::min_corner, 1>(aabb), height);
-  Eigen::Vector3d top_right(bg::get<bg::max_corner, 0>(aabb), bg::get<bg::max_corner, 1>(aabb), height);
-  Eigen::Quaterniond q(quaternion.w, quaternion.x, quaternion.y, quaternion.z);
-
-  // rotate min point of AABB
-  Eigen::Vector3d rotated_bottom_left = rotateVector(bottom_left, q);
-  Eigen::Vector3d rotated_top_left = rotateVector(top_left, q);
-  Eigen::Vector3d rotated_bottom_right = rotateVector(bottom_right, q);
-  Eigen::Vector3d rotated_top_right = rotateVector(top_right, q);
-
-  orientedBoundingBox obb;
-  obb.bottom_left.set<0>(rotated_bottom_left.x());
-  obb.bottom_left.set<1>(rotated_bottom_left.y());
-  obb.top_left.set<0>(rotated_top_left.x());
-  obb.top_left.set<1>(rotated_top_left.y());
-  obb.top_right.set<0>(rotated_top_right.x());
-  obb.top_right.set<1>(rotated_top_right.y());
-  obb.bottom_right.set<0>(rotated_bottom_right.x());
-  obb.bottom_right.set<1>(rotated_bottom_right.y());
-
-  obb.height = height;
-
-  return obb;
 }
 
 Eigen::Vector3d CoreDataset::rotateVector(const Eigen::Vector3d vec, const Eigen::Quaterniond quaternion)
@@ -695,7 +604,7 @@ Eigen::Vector3d CoreDataset::rotateVector(const Eigen::Vector3d vec, const Eigen
 }
 
 void CoreDataset::intersectionDegree(const seerep_core_msgs::AABB& aabb, const orientedBoundingBox& obb,
-                                     bool fullEncapsulation, bool partialEncapsulation)
+                                     bool& fullEncapsulation, bool& partialEncapsulation)
 {
   // convert seerep core aabb to cgal polygon
   CGAL::Polygon_2<Kernel> aabb_cgal;

--- a/seerep_srv/seerep_core/src/core_dataset.cpp
+++ b/seerep_srv/seerep_core/src/core_dataset.cpp
@@ -132,8 +132,10 @@ CoreDataset::querySpatial(std::shared_ptr<DatatypeSpecifics> datatypeSpecifics, 
 {
   if (query.boundingbox)
   {
+    // a data structure for holding the result of a query to the r tree
     std::optional<std::vector<seerep_core_msgs::AabbIdPair>> rt_result = std::vector<seerep_core_msgs::AabbIdPair>();
-    // axis-aligned bounding box
+
+    // retrieve axis-aligned bounding box from the requested query
     seerep_core_msgs::AABB aabb(seerep_core_msgs::Point(bg::get<bg::min_corner, 0>(query.boundingbox.value()),
                                                         bg::get<bg::min_corner, 1>(query.boundingbox.value()),
                                                         bg::get<bg::min_corner, 2>(query.boundingbox.value())),
@@ -141,8 +143,15 @@ CoreDataset::querySpatial(std::shared_ptr<DatatypeSpecifics> datatypeSpecifics, 
                                                         bg::get<bg::max_corner, 1>(query.boundingbox.value()),
                                                         bg::get<bg::max_corner, 2>(query.boundingbox.value())));
 
+    // perform the query on the rtree
     datatypeSpecifics->rt.query(boost::geometry::index::intersects(aabb), std::back_inserter(rt_result.value()));
-    return rt_result;
+
+    // perform intersection of oriented(!) bounding box from the query and the resultant
+
+    // if the bounding box is not of volume zero, push into the rt_result and return
+    // return rt_result;
+
+    // otherwise return std::nullopt
   }
   else
   {

--- a/seerep_srv/seerep_core/src/core_project.cpp
+++ b/seerep_srv/seerep_core/src/core_project.cpp
@@ -134,6 +134,7 @@ std::shared_ptr<std::mutex> CoreProject::getHdf5FileMutex()
 {
   return m_write_mtx;
 }
+
 std::shared_ptr<HighFive::File> CoreProject::getHdf5File()
 {
   return m_hdf5_file;

--- a/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_conversion.h
+++ b/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_conversion.h
@@ -278,6 +278,8 @@ private:
   static void fromFbDataLabelsBb(
       const flatbuffers::Vector<flatbuffers::Offset<seerep::fb::BoundingBoxLabeledWithCategory>>* labelsBB,
       std::unordered_map<std::string, std::vector<seerep_core_msgs::LabelWithInstance>>& labelsWithInstancesWithCategory);
+
+  static seerep_core_msgs::quaternion fromFbQuaternion(const seerep::fb::Quaternion* quaternion);
 };
 
 }  // namespace seerep_core_fb

--- a/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_conversion.h
+++ b/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_conversion.h
@@ -281,7 +281,7 @@ private:
       const flatbuffers::Vector<flatbuffers::Offset<seerep::fb::BoundingBoxLabeledWithCategory>>* labelsBB,
       std::unordered_map<std::string, std::vector<seerep_core_msgs::LabelWithInstance>>& labelsWithInstancesWithCategory);
 
-  static seerep_core_msgs::quaternion fromFbQuaternion(const seerep::fb::Quaternion* quaternion);
+  static std::optional<seerep_core_msgs::quaternion> fromFbQuaternion(const seerep::fb::Query* query);
 };
 
 }  // namespace seerep_core_fb

--- a/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_conversion.h
+++ b/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_conversion.h
@@ -239,6 +239,8 @@ private:
    */
   static uint fromFbQueryMaxNumData(const seerep::fb::Query* query);
 
+  static uint fromFbQueryEncapsulated(const seerep::fb::Query* query);
+
   /**
    * @brief converts the header of the flatbuffer data message to seerep core specific message
    * @param header the header in the flatbuffer data message

--- a/seerep_srv/seerep_core_fb/src/core_fb_conversion.cpp
+++ b/seerep_srv/seerep_core_fb/src/core_fb_conversion.cpp
@@ -43,6 +43,7 @@ seerep_core_msgs::Query CoreFbConversion::fromFb(const seerep::fb::Query* query,
   queryCore.withoutData = fromFbQueryWithoutData(query);
   queryCore.maxNumData = fromFbQueryMaxNumData(query);
   queryCore.rotation = fromFbQuaternion(query->boundingboxStamped()->boundingbox()->rotation());
+  queryCore.encapsulated = fromFbQueryEncapsulated(query);
 
   return queryCore;
 }
@@ -514,6 +515,16 @@ uint CoreFbConversion::fromFbQueryMaxNumData(const seerep::fb::Query* query)
   return 0;
 }
 
+uint CoreFbConversion::fromFbQueryEncapsulated(const seerep::fb::Query* query)
+{
+  if (flatbuffers::IsFieldPresent(query, seerep::fb::Query::VT_ENCAPSULATED))
+  {
+    return query->encapsulated();
+  }
+
+  return 0;
+}
+
 void CoreFbConversion::fromFbDataHeader(const seerep::fb::Header* header, seerep_core_msgs::Header& coreHeader,
                                         seerep_core_msgs::Datatype&& datatype)
 {
@@ -667,16 +678,18 @@ std::vector<seerep_core_msgs::Datatype> CoreFbConversion::fromFbDatatypeVector(c
   }
 
   return dt_vector;
-  seerep_core_msgs::quaternion CoreFbConversion::fromFbQuaternion(const seerep::fb::Quaternion* quaternion)
-  {
-    seerep_core_msgs::quaternion quaternionCore;
+}
 
-    quaternionCore.x = quaternion->x();
-    quaternionCore.y = quaternion->y();
-    quaternionCore.z = quaternion->z();
-    quaternionCore.w = quaternion->w();
+seerep_core_msgs::quaternion CoreFbConversion::fromFbQuaternion(const seerep::fb::Quaternion* quaternion)
+{
+  seerep_core_msgs::quaternion quaternionCore;
 
-    return quaternionCore;
-  }
+  quaternionCore.x = quaternion->x();
+  quaternionCore.y = quaternion->y();
+  quaternionCore.z = quaternion->z();
+  quaternionCore.w = quaternion->w();
+
+  return quaternionCore;
+}
 
 }  // namespace seerep_core_fb

--- a/seerep_srv/seerep_core_fb/src/core_fb_conversion.cpp
+++ b/seerep_srv/seerep_core_fb/src/core_fb_conversion.cpp
@@ -42,6 +42,7 @@ seerep_core_msgs::Query CoreFbConversion::fromFb(const seerep::fb::Query* query,
   fromFbQueryDataUuids(query, queryCore.dataUuids);
   queryCore.withoutData = fromFbQueryWithoutData(query);
   queryCore.maxNumData = fromFbQueryMaxNumData(query);
+  queryCore.rotation = fromFbQuaternion(query->boundingboxStamped()->boundingbox()->rotation());
 
   return queryCore;
 }
@@ -666,6 +667,16 @@ std::vector<seerep_core_msgs::Datatype> CoreFbConversion::fromFbDatatypeVector(c
   }
 
   return dt_vector;
-}
+  seerep_core_msgs::quaternion CoreFbConversion::fromFbQuaternion(const seerep::fb::Quaternion* quaternion)
+  {
+    seerep_core_msgs::quaternion quaternionCore;
+
+    quaternionCore.x = quaternion->x();
+    quaternionCore.y = quaternion->y();
+    quaternionCore.z = quaternion->z();
+    quaternionCore.w = quaternion->w();
+
+    return quaternionCore;
+  }
 
 }  // namespace seerep_core_fb

--- a/seerep_srv/seerep_core_fb/src/core_fb_conversion.cpp
+++ b/seerep_srv/seerep_core_fb/src/core_fb_conversion.cpp
@@ -42,7 +42,7 @@ seerep_core_msgs::Query CoreFbConversion::fromFb(const seerep::fb::Query* query,
   fromFbQueryDataUuids(query, queryCore.dataUuids);
   queryCore.withoutData = fromFbQueryWithoutData(query);
   queryCore.maxNumData = fromFbQueryMaxNumData(query);
-  queryCore.rotation = fromFbQuaternion(query->boundingboxStamped()->boundingbox()->rotation());
+  queryCore.rotation = fromFbQuaternion(query);
   queryCore.encapsulated = fromFbQueryEncapsulated(query);
 
   return queryCore;
@@ -680,16 +680,22 @@ std::vector<seerep_core_msgs::Datatype> CoreFbConversion::fromFbDatatypeVector(c
   return dt_vector;
 }
 
-seerep_core_msgs::quaternion CoreFbConversion::fromFbQuaternion(const seerep::fb::Quaternion* quaternion)
+std::optional<seerep_core_msgs::quaternion> CoreFbConversion::fromFbQuaternion(const seerep::fb::Query* query)
 {
-  seerep_core_msgs::quaternion quaternionCore;
+  if (flatbuffers::IsFieldPresent(query, seerep::fb::Query::VT_BOUNDINGBOXSTAMPED))
+  {
+    if (flatbuffers::IsFieldPresent(query->boundingboxStamped()->boundingbox(), seerep::fb::Boundingbox::VT_ROTATION))
+    {
+      seerep_core_msgs::quaternion quaternionCore;
+      quaternionCore.x = query->boundingboxStamped()->boundingbox()->rotation()->x();
+      quaternionCore.y = query->boundingboxStamped()->boundingbox()->rotation()->y();
+      quaternionCore.z = query->boundingboxStamped()->boundingbox()->rotation()->z();
+      quaternionCore.w = query->boundingboxStamped()->boundingbox()->rotation()->w();
 
-  quaternionCore.x = quaternion->x();
-  quaternionCore.y = quaternion->y();
-  quaternionCore.z = quaternion->z();
-  quaternionCore.w = quaternion->w();
-
-  return quaternionCore;
+      return quaternionCore;
+    }
+  }
+  return std::nullopt;
 }
 
 }  // namespace seerep_core_fb

--- a/seerep_srv/seerep_core_pb/include/seerep_core_pb/core_pb_conversion.h
+++ b/seerep_srv/seerep_core_pb/include/seerep_core_pb/core_pb_conversion.h
@@ -159,6 +159,8 @@ private:
   static void fromFbQueryMaxNumData(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore);
 
   static void fromPbQuaternion(const seerep::pb::Quaternion& quaternion, seerep_core_msgs::quaternion& quaternionCore);
+
+  static void fromPbQueryEncapsulated(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore);
 };
 
 }  // namespace seerep_core_pb

--- a/seerep_srv/seerep_core_pb/include/seerep_core_pb/core_pb_conversion.h
+++ b/seerep_srv/seerep_core_pb/include/seerep_core_pb/core_pb_conversion.h
@@ -157,6 +157,8 @@ private:
    * @param queryCore query message in seerep core format
    */
   static void fromFbQueryMaxNumData(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore);
+
+  static void fromPbQuaternion(const seerep::pb::Quaternion& quaternion, seerep_core_msgs::quaternion& quaternionCore);
 };
 
 }  // namespace seerep_core_pb

--- a/seerep_srv/seerep_core_pb/include/seerep_core_pb/core_pb_conversion.h
+++ b/seerep_srv/seerep_core_pb/include/seerep_core_pb/core_pb_conversion.h
@@ -158,7 +158,8 @@ private:
    */
   static void fromFbQueryMaxNumData(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore);
 
-  static void fromPbQuaternion(const seerep::pb::Quaternion& quaternion, seerep_core_msgs::quaternion& quaternionCore);
+  static void fromPbQuaternion(const seerep::pb::Quaternion& quaternion,
+                               std::optional<seerep_core_msgs::quaternion>& quaternionCore);
 
   static void fromPbQueryEncapsulated(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore);
 };

--- a/seerep_srv/seerep_core_pb/src/core_pb_conversion.cpp
+++ b/seerep_srv/seerep_core_pb/src/core_pb_conversion.cpp
@@ -359,6 +359,8 @@ void CorePbConversion::fromPbBoundingBox(const seerep::pb::Query& query, seerep_
     queryCore.boundingbox.value().max_corner().set<2>(query.boundingboxstamped().boundingbox().center_point().z() +
                                                       query.boundingboxstamped().boundingbox().spatial_extent().z() /
                                                           2.0);
+
+    fromPbQuaternion(query.boundingboxstamped().boundingbox().rotation(), queryCore.rotation);
   }
 }
 
@@ -464,6 +466,13 @@ void CorePbConversion::toPb(const seerep_core_msgs::AABB& aabb, seerep::pb::Boun
   bb_pb->mutable_spatial_extent()->set_x(se_x);
   bb_pb->mutable_spatial_extent()->set_y(se_y);
   bb_pb->mutable_spatial_extent()->set_z(se_z);
-}
+  void CorePbConversion::fromPbQuaternion(const seerep::pb::Quaternion& quaternion,
+                                          seerep_core_msgs::quaternion& quaternionCore)
+  {
+    quaternionCore.x = quaternion.x();
+    quaternionCore.y = quaternion.y();
+    quaternionCore.z = quaternion.z();
+    quaternionCore.w = quaternion.w();
+  }
 
 }  // namespace seerep_core_pb

--- a/seerep_srv/seerep_core_pb/src/core_pb_conversion.cpp
+++ b/seerep_srv/seerep_core_pb/src/core_pb_conversion.cpp
@@ -361,7 +361,10 @@ void CorePbConversion::fromPbBoundingBox(const seerep::pb::Query& query, seerep_
                                                       query.boundingboxstamped().boundingbox().spatial_extent().z() /
                                                           2.0);
 
-    fromPbQuaternion(query.boundingboxstamped().boundingbox().rotation(), queryCore.rotation);
+    if (query.boundingboxstamped().boundingbox().has_rotation())
+    {
+      fromPbQuaternion(query.boundingboxstamped().boundingbox().rotation(), queryCore.rotation);
+    }
   }
 }
 
@@ -470,12 +473,12 @@ void CorePbConversion::toPb(const seerep_core_msgs::AABB& aabb, seerep::pb::Boun
 }
 
 void CorePbConversion::fromPbQuaternion(const seerep::pb::Quaternion& quaternion,
-                                        seerep_core_msgs::quaternion& quaternionCore)
+                                        std::optional<seerep_core_msgs::quaternion>& quaternionCore)
 {
-  quaternionCore.x = quaternion.x();
-  quaternionCore.y = quaternion.y();
-  quaternionCore.z = quaternion.z();
-  quaternionCore.w = quaternion.w();
+  quaternionCore.value().x = quaternion.x();
+  quaternionCore.value().y = quaternion.y();
+  quaternionCore.value().z = quaternion.z();
+  quaternionCore.value().w = quaternion.w();
 }
 
 void CorePbConversion::fromPbQueryEncapsulated(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore)

--- a/seerep_srv/seerep_core_pb/src/core_pb_conversion.cpp
+++ b/seerep_srv/seerep_core_pb/src/core_pb_conversion.cpp
@@ -17,6 +17,7 @@ seerep_core_msgs::Query CorePbConversion::fromPb(const seerep::pb::Query& query,
   fromPbDataUuids(query, queryCore);
   fromPbWithOutData(query, queryCore);
   fromFbQueryMaxNumData(query, queryCore);
+  fromPbQueryEncapsulated(query, queryCore);
 
   return queryCore;
 }
@@ -466,13 +467,20 @@ void CorePbConversion::toPb(const seerep_core_msgs::AABB& aabb, seerep::pb::Boun
   bb_pb->mutable_spatial_extent()->set_x(se_x);
   bb_pb->mutable_spatial_extent()->set_y(se_y);
   bb_pb->mutable_spatial_extent()->set_z(se_z);
-  void CorePbConversion::fromPbQuaternion(const seerep::pb::Quaternion& quaternion,
-                                          seerep_core_msgs::quaternion& quaternionCore)
-  {
-    quaternionCore.x = quaternion.x();
-    quaternionCore.y = quaternion.y();
-    quaternionCore.z = quaternion.z();
-    quaternionCore.w = quaternion.w();
-  }
+}
+
+void CorePbConversion::fromPbQuaternion(const seerep::pb::Quaternion& quaternion,
+                                        seerep_core_msgs::quaternion& quaternionCore)
+{
+  quaternionCore.x = quaternion.x();
+  quaternionCore.y = quaternion.y();
+  quaternionCore.z = quaternion.z();
+  quaternionCore.w = quaternion.w();
+}
+
+void CorePbConversion::fromPbQueryEncapsulated(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore)
+{
+  queryCore.encapsulated = query.encapsulated();
+}
 
 }  // namespace seerep_core_pb


### PR DESCRIPTION
This PR implements the following:

- recieve a quaternion from the user in the already existing query
- recieve a boolean variable denoting the user's choice of a full or partial overlap
- orient the aabb using the provided quaternion
- query the rtree with the aabb
- check if the recieved results fall inside the oriented bb fully or partially
- keep or delete the results according to the user's wishes (as communicated in the var in step 2)