### PR TITLE
Return newly indexed projects from SEEREP core

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,3 @@
 [settings]
-known_third_party = cv2,fb,flatbuffers,google,grpc,imageio,matplotlib,numpy,quaternion,rospy,seerep,sensor_msgs,setuptools,std_msgs,tf,util,util_fb,yaml
+known_third_party = cv2,flatbuffers,google,grpc,imageio,matplotlib,numpy,quaternion,rospy,seerep,sensor_msgs,setuptools,std_msgs,tf,util,util_fb,yaml
 profile =black

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,3 @@
 [settings]
-known_third_party = cv2,flatbuffers,google,grpc,imageio,matplotlib,numpy,quaternion,rospy,seerep,sensor_msgs,setuptools,std_msgs,tf,util,util_fb,yaml
+known_third_party = cv2,fb,flatbuffers,google,grpc,imageio,matplotlib,numpy,quaternion,rospy,seerep,sensor_msgs,setuptools,std_msgs,tf,util,util_fb,yaml
 profile =black

--- a/examples/python/gRPC/meta/gRPC_fb_loadProjects.py
+++ b/examples/python/gRPC/meta/gRPC_fb_loadProjects.py
@@ -3,6 +3,7 @@
 import flatbuffers
 from seerep.fb.Empty import Empty
 from seerep.fb.meta_operations_grpc_fb import MetaOperationsStub
+from seerep.fb.ProjectInfos import ProjectInfos
 from seerep.util.common import get_gRPC_channel
 from seerep.util.fb_helper import createEmpty
 
@@ -12,7 +13,8 @@ stub = MetaOperationsStub(channel)
 
 fbb = flatbuffers.Builder(1024)
 responseBuf = stub.LoadProjects(bytes(createEmpty(fbb)))
-responseBuf = Empty.GetRootAs(responseBuf)
+responseBuf = ProjectInfos.GetRootAs(responseBuf)
 
 if responseBuf:
-    print("Projects loaded successfully.")
+    for i in range(responseBuf.ProjectsLength()):
+        print(responseBuf.Projects(i).Name().decode("utf-8") + " " + responseBuf.Projects(i).Uuid().decode("utf-8"))

--- a/examples/python/gRPC/meta/gRPC_fb_loadProjects.py
+++ b/examples/python/gRPC/meta/gRPC_fb_loadProjects.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import flatbuffers
+from seerep.fb.Empty import Empty
+from seerep.fb.meta_operations_grpc_fb import MetaOperationsStub
+from seerep.util.common import get_gRPC_channel
+from seerep.util.fb_helper import createEmpty
+
+channel = get_gRPC_channel()
+
+stub = MetaOperationsStub(channel)
+
+fbb = flatbuffers.Builder(1024)
+responseBuf = stub.LoadProjects(bytes(createEmpty(fbb)))
+responseBuf = Empty.GetRootAs(responseBuf)
+
+if responseBuf:
+    print("Projects loaded successfully.")

--- a/examples/python/gRPC/util/fb_helper.py
+++ b/examples/python/gRPC/util/fb_helper.py
@@ -141,6 +141,14 @@ def getOrCreateProject(
     return projectUuid
 
 
+def createEmpty(builder):
+    '''Create an empty flatbuffer'''
+    Empty.Start(builder)
+    emptyMsg = Empty.End(builder)
+    builder.Finish(emptyMsg)
+    return builder.Output()
+
+
 def createTimeStamp(builder, seconds, nanoseconds=0):
     '''Create a time stamp in flatbuffers'''
     Timestamp.Start(builder)

--- a/seerep_com/fbs/meta_operations.fbs
+++ b/seerep_com/fbs/meta_operations.fbs
@@ -15,7 +15,7 @@ namespace seerep.fb;
 rpc_service MetaOperations {
   CreateProject(seerep.fb.ProjectCreation):seerep.fb.ProjectInfo;
   GetProjects(seerep.fb.Empty):seerep.fb.ProjectInfos;
-  LoadProjects(seerep.fb.Empty):seerep.fb.Empty;
+  LoadProjects(seerep.fb.Empty):seerep.fb.ProjectInfos;
   DeleteProject(seerep.fb.ProjectInfo):seerep.fb.Empty;
   GetOverallTimeInterval(seerep.fb.UuidDatatypePair):seerep.fb.TimeInterval;
   GetOverallBoundingBox(seerep.fb.UuidDatatypePair):seerep.fb.Boundingbox;

--- a/seerep_srv/seerep_core/include/seerep_core/core.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core.h
@@ -149,9 +149,10 @@ public:
   std::shared_ptr<HighFive::File> getHdf5File(const boost::uuids::uuid& projectuuid);
 
   /**
-   * @brief create the project object for each HDF5 file in the data folder
+   * @brief Create the project object for unindexed projects in the data folder
+   * @return Vector of ProjectInfos of the newly indexed projects
    */
-  void loadProjectsInFolder();
+  std::vector<seerep_core_msgs::ProjectInfo> loadProjectsInFolder();
 
   /**
    * @brief removes the project from the seerep server and deletes the HDF5 file

--- a/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_conversion.h
+++ b/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_conversion.h
@@ -17,6 +17,9 @@
 #include <seerep_msgs/image_generated.h>
 #include <seerep_msgs/point_cloud_2_generated.h>
 #include <seerep_msgs/point_stamped_generated.h>
+#include <seerep_msgs/project_info.h>
+#include <seerep_msgs/project_info_generated.h>
+#include <seerep_msgs/project_infos_generated.h>
 #include <seerep_msgs/query_generated.h>
 #include <seerep_msgs/query_instance_generated.h>
 #include <seerep_msgs/region_of_interest.h>
@@ -141,6 +144,19 @@ public:
    */
   static flatbuffers::Offset<seerep::fb::CameraIntrinsics> toFb(flatbuffers::grpc::MessageBuilder& mb,
                                                                 const seerep_core_msgs::camera_intrinsics ci);
+
+  /**
+   * @brief Converts a seerep core project info message into the corresponding flatbuffer message
+   *
+   * @param mb Flatbuffers message builder
+   * @param prjInfo seerep core project info message to convert
+   * @return flatbuffers::Offset<seerep::fb::ProjectInfo>
+   */
+  static flatbuffers::Offset<seerep::fb::ProjectInfo> toFb(flatbuffers::grpc::MessageBuilder& fbb,
+                                                           const seerep_core_msgs::ProjectInfo& prjInfo);
+
+  static flatbuffers::Offset<seerep::fb::ProjectInfos> toFb(flatbuffers::grpc::MessageBuilder& fbb,
+                                                            const std::vector<seerep_core_msgs::ProjectInfo>& prjInfos);
 
   /**
    * @brief converts the flatbuffer region of interest message to the specific seerep core message

--- a/seerep_srv/seerep_core_fb/src/core_fb_conversion.cpp
+++ b/seerep_srv/seerep_core_fb/src/core_fb_conversion.cpp
@@ -380,6 +380,30 @@ flatbuffers::Offset<seerep::fb::TimeInterval> CoreFbConversion::toFb(flatbuffers
   return timeIntervalBuilder.Finish();
 }
 
+flatbuffers::Offset<seerep::fb::ProjectInfo> CoreFbConversion::toFb(flatbuffers::grpc::MessageBuilder& fbb,
+                                                                    const seerep_core_msgs::ProjectInfo& prjInfo)
+{
+  auto geoCordsOffset = seerep::fb::CreateGeodeticCoordinatesDirect(
+      fbb, prjInfo.geodetCoords.coordinateSystem.c_str(), prjInfo.geodetCoords.ellipsoid.c_str(),
+      prjInfo.geodetCoords.longitude, prjInfo.geodetCoords.latitude, prjInfo.geodetCoords.altitude);
+
+  return seerep::fb::CreateProjectInfoDirect(fbb, prjInfo.name.c_str(),
+                                             boost::lexical_cast<std::string>(prjInfo.uuid).c_str(),
+                                             prjInfo.frameId.c_str(), geoCordsOffset, prjInfo.version.c_str());
+}
+
+flatbuffers::Offset<seerep::fb::ProjectInfos>
+CoreFbConversion::toFb(flatbuffers::grpc::MessageBuilder& fbb,
+                       const std::vector<seerep_core_msgs::ProjectInfo>& prjInfos)
+{
+  std::vector<flatbuffers::Offset<seerep::fb::ProjectInfo>> prjInfosConv;
+  for (auto prjInfo : prjInfos)
+  {
+    prjInfosConv.push_back(toFb(fbb, prjInfo));
+  }
+  return seerep::fb::CreateProjectInfosDirect(fbb, &prjInfosConv);
+}
+
 void CoreFbConversion::fromFbQueryProject(const seerep::fb::Query* query,
                                           std::optional<std::vector<boost::uuids::uuid>>& queryCoreProjects)
 {

--- a/seerep_srv/seerep_server/include/seerep_server/fb_meta_operations.h
+++ b/seerep_srv/seerep_server/include/seerep_server/fb_meta_operations.h
@@ -22,7 +22,7 @@ public:
   grpc::Status GetProjects(grpc::ServerContext* context, const flatbuffers::grpc::Message<seerep::fb::Empty>* request,
                            flatbuffers::grpc::Message<seerep::fb::ProjectInfos>* response) override;
   grpc::Status LoadProjects(grpc::ServerContext* context, const flatbuffers::grpc::Message<seerep::fb::Empty>* request,
-                            flatbuffers::grpc::Message<seerep::fb::Empty>* response) override;
+                            flatbuffers::grpc::Message<seerep::fb::ProjectInfos>* response) override;
   grpc::Status DeleteProject(grpc::ServerContext* context,
                              const flatbuffers::grpc::Message<seerep::fb::ProjectInfo>* request,
                              flatbuffers::grpc::Message<seerep::fb::Empty>* response) override;


### PR DESCRIPTION
Summary:
- Return newly indexed projects when calling `LoadProjects` via gRPC
- Refactor `GetProjects` and `LoadProjects` 
- Python script to trigger the loading of the new projects