### PR TITLE
Polygon query

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends -y \
         gdb \
         unzip \
         git \
+        libcgal-dev \
         sudo \
         ssh \
         vim \

--- a/examples/python/gRPC/images/gRPC_fb_queryImageAndVisualize.py
+++ b/examples/python/gRPC/images/gRPC_fb_queryImageAndVisualize.py
@@ -35,12 +35,14 @@ if not projectuuid:
 # 3. Get gRPC service object
 stub = imageService.ImageServiceStub(channel)
 
-
 # Create all necessary objects for the query
-header = createHeader(builder, frame="map")
-pointMin = createPoint(builder, 2.8, -1.0, -1.0)
-pointMax = createPoint(builder, 3.0, 0.5, 1.0)
-boundingboxStamped = createBoundingBoxStamped(builder, header, pointMin, pointMax)
+l = 10
+polygon_vertices = []
+polygon_vertices.append(createPoint2d(builder, -1.0 * l, -1.0 * l))
+polygon_vertices.append(createPoint2d(builder, -1.0 * l, l))
+polygon_vertices.append(createPoint2d(builder, l, l))
+polygon_vertices.append(createPoint2d(builder, l, -1.0 * l))
+polygon2d = createPolygon2D(builder, 7, -1, polygon_vertices)
 
 if t1:
     timeMin = createTimeStamp(builder, 1661336503, 0)
@@ -79,6 +81,7 @@ query = createQuery(
     # instanceUuids=instanceUuids,
     # dataUuids=dataUuids,
     withoutData=False,
+    fullyEncapsulated=False,
 )
 builder.Finish(query)
 buf = builder.Output()

--- a/examples/python/gRPC/images/gRPC_pb_queryImage.py
+++ b/examples/python/gRPC/images/gRPC_pb_queryImage.py
@@ -7,6 +7,7 @@ from seerep.pb import image_service_pb2_grpc as imageService
 from seerep.pb import label_pb2
 from seerep.pb import labels_with_category_pb2 as labels_with_category
 from seerep.pb import meta_operations_pb2_grpc as metaOperations
+from seerep.pb import point2d_pb2 as point2d
 from seerep.pb import query_pb2 as query
 from seerep.util.common import get_gRPC_channel
 
@@ -33,14 +34,30 @@ if projectuuid == "":
 # 4. Create a query with parameters
 theQuery = query.Query()
 theQuery.projectuuid.append(projectuuid)
-theQuery.boundingboxStamped.header.frame_id = "map"
 
-theQuery.boundingboxStamped.boundingbox.center_point.x = 50.0
-theQuery.boundingboxStamped.boundingbox.center_point.y = 50.0
-theQuery.boundingboxStamped.boundingbox.center_point.z = 50.0
-theQuery.boundingboxStamped.boundingbox.spatial_extent.x = 100.0
-theQuery.boundingboxStamped.boundingbox.spatial_extent.y = 100.0
-theQuery.boundingboxStamped.boundingbox.spatial_extent.z = 100.0
+theQuery.polygon.z = -1
+theQuery.polygon.height = 7
+
+l = 100
+bottom_left = point2d.Point2D()
+bottom_left.x = -l
+bottom_left.y = -l
+theQuery.polygon.vertices.append(bottom_left)
+
+top_left = point2d.Point2D()
+top_left.x = -l
+top_left.y = l
+theQuery.polygon.vertices.append(top_left)
+
+top_right = point2d.Point2D()
+top_right.x = l
+top_right.y = l
+theQuery.polygon.vertices.append(top_right)
+
+bottom_right = point2d.Point2D()
+bottom_right.x = l
+bottom_right.y = -l
+theQuery.polygon.vertices.append(bottom_right)
 
 # since epoche
 theQuery.timeinterval.time_min.seconds = 1638549273

--- a/examples/python/gRPC/images/gRPC_pb_queryImageGrid.py
+++ b/examples/python/gRPC/images/gRPC_pb_queryImageGrid.py
@@ -29,12 +29,29 @@ if projectuuid == "":
 
 theQuery = query.Query()
 theQuery.projectuuid.append(projectuuid)
-theQuery.boundingboxStamped.header.frame_id = "map"
 
-theQuery.boundingboxStamped.boundingbox.center_point.z = 0.0
-theQuery.boundingboxStamped.boundingbox.spatial_extent.z = 1.0
-theQuery.boundingboxStamped.boundingbox.spatial_extent.x = 1.0
-theQuery.boundingboxStamped.boundingbox.spatial_extent.y = 1.0
+bottom_left = point2d.Point2D()
+bottom_left.x = -150
+bottom_left.y = -150
+theQuery.polygon.vertices.append(bottom_left)
+
+top_left = point2d.Point2D()
+top_left.x = -150
+top_left.y = 150
+theQuery.polygon.vertices.append(top_left)
+
+top_right = point2d.Point2D()
+top_right.x = 150
+top_right.y = 150
+theQuery.polygon.vertices.append(top_right)
+
+bottom_right = point2d.Point2D()
+bottom_right.x = 150
+bottom_right.y = -150
+theQuery.polygon.vertices.append(bottom_right)
+
+theQuery.polygon.z = -1
+theQuery.polygon.height = 7
 
 # since epoche
 theQuery.timeinterval.time_min.seconds = 1638549273

--- a/examples/python/gRPC/images/gRPC_pb_sendLabeledImageGrid.py
+++ b/examples/python/gRPC/images/gRPC_pb_sendLabeledImageGrid.py
@@ -94,7 +94,7 @@ for k in range(9):
                 label.label.label = "testlabelgeneral" + str(i)
                 label.label.confidence = i / 10.0
                 # assuming that that the general labels are not instance related -> no instance uuid
-                # label.instanceUuid = str(uuid.uuid4())
+                label.instanceUuid = str(uuid.uuid4())
                 labelsCat.labelWithInstance.append(label)
             theImage.labels_general.append(labelsCat)
 

--- a/examples/python/gRPC/instances/gRPC_fb_getInstances.py
+++ b/examples/python/gRPC/instances/gRPC_fb_getInstances.py
@@ -5,10 +5,9 @@ from seerep.fb import Datatype, UuidsPerProject
 from seerep.fb import instance_service_grpc_fb as instanceService
 from seerep.util.common import get_gRPC_channel
 from seerep.util.fb_helper import (
-    createBoundingBoxStamped,
-    createHeader,
     createLabelWithCategory,
-    createPoint,
+    createPoint2d,
+    createPolygon2D,
     createQuery,
     createQueryInstance,
     createTimeInterval,
@@ -33,10 +32,12 @@ stub = instanceService.InstanceServiceStub(channel)
 
 
 # Create all necessary objects for the query
-header = createHeader(builder, frame="map")
-pointMin = createPoint(builder, 0.0, 0.0, 0.0)
-pointMax = createPoint(builder, 100.0, 100.0, 100.0)
-boundingboxStamped = createBoundingBoxStamped(builder, header, pointMin, pointMax)
+polygon_vertices = []
+polygon_vertices.append(createPoint2d(builder, 0, 0))
+polygon_vertices.append(createPoint2d(builder, 0, 100))
+polygon_vertices.append(createPoint2d(builder, 100, 100))
+polygon_vertices.append(createPoint2d(builder, 0, 100))
+polygon2d = createPolygon2D(builder, 100, 0, polygon_vertices)
 
 timeMin = createTimeStamp(builder, 1610549273, 0)
 timeMax = createTimeStamp(builder, 1938549273, 0)
@@ -62,6 +63,7 @@ query = createQuery(
     # instanceUuids=instanceUuids,
     # dataUuids=dataUuids,
     withoutData=True,
+    fullyEncapsulated=False,
 )
 
 

--- a/examples/python/gRPC/point/gRPC_fb_queryPoints.py
+++ b/examples/python/gRPC/point/gRPC_fb_queryPoints.py
@@ -5,11 +5,10 @@ from seerep.fb import PointStamped
 from seerep.fb import point_service_grpc_fb as pointService
 from seerep.util.common import get_gRPC_channel
 from seerep.util.fb_helper import (
-    createBoundingBoxStamped,
-    createHeader,
     createLabelWithCategory,
     createLabelWithConfidence,
-    createPoint,
+    createPoint2d,
+    createPolygon2D,
     createQuery,
     createTimeInterval,
     createTimeStamp,
@@ -21,16 +20,19 @@ builder = flatbuffers.Builder(1024)
 PROJECT_NAME = "simulatedDataWithInstances"
 channel = get_gRPC_channel()
 # 1. Get all projects from the server
-projectuuid = getProject(builder, channel, 'LabeledImagesInGrid')
+projectuuid = getProject(builder, channel, 'testproject')
 # 2. Check if the defined project exist; if not exit
 if not projectuuid:
     exit()
 
 # Create all necessary objects for the query
-header = createHeader(builder, frame="map")
-pointMin = createPoint(builder, 0.0, 0.0, 0.0)
-pointMax = createPoint(builder, 100.0, 100.0, 100.0)
-boundingboxStamped = createBoundingBoxStamped(builder, header, pointMin, pointMax)
+l = 10
+polygon_vertices = []
+polygon_vertices.append(createPoint2d(builder, -1.0 * l, -1.0 * l))
+polygon_vertices.append(createPoint2d(builder, -1.0 * l, l))
+polygon_vertices.append(createPoint2d(builder, l, l))
+polygon_vertices.append(createPoint2d(builder, l, -1.0 * l))
+polygon2d = createPolygon2D(builder, 7, -1, polygon_vertices)
 
 timeMin = createTimeStamp(builder, 1610549273, 0)
 timeMax = createTimeStamp(builder, 1938549273, 0)

--- a/examples/python/gRPC/pointcloud/gRPC_fb_queryPointCloud.py
+++ b/examples/python/gRPC/pointcloud/gRPC_fb_queryPointCloud.py
@@ -10,11 +10,8 @@ from seerep.fb import PointCloud2
 from seerep.fb import point_cloud_service_grpc_fb as pointCloudService
 from seerep.util.common import get_gRPC_channel
 from seerep.util.fb_helper import (
-    createBoundingBoxStamped,
-    createHeader,
     createLabelWithCategory,
     createLabelWithConfidence,
-    createPoint,
     createPoint2d,
     createPolygon2D,
     createQuery,
@@ -39,7 +36,6 @@ if projectuuid is None:
 builder = flatbuffers.Builder(1024)
 
 # Create all necessary objects for the query
-# header = createHeader(builder, frame="map")
 l = 10
 polygon_vertices = []
 polygon_vertices.append(createPoint2d(builder, -1.0 * l, -1.0 * l))
@@ -51,7 +47,6 @@ polygon2d = createPolygon2D(builder, 7, -1, polygon_vertices)
 timeMin = createTimeStamp(builder, 1610549273, 0)
 timeMax = createTimeStamp(builder, 1938549273, 0)
 timeInterval = createTimeInterval(builder, timeMin, timeMax)
-
 
 projectUuids = [builder.CreateString(projectuuid)]
 # list of categories

--- a/examples/python/gRPC/pointcloud/gRPC_fb_queryPointCloud.py
+++ b/examples/python/gRPC/pointcloud/gRPC_fb_queryPointCloud.py
@@ -10,7 +10,13 @@ from seerep.fb import PointCloud2
 from seerep.fb import point_cloud_service_grpc_fb as pointCloudService
 from seerep.util.common import get_gRPC_channel
 from seerep.util.fb_helper import (
+    createBoundingBoxStamped,
+    createHeader,
     createLabelWithCategory,
+    createLabelWithConfidence,
+    createPoint,
+    createPoint2d,
+    createPolygon2D,
     createQuery,
     createTimeInterval,
     createTimeStamp,
@@ -23,31 +29,65 @@ stubPointCloud = pointCloudService.PointCloudServiceStub(channel)
 builder = flatbuffers.Builder(1024)
 
 PROJECTNAME = "testproject"
-projectUuid = getProject(builder, channel, PROJECTNAME)
+projectuuid = getProject(builder, channel, PROJECTNAME)
 
-if projectUuid is None:
+if projectuuid is None:
     print(f"Project: {PROJECTNAME} does not exist")
     sys.exit()
 
 
 builder = flatbuffers.Builder(1024)
 
+# Create all necessary objects for the query
+# header = createHeader(builder, frame="map")
+l = 10
+polygon_vertices = []
+polygon_vertices.append(createPoint2d(builder, -1.0 * l, -1.0 * l))
+polygon_vertices.append(createPoint2d(builder, -1.0 * l, l))
+polygon_vertices.append(createPoint2d(builder, l, l))
+polygon_vertices.append(createPoint2d(builder, l, -1.0 * l))
+polygon2d = createPolygon2D(builder, 7, -1, polygon_vertices)
+
 timeMin = createTimeStamp(builder, 1610549273, 0)
 timeMax = createTimeStamp(builder, 1938549273, 0)
 timeInterval = createTimeInterval(builder, timeMin, timeMax)
 
-category = "0"
-labels = [[builder.CreateString("testlabel0"), builder.CreateString("BoundingBoxLabel0")]]
-labelCategory = createLabelWithCategory(builder, category, labels)
 
-queryMsg = createQuery(
-    builder, projectUuids=[builder.CreateString(projectUuid)], timeInterval=timeInterval, labels=labelCategory
+projectUuids = [builder.CreateString(projectuuid)]
+# list of categories
+category = ["0"]
+# list of labels per category
+labels = [
+    [
+        createLabelWithConfidence(builder, "testlabel0"),
+        createLabelWithConfidence(builder, "testlabelgeneral0"),
+    ]
+]
+labelCategory = createLabelWithCategory(builder, category, labels)
+dataUuids = [builder.CreateString("3e12e18d-2d53-40bc-a8af-c5cca3c3b248")]
+instanceUuids = [builder.CreateString("3e12e18d-2d53-40bc-a8af-c5cca3c3b248")]
+
+# 4. Create a query with parameters
+# all parameters are optional
+# with all parameters set (especially with the data and instance uuids set) the result of the query will be empty. Set the query parameters to adequate values or remove them from the query creation
+query = createQuery(
+    builder,
+    # boundingBox=boundingboxStamped,
+    # timeInterval=timeInterval,
+    # labels=labelCategory,
+    # mustHaveAllLabels=True,
+    projectUuids=projectUuids,
+    # instanceUuids=instanceUuids,
+    # dataUuids=dataUuids,
+    withoutData=True,
+    polygon2d=polygon2d,
+    fullyEncapsulated=True,
 )
-builder.Finish(queryMsg)
+builder.Finish(query)
 buf = builder.Output()
 
 for responseBuf in stubPointCloud.GetPointCloud2(bytes(buf)):
-    response = PointCloud2.GetRootAs(responseBuf)
+    response = PointCloud2.PointCloud2.GetRootAs(responseBuf)
 
     print("---Header---")
     print(f"Message UUID: {response.Header().UuidMsgs().decode('utf-8')}")

--- a/examples/python/gRPC/pointcloud/gRPC_fb_sendPointCloud.py
+++ b/examples/python/gRPC/pointcloud/gRPC_fb_sendPointCloud.py
@@ -61,7 +61,13 @@ def createPointCloud(builder, header, height=960, width=1280):
     # labelsBbVector = addToBoundingBoxLabeledVector(builder, labelsBBCat)
 
     # Note: rgb field is float, for simplification
-    points = np.random.randn(height, width, 4).astype(np.float32)
+    pointsBox = [[]]
+    lim = 3
+    for a in range(-lim, lim + 1, 1):
+        for b in range(-lim, lim + 1, 1):
+            for c in range(-lim, lim + 1, 1):
+                pointsBox[0].append([a, b, c, 0])
+    points = np.array(pointsBox).astype(np.float32)
     print(f"Data: {points}")
 
     pointsVector = builder.CreateByteVector(points.tobytes())
@@ -144,4 +150,5 @@ tfStub = tf_service_grpc_fb.TfServiceStub(channel)
 tfStub.TransferTransformStamped(createTF(channel, NUM_POINT_CLOUDS, projectUuid, theTime))
 
 stub = pointCloudService.PointCloudServiceStub(channel)
-responseBuf = stub.TransferPointCloud2(createPointClouds(projectUuid, NUM_POINT_CLOUDS, theTime))
+pc = createPointClouds(projectUuid, NUM_POINT_CLOUDS, theTime)
+responseBuf = stub.TransferPointCloud2(pc)

--- a/examples/python/gRPC/simulated-data/querySimulatedData.py
+++ b/examples/python/gRPC/simulated-data/querySimulatedData.py
@@ -5,10 +5,9 @@ from seerep.fb import Image
 from seerep.fb import image_service_grpc_fb as imageService
 from seerep.util.common import get_gRPC_channel
 from seerep.util.fb_helper import (
-    createBoundingBoxStamped,
-    createHeader,
     createLabelWithCategory,
-    createPoint,
+    createPoint2d,
+    createPolygon2D,
     createQuery,
     createTimeInterval,
     createTimeStamp,
@@ -29,10 +28,13 @@ if not projectuuid:
 stub = imageService.ImageServiceStub(channel)
 
 # Create all necessary objects for the query
-header = createHeader(builder, frame="map")
-pointMin = createPoint(builder, -5.0, -5.0, -100.0)
-pointMax = createPoint(builder, 5.0, 5.0, 100.0)
-boundingboxStamped = createBoundingBoxStamped(builder, header, pointMin, pointMax)
+l = 5
+polygon_vertices = []
+polygon_vertices.append(createPoint2d(builder, -1.0 * l, -1.0 * l))
+polygon_vertices.append(createPoint2d(builder, -1.0 * l, l))
+polygon_vertices.append(createPoint2d(builder, l, l))
+polygon_vertices.append(createPoint2d(builder, l, -1.0 * l))
+polygon2d = createPolygon2D(builder, 200, -100, polygon_vertices)
 
 timeMin = createTimeStamp(builder, 1654688920, 0)
 timeMax = createTimeStamp(builder, 1654688940, 0)

--- a/examples/python/gRPC/util/fb_helper.py
+++ b/examples/python/gRPC/util/fb_helper.py
@@ -21,6 +21,7 @@ from seerep.fb import (
     PointCloud2,
     PointField,
     PointStamped,
+    Polygon2D,
     ProjectCreation,
     ProjectInfo,
     ProjectInfos,
@@ -347,6 +348,22 @@ def createBoundingBox(builder, centerPoint, spatialExtent, rotation=None):
     return Boundingbox.End(builder)
 
 
+def createPolygon2D(builder, height, z, vertices):
+    '''Create a 2D Polygon in flatbuffers'''
+
+    Polygon2D.StartVerticesVector(builder, len(vertices))
+    for v in vertices:
+        builder.PrependUOffsetTRelative(v)
+    vertices_fb = builder.EndVector()
+
+    Polygon2D.Start(builder)
+    Polygon2D.AddHeight(builder, height)
+    Polygon2D.AddZ(builder, z)
+    Polygon2D.AddVertices(builder, vertices_fb)
+
+    return Polygon2D.End(builder)
+
+
 def createBoundingBoxStamped(builder, header, centerPoint, spatialExtent, rotation=None):
     '''Creates a stamped 3D bounding box in flatbuffers'''
     boundingBox = createBoundingBox(builder, centerPoint, spatialExtent, rotation)
@@ -434,6 +451,8 @@ def createQuery(
     instanceUuids=None,
     dataUuids=None,
     withoutData=False,
+    polygon2d=None,
+    fullyEncapsulated=False,
 ):
     '''Create a query, all parameters are optional'''
 
@@ -459,6 +478,8 @@ def createQuery(
     Query.Start(builder)
     if boundingBox:
         Query.AddBoundingboxStamped(builder, boundingBox)
+    if polygon2d:
+        Query.AddPolygon(builder, polygon2d)
     if timeInterval:
         Query.AddTimeinterval(builder, timeInterval)
     if labels:
@@ -473,6 +494,7 @@ def createQuery(
         Query.QueryAddDatauuid(builder, dataUuidOffset)
     # no if; has default value
     Query.AddWithoutdata(builder, withoutData)
+    Query.AddFullyEncapsulated(builder, fullyEncapsulated)
 
     return Query.End(builder)
 

--- a/seerep_msgs/CMakeLists.txt
+++ b/seerep_msgs/CMakeLists.txt
@@ -44,6 +44,7 @@ set(MY_PROTO_FILES
     protos/point2d.proto
     protos/polygon_stamped.proto
     protos/polygon.proto
+    protos/polygon2d.proto
     protos/pose_stamped.proto
     protos/pose.proto
     protos/project_info.proto
@@ -102,6 +103,7 @@ set(MY_FBS_FILES
     fbs/point2d.fbs
     fbs/polygon_stamped.fbs
     fbs/polygon.fbs
+    fbs/polygon2d.fbs
     fbs/pose_stamped.fbs
     fbs/pose.fbs
     fbs/project_info.fbs
@@ -140,6 +142,7 @@ set(MY_CORE_MSGS
     ${CMAKE_CURRENT_SOURCE_DIR}/core/datatype.h
     ${CMAKE_CURRENT_SOURCE_DIR}/core/label_with_instance.h
     ${CMAKE_CURRENT_SOURCE_DIR}/core/project_info.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/polygon2d.h
     ${CMAKE_CURRENT_SOURCE_DIR}/core/query_result_project.h
     ${CMAKE_CURRENT_SOURCE_DIR}/core/query_result.h
     ${CMAKE_CURRENT_SOURCE_DIR}/core/query_tf.h

--- a/seerep_msgs/core/polygon2d.h
+++ b/seerep_msgs/core/polygon2d.h
@@ -10,7 +10,7 @@ struct Polygon2D
   std::vector<Point2D> vertices;
   int z;
   int height;
-}
+};
 }  // namespace seerep_core_msgs
 
-#endif SEEREP_CORE_MSGS_POLYGON2D_H_
+#endif

--- a/seerep_msgs/core/polygon2d.h
+++ b/seerep_msgs/core/polygon2d.h
@@ -1,0 +1,16 @@
+#ifndef SEEREP_CORE_MSGS_POLYGON2D_H_
+#define SEEREP_CORE_MSGS_POLYGON2D_H_
+
+#include "aabb.h"
+
+namespace seerep_core_msgs
+{
+struct Polygon2D
+{
+  std::vector<Point2D> vertices;
+  int z;
+  int height;
+}
+}  // namespace seerep_core_msgs
+
+#endif SEEREP_CORE_MSGS_POLYGON2D_H_

--- a/seerep_msgs/core/query.h
+++ b/seerep_msgs/core/query.h
@@ -15,14 +15,16 @@ struct Query
 {
   Header header;
   std::optional<std::vector<boost::uuids::uuid>> projects;  ///< search all projects if not set
-  std::optional<Polygon2D> polygon;
-  std::optional<Timeinterval> timeinterval;                                        ///< only do temporal query if set
+  std::optional<AABB> boundingbox;
+  std::optional<Polygon2D> polygon;          // query point clouds in the region defined by this polygon
+  std::optional<Timeinterval> timeinterval;  ///< only do temporal query if set
   std::optional<std::unordered_map<std::string, std::vector<std::string>>> label;  ///< only do semantic query if set
   bool mustHaveAllLabels;  ///< a dataset only fulfills semantic query if all labels are present
   std::optional<std::vector<boost::uuids::uuid>> instances;  ///< only query instances if set
   std::optional<std::vector<boost::uuids::uuid>> dataUuids;  ///< only filter by data uuid if set
   bool withoutData;                                          ///< do not return the data itself if set
   uint maxNumData;                                           ///< max number of datasets that should be returned
+  bool fullyEncapsulated;  // if true, only return results fully inside the polygon defined above
 };
 
 } /* namespace seerep_core_msgs */

--- a/seerep_msgs/core/query.h
+++ b/seerep_msgs/core/query.h
@@ -6,6 +6,7 @@
 
 #include "aabb.h"
 #include "header.h"
+#include "polygon2d.h"
 #include "timeinterval.h"
 
 namespace seerep_core_msgs
@@ -13,8 +14,8 @@ namespace seerep_core_msgs
 struct Query
 {
   Header header;
-  std::optional<std::vector<boost::uuids::uuid>> projects;                         ///< search all projects if not set
-  std::optional<AABB> boundingbox;                                                 ///< only do spatial query if set
+  std::optional<std::vector<boost::uuids::uuid>> projects;  ///< search all projects if not set
+  std::optional<Polygon2D> polygon;
   std::optional<Timeinterval> timeinterval;                                        ///< only do temporal query if set
   std::optional<std::unordered_map<std::string, std::vector<std::string>>> label;  ///< only do semantic query if set
   bool mustHaveAllLabels;  ///< a dataset only fulfills semantic query if all labels are present

--- a/seerep_msgs/fbs/polygon2d.fbs
+++ b/seerep_msgs/fbs/polygon2d.fbs
@@ -1,0 +1,10 @@
+
+include "point2d.fbs";
+
+namespace seerep.fb;
+
+table Polygon2D {
+    vertices:[seerep.fb.Point2D];
+    z:double;
+    height:double;
+}

--- a/seerep_msgs/fbs/query.fbs
+++ b/seerep_msgs/fbs/query.fbs
@@ -8,6 +8,7 @@ namespace seerep.fb;
 
 table Query {
   polygon:Polygon2D;
+  boundingboxStamped:BoundingboxStamped;
   timeinterval:TimeInterval;
   label:[LabelsWithCategory];
   mustHaveAllLabels:bool;
@@ -16,4 +17,5 @@ table Query {
   datauuid:[string];
   withoutdata:bool;
   maxNumData:uint;
+  fullyEncapsulated:bool;
 }

--- a/seerep_msgs/fbs/query.fbs
+++ b/seerep_msgs/fbs/query.fbs
@@ -2,11 +2,12 @@
 include "time_interval.fbs";
 include "boundingbox_stamped.fbs";
 include "labels_with_category.fbs";
+include "polygon2d.fbs";
 
 namespace seerep.fb;
 
 table Query {
-  boundingboxStamped:BoundingboxStamped;
+  polygon:Polygon2D;
   timeinterval:TimeInterval;
   label:[LabelsWithCategory];
   mustHaveAllLabels:bool;

--- a/seerep_msgs/protos/polygon2d.proto
+++ b/seerep_msgs/protos/polygon2d.proto
@@ -2,11 +2,11 @@ syntax = "proto3";
 
 package seerep.pb;
 
-import "point.proto";
+import "point2d.proto";
 
 message Polygon2D
 {
-  repeated Point vertices = 1;
+  repeated Point2D vertices = 1;
   double z = 2;
   double height = 3;
 }

--- a/seerep_msgs/protos/polygon2d.proto
+++ b/seerep_msgs/protos/polygon2d.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package seerep.pb;
+
+import "point.proto";
+
+message Polygon2D
+{
+  repeated Point vertices = 1;
+  double z = 2;
+  double height = 3;
+}

--- a/seerep_msgs/protos/query.proto
+++ b/seerep_msgs/protos/query.proto
@@ -5,10 +5,11 @@ package seerep.pb;
 import "time_interval.proto";
 import "boundingbox_stamped.proto";
 import "labels_with_category.proto";
+import "polygon2d.proto";
 
 message Query
 {
-  BoundingboxStamped boundingboxStamped = 1;
+  Polygon2D polygon = 1;
   TimeInterval timeinterval = 2;
   repeated LabelsWithCategory labelsWithCategory = 3;
   bool mustHaveAllLabels = 4;

--- a/seerep_msgs/protos/query.proto
+++ b/seerep_msgs/protos/query.proto
@@ -9,7 +9,7 @@ import "polygon2d.proto";
 
 message Query
 {
-  Polygon2D polygon = 1;
+  BoundingboxStamped boundingboxStamped = 1;
   TimeInterval timeinterval = 2;
   repeated LabelsWithCategory labelsWithCategory = 3;
   bool mustHaveAllLabels = 4;
@@ -18,4 +18,6 @@ message Query
   repeated string datauuid = 7;
   bool withoutdata = 8;
   uint32 maxNumData = 9;
+  Polygon2D polygon = 10;
+  bool fullyEncapsulated = 11;
 }

--- a/seerep_srv/seerep_core/CMakeLists.txt
+++ b/seerep_srv/seerep_core/CMakeLists.txt
@@ -29,6 +29,8 @@ find_package(
 
 find_package(catkin REQUIRED COMPONENTS tf2)
 
+find_package(CGAL REQUIRED)
+
 configure_file(include/SeerepCoreConfig.h.in SeerepCoreConfig.h)
 
 include_directories(
@@ -65,6 +67,7 @@ target_link_libraries(
   ${Boost_LOG_SETUP_LIBRARY}
   ${catkin_LIBRARIES}
   Eigen3::Eigen
+  CGAL::CGAL
 )
 
 set(INSTALL_HEADERS

--- a/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
@@ -1,6 +1,9 @@
 #ifndef SEEREP_CORE_CORE_DATASET_H_
 #define SEEREP_CORE_CORE_DATASET_H_
 
+#include <CGAL/Boolean_set_operations_2.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+
 #include <algorithm>
 #include <cstdint>
 #include <functional>
@@ -25,6 +28,8 @@
 #include <boost/uuid/uuid.hpp>             // uuid class
 #include <boost/uuid/uuid_generators.hpp>  // generators
 #include <boost/uuid/uuid_io.hpp>          // streaming operators etc.
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel Kernel;
 
 namespace seerep_core
 {
@@ -175,6 +180,17 @@ private:
    * @param datatype the datatype to consider
    */
   void tryAddingDataWithMissingTF(const seerep_core_msgs::Datatype& datatype);
+
+  /**
+   * @brief determine if the axis aligned bounding box is fully or paritally inside the oriented bounding box
+   *
+   * @param aabb axis aligned bounding box
+   * @param polygon polygon
+   * @param fullEncapsulation boolean variable to denote if the aabb fully inside the obb
+   * @param partialEncapsulation boolean variable to denote if the aabb partially inside the obb
+   */
+  void intersectionDegree(const seerep_core_msgs::AABB& aabb, const seerep_core_msgs::Polygon2D& polygon,
+                          bool& fullEncapsulation, bool& partialEncapsulation);
 
   void getUuidsFromMap(std::unordered_map<boost::uuids::uuid, std::vector<boost::uuids::uuid>,
                                           boost::hash<boost::uuids::uuid>>& datasetInstancesMap,

--- a/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
@@ -182,6 +182,32 @@ private:
   void tryAddingDataWithMissingTF(const seerep_core_msgs::Datatype& datatype);
 
   /**
+   * @brief Check if the created CGAL polygon follows the requirements. It should be simple (no more than two vertices
+   * on an edge), convex (no inward egdes), the vertices should be in a counter clockwise order.
+   *
+   * @param polygon_cgal a polygon defined with CGAL
+   * @return true The polygon abides by CGAL requirements
+   * @return false The polygon does not abide by CGAL requirements
+   */
+  bool verifyPolygonIntegrity(CGAL::Polygon_2<Kernel>& polygon_cgal);
+
+  /**
+   * @brief convert core msg polygon to CGAL polygon
+   *
+   * @param polygon core msg polygon
+   * @return CGAL::Polygon_2<Kernel> cgal polygon
+   */
+  CGAL::Polygon_2<Kernel> toCGALPolygon(const seerep_core_msgs::Polygon2D& polygon);
+
+  /**
+   * @brief convert core msg aabb to CGAL aabb
+   *
+   * @param polygon core msg aabb
+   * @return CGAL::Polygon_2<Kernel> cgal aabb
+   */
+  CGAL::Polygon_2<Kernel> toCGALPolygon(const seerep_core_msgs::AABB& aabb);
+
+  /**
    * @brief determine if the axis aligned bounding box is fully or paritally inside the oriented bounding box
    *
    * @param aabb axis aligned bounding box
@@ -195,6 +221,15 @@ private:
   void getUuidsFromMap(std::unordered_map<boost::uuids::uuid, std::vector<boost::uuids::uuid>,
                                           boost::hash<boost::uuids::uuid>>& datasetInstancesMap,
                        std::vector<boost::uuids::uuid>& datasets, std::vector<boost::uuids::uuid>& result);
+
+  /**
+   * @brief Convert polygon to a smallest possible encapsulating AABB
+   *
+   * @param polygon core msg polygon
+   * @return seerep_core_msg::AABB core msg aabb
+   */
+  seerep_core_msgs::AABB polygonToAABB(const seerep_core_msgs::Polygon2D& polygon);
+
   /**
    * @brief queries the spatial index and returns a vector of bounding box / UUID pairs matching the query
    * @param datatypeSpecifics the datatype specific information to be used in the query

--- a/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_conversion.h
+++ b/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_conversion.h
@@ -248,12 +248,28 @@ private:
   static bool fromFbQueryMustHaveAllLabels(const seerep::fb::Query* query);
 
   /**
+   * @brief extracts the fullyEncapsulated flag of the flatbuffer query message
+   * @param query the flatbuffer message
+   * @return true results of the query must be entirely inside the query polygon
+   * @return false results of the query may not be entirely inside the query polygon
+   */
+  static bool fromFbQueryFullyEncapsulated(const seerep::fb::Query* query);
+
+  /**
    * @brief extracts the maxNumData of the flatbuffer query message
    *
    * @param query the flatbuffer query message
    * @return uint max number of datasets that should be returned
    */
   static uint fromFbQueryMaxNumData(const seerep::fb::Query* query);
+
+  /**
+   * @brief extracts and converts a polygon from a fb query
+   *
+   * @param query fb query message
+   * @return seerep_core_msgs::Polygon2D polygon2d as a core msg
+   */
+  static seerep_core_msgs::Polygon2D fromFbQueryPolygon(const seerep::fb::Query* query);
 
   /**
    * @brief converts the header of the flatbuffer data message to seerep core specific message

--- a/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_conversion.h
+++ b/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_conversion.h
@@ -269,7 +269,7 @@ private:
    * @param query fb query message
    * @return seerep_core_msgs::Polygon2D polygon2d as a core msg
    */
-  static seerep_core_msgs::Polygon2D fromFbQueryPolygon(const seerep::fb::Query* query);
+  static void fromFbQueryPolygon(const seerep::fb::Query* query, seerep_core_msgs::Polygon2D& polygon);
 
   /**
    * @brief converts the header of the flatbuffer data message to seerep core specific message

--- a/seerep_srv/seerep_core_fb/src/core_fb_conversion.cpp
+++ b/seerep_srv/seerep_core_fb/src/core_fb_conversion.cpp
@@ -42,6 +42,8 @@ seerep_core_msgs::Query CoreFbConversion::fromFb(const seerep::fb::Query* query,
   fromFbQueryDataUuids(query, queryCore.dataUuids);
   queryCore.withoutData = fromFbQueryWithoutData(query);
   queryCore.maxNumData = fromFbQueryMaxNumData(query);
+  queryCore.polygon = fromFbQueryPolygon(query);
+  queryCore.fullyEncapsulated = fromFbQueryFullyEncapsulated(query);
 
   return queryCore;
 }
@@ -527,6 +529,16 @@ bool CoreFbConversion::fromFbQueryMustHaveAllLabels(const seerep::fb::Query* que
   return false;
 }
 
+bool CoreFbConversion::fromFbQueryFullyEncapsulated(const seerep::fb::Query* query)
+{
+  if (flatbuffers::IsFieldPresent(query, seerep::fb::Query::VT_FULLYENCAPSULATED))
+  {
+    return query->fullyEncapsulated();
+  }
+
+  return false;
+}
+
 uint CoreFbConversion::fromFbQueryMaxNumData(const seerep::fb::Query* query)
 {
   if (flatbuffers::IsFieldPresent(query, seerep::fb::Query::VT_MAXNUMDATA))
@@ -638,6 +650,25 @@ void CoreFbConversion::fromFbDataLabelsBb2d(
       }
       labelsWithInstancesWithCategory.emplace(labelsCategories->category()->c_str(), labelWithInstanceVector);
     }
+  }
+}
+
+seerep_core_msgs::Polygon2D CoreFbConversion::fromFbQueryPolygon(const seerep::fb::Query* query)
+{
+  if (flatbuffers::IsFieldPresent(query, seerep::fb::Query::VT_POLYGON))
+  {
+    seerep_core_msgs::Polygon2D p;
+
+    for (auto point : *query->polygon()->vertices())
+    {
+      seerep_core_msgs::Point2D temp(point->x(), point->y());
+      p.vertices.push_back(temp);
+    }
+
+    p.height = query->polygon()->height();
+    p.z = query->polygon()->z();
+
+    return p;
   }
 }
 

--- a/seerep_srv/seerep_core_fb/src/core_fb_conversion.cpp
+++ b/seerep_srv/seerep_core_fb/src/core_fb_conversion.cpp
@@ -42,7 +42,7 @@ seerep_core_msgs::Query CoreFbConversion::fromFb(const seerep::fb::Query* query,
   fromFbQueryDataUuids(query, queryCore.dataUuids);
   queryCore.withoutData = fromFbQueryWithoutData(query);
   queryCore.maxNumData = fromFbQueryMaxNumData(query);
-  queryCore.polygon = fromFbQueryPolygon(query);
+  fromFbQueryPolygon(query, queryCore.polygon.value());
   queryCore.fullyEncapsulated = fromFbQueryFullyEncapsulated(query);
 
   return queryCore;
@@ -653,22 +653,18 @@ void CoreFbConversion::fromFbDataLabelsBb2d(
   }
 }
 
-seerep_core_msgs::Polygon2D CoreFbConversion::fromFbQueryPolygon(const seerep::fb::Query* query)
+void CoreFbConversion::fromFbQueryPolygon(const seerep::fb::Query* query, seerep_core_msgs::Polygon2D& polygon)
 {
   if (flatbuffers::IsFieldPresent(query, seerep::fb::Query::VT_POLYGON))
   {
-    seerep_core_msgs::Polygon2D p;
-
     for (auto point : *query->polygon()->vertices())
     {
       seerep_core_msgs::Point2D temp(point->x(), point->y());
-      p.vertices.push_back(temp);
+      polygon.vertices.push_back(temp);
     }
 
-    p.height = query->polygon()->height();
-    p.z = query->polygon()->z();
-
-    return p;
+    polygon.height = query->polygon()->height();
+    polygon.z = query->polygon()->z();
   }
 }
 

--- a/seerep_srv/seerep_core_pb/include/seerep_core_pb/core_pb_conversion.h
+++ b/seerep_srv/seerep_core_pb/include/seerep_core_pb/core_pb_conversion.h
@@ -126,11 +126,31 @@ private:
    */
   static void fromPbBoundingBox(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore);
   /**
+   * @brief converts seerep probotbuf point2d to core msg point2d
+   *
+   * @param point protobuf point2d msg
+   * @return seerep_core_msgs::Point2D core point2d msg
+   */
+  static seerep_core_msgs::Point2D fromPbPoint2D(const seerep::pb::Point2D& point);
+  /**
+   * @brief
+   *
+   * @param query
+   * @param queryCore
+   */
+  static void fromPbPolygon(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore);
+  /**
    * @brief converts the mustHaveAllLabels flag of the protobuf query message to seerep core specific message
    * @param query the protobuf query message
    * @param queryCore query message in seerep core format
    */
   static void fromPbMustHaveAllLabels(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore);
+  /**
+   * @brief converts the fullyEncapsulated flag of the protobuf query message to seerep core specific message
+   * @param query the protobuf query message
+   * @param queryCore query message in seerep core format
+   */
+  static void fromPbFullyEncapsulated(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore);
   /**
    * @brief converts the instance uuids of the protobuf query message to seerep core specific message
    * @param query the protobuf query message

--- a/seerep_srv/seerep_core_pb/src/core_pb_conversion.cpp
+++ b/seerep_srv/seerep_core_pb/src/core_pb_conversion.cpp
@@ -8,6 +8,7 @@ seerep_core_msgs::Query CorePbConversion::fromPb(const seerep::pb::Query& query,
   queryCore.header.datatype = datatype;
 
   fromPbBoundingBox(query, queryCore);
+  fromPbPolygon(query, queryCore);
   fromPbTime(query, queryCore);
   fromPbLabel(query, queryCore);
 
@@ -348,12 +349,15 @@ void CorePbConversion::fromPbPolygon(const seerep::pb::Query& query, seerep_core
 {
   if (query.has_polygon())
   {
+    queryCore.polygon = seerep_core_msgs::Polygon2D();
+
+    queryCore.polygon->height = query.polygon().height();
+    queryCore.polygon->z = query.polygon().z();
     for (auto vertex : query.polygon().vertices())
     {
-      queryCore.polygon.value().vertices.push_back(fromPbPoint2D(vertex));
+      seerep_core_msgs::Point2D p = fromPbPoint2D(vertex);
+      queryCore.polygon->vertices.push_back(p);
     }
-    queryCore.polygon.value().height = query.polygon().height();
-    queryCore.polygon.value().z = query.polygon().z();
   }
 }
 

--- a/seerep_srv/seerep_core_pb/src/core_pb_conversion.cpp
+++ b/seerep_srv/seerep_core_pb/src/core_pb_conversion.cpp
@@ -17,6 +17,7 @@ seerep_core_msgs::Query CorePbConversion::fromPb(const seerep::pb::Query& query,
   fromPbDataUuids(query, queryCore);
   fromPbWithOutData(query, queryCore);
   fromFbQueryMaxNumData(query, queryCore);
+  fromPbFullyEncapsulated(query, queryCore);
 
   return queryCore;
 }
@@ -333,6 +334,29 @@ void CorePbConversion::fromPbTime(const seerep::pb::Query& query, seerep_core_ms
   }
 }
 
+seerep_core_msgs::Point2D CorePbConversion::fromPbPoint2D(const seerep::pb::Point2D& point)
+{
+  seerep_core_msgs::Point2D pointCore;
+
+  pointCore.set<0>(point.x());
+  pointCore.set<1>(point.y());
+
+  return pointCore;
+}
+
+void CorePbConversion::fromPbPolygon(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore)
+{
+  if (query.has_polygon())
+  {
+    for (auto vertex : query.polygon().vertices())
+    {
+      queryCore.polygon.value().vertices.push_back(fromPbPoint2D(vertex));
+    }
+    queryCore.polygon.value().height = query.polygon().height();
+    queryCore.polygon.value().z = query.polygon().z();
+  }
+}
+
 void CorePbConversion::fromPbBoundingBox(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore)
 {
   if (query.boundingboxstamped().has_header() && query.boundingboxstamped().has_boundingbox() &&
@@ -365,6 +389,11 @@ void CorePbConversion::fromPbBoundingBox(const seerep::pb::Query& query, seerep_
 void CorePbConversion::fromPbMustHaveAllLabels(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore)
 {
   queryCore.mustHaveAllLabels = query.musthavealllabels();
+}
+
+void CorePbConversion::fromPbFullyEncapsulated(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore)
+{
+  queryCore.fullyEncapsulated = query.fullyencapsulated();
 }
 
 void CorePbConversion::fromPbInstance(const seerep::pb::Query& query, seerep_core_msgs::Query& queryCore)


### PR DESCRIPTION
Allow the user to query point cloud data using a polygon instead of a bounding box.

The Polygon has 2D vertices, along with a constant `z` value for all the points and a `height`. The z value defined the position of the 2D polygon along the z axis, and height defines how tall it is.

The user provides, along with this query, a boolean variable called `fullyEncapsulated`. If true, the results returned by the query must be entirely inside the provided polygon. The possibility of their not being fully inside the polygon arises due to the polygon's feature of being irregular. Being able to query irregular spaces (non axis aligned bb / oriented bb) is the principle contribution of this PR.