### PR TITLE
Remove unused core functions for time attributes

### DIFF
--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
@@ -96,25 +96,6 @@ public:
   template <class T>
   void readHeader(const std::string& id, HighFive::AnnotateTraits<T>& object, seerep_core_msgs::Header& header);
 
-  // ################
-  //  Time
-  // ################
-  void readTimeFromRaw(const std::string& datatypeGroup, const std::string& uuid, int64_t& secs, int64_t& nanos);
-  void readTime(const std::string& datatypeGroup, const std::string& uuid, int64_t& secs, int64_t& nanos);
-  template <class T>
-  void readTimeFromAnnotateTraits(const std::string& id, int64_t& value,
-                                  const HighFive::AnnotateTraits<T>& highFiveObject, const std::string& attribute);
-
-  void writeTimeToRaw(const std::string& datatypeGroup, const std::string& uuid, const int64_t& secs,
-                      const int64_t& nanos);
-  void writeTime(const std::string& datatypeGroup, const std::string& uuid, const int64_t& secs, const int64_t& nanos);
-  template <class T>
-  void writeTimeToAnnotateTraits(const int64_t& value, HighFive::AnnotateTraits<T>& highFiveObject,
-                                 const std::string& attribute);
-
-  bool hasTimeRaw(const std::string& datatypeGroup, const std::string& uuid);
-  bool hasTime(const std::string& datatypeGroup, const std::string& uuid);
-
   // BoundingBoxes
   /**
    * @brief read the labels and instances of a dataset of all categories and add them to the category-labels/instances map

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/impl/hdf5_core_general.hpp
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/impl/hdf5_core_general.hpp
@@ -33,36 +33,6 @@ void Hdf5CoreGeneral::writeAttributeToHdf5(HighFive::AnnotateTraits<C>& object, 
 }
 
 template <class T>
-void Hdf5CoreGeneral::readTimeFromAnnotateTraits(const std::string& id, int64_t& value,
-                                                 const HighFive::AnnotateTraits<T>& highFiveObject,
-                                                 const std::string& attribute)
-{
-  if (highFiveObject.hasAttribute(attribute))
-  {
-    highFiveObject.getAttribute(attribute).read(value);
-  }
-  else
-  {
-    throw std::invalid_argument("id " + id + " has no attribute " + attribute);
-  }
-}
-
-template <class T>
-void Hdf5CoreGeneral::writeTimeToAnnotateTraits(const int64_t& value, HighFive::AnnotateTraits<T>& highFiveObject,
-                                                const std::string& attribute)
-{
-  if (highFiveObject.hasAttribute(attribute))
-  {
-    highFiveObject.getAttribute(attribute).write(value);
-  }
-  else
-  {
-    highFiveObject.createAttribute(attribute, value);
-  }
-  m_file->flush();
-}
-
-template <class T>
 std::shared_ptr<HighFive::DataSet> Hdf5CoreGeneral::getHdf5DataSet(const std::string& hdf5DataSetPath,
                                                                    HighFive::DataSpace& dataSpace)
 {

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
@@ -334,70 +334,6 @@ void Hdf5CoreGeneral::writeLabelsGeneral(
   m_file->flush();
 }
 
-bool Hdf5CoreGeneral::hasTimeRaw(const std::string& datatypeGroup, const std::string& uuid)
-{
-  return hasTime(datatypeGroup, uuid + "/" + RAWDATA);
-}
-
-bool Hdf5CoreGeneral::hasTime(const std::string& datatypeGroup, const std::string& uuid)
-{
-  std::string id = datatypeGroup + "/" + uuid;
-  checkExists(id);
-
-  switch (m_file->getObjectType(id))
-  {
-    case HighFive::ObjectType::Group:
-      BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace) << "get group " << id;
-      return m_file->getGroup(id).hasAttribute(HEADER_STAMP_SECONDS) &&
-             m_file->getGroup(id).hasAttribute(HEADER_STAMP_NANOS);
-
-    case HighFive::ObjectType::Dataset:
-      BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace) << "get dataset " << id;
-      return m_file->getDataSet(id).hasAttribute(HEADER_STAMP_SECONDS) &&
-             m_file->getDataSet(id).hasAttribute(HEADER_STAMP_NANOS);
-
-    default:
-      return false;
-  }
-}
-
-void Hdf5CoreGeneral::writeTimeToRaw(const std::string& datatypeGroup, const std::string& uuid, const int64_t& secs,
-                                     const int64_t& nanos)
-{
-  writeTime(datatypeGroup, uuid + "/" + RAWDATA, secs, nanos);
-}
-
-void Hdf5CoreGeneral::writeTime(const std::string& datatypeGroup, const std::string& uuid, const int64_t& secs,
-                                const int64_t& nanos)
-{
-  std::string id = datatypeGroup + "/" + uuid;
-  checkExists(id);
-
-  switch (m_file->getObjectType(id))
-  {
-    case HighFive::ObjectType::Group:
-    {
-      BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace) << "get group " << id;
-      HighFive::Group group = m_file->getGroup(id);
-      writeTimeToAnnotateTraits(secs, group, HEADER_STAMP_SECONDS);
-      writeTimeToAnnotateTraits(nanos, group, HEADER_STAMP_NANOS);
-    };
-    break;
-
-    case HighFive::ObjectType::Dataset:
-    {
-      BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace) << "get group " << id;
-      HighFive::DataSet dataset = m_file->getDataSet(id);
-      writeTimeToAnnotateTraits(secs, dataset, HEADER_STAMP_SECONDS);
-      writeTimeToAnnotateTraits(nanos, dataset, HEADER_STAMP_NANOS);
-    };
-    break;
-
-    default:
-      break;
-  }
-}
-
 void Hdf5CoreGeneral::writeAABB(
     const std::string& datatypeGroup, const std::string& uuid,
     const boost::geometry::model::box<boost::geometry::model::point<float, 3, boost::geometry::cs::cartesian>>& aabb)
@@ -455,43 +391,6 @@ bool Hdf5CoreGeneral::hasAABB(const std::string& datatypeGroup, const std::strin
   BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace) << "get group " << id;
   HighFive::Group group = m_file->getGroup(id);
   return group.hasAttribute(AABB_FIELD);
-}
-
-void Hdf5CoreGeneral::readTimeFromRaw(const std::string& datatypeGroup, const std::string& uuid, int64_t& secs,
-                                      int64_t& nanos)
-{
-  readTime(datatypeGroup, uuid + "/" + RAWDATA, secs, nanos);
-}
-
-void Hdf5CoreGeneral::readTime(const std::string& datatypeGroup, const std::string& uuid, int64_t& secs, int64_t& nanos)
-{
-  std::string id = datatypeGroup + "/" + uuid;
-  checkExists(id);
-
-  switch (m_file->getObjectType(id))
-  {
-    case HighFive::ObjectType::Group:
-    {
-      BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace) << "get group " << id;
-      HighFive::Group group = m_file->getGroup(id);
-      readTimeFromAnnotateTraits(id, secs, group, HEADER_STAMP_SECONDS);
-      readTimeFromAnnotateTraits(id, nanos, group, HEADER_STAMP_NANOS);
-    };
-    break;
-
-    case HighFive::ObjectType::Dataset:
-    {
-      BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace) << "get group " << id;
-      HighFive::DataSet dataset = m_file->getDataSet(id);
-      readTimeFromAnnotateTraits(id, secs, dataset, HEADER_STAMP_SECONDS);
-      readTimeFromAnnotateTraits(id, nanos, dataset, HEADER_STAMP_NANOS);
-    };
-    break;
-
-    default:
-      secs = std::numeric_limits<uint64_t>::min();
-      nanos = std::numeric_limits<uint64_t>::min();
-  }
 }
 
 void Hdf5CoreGeneral::deleteAttribute(const std::shared_ptr<HighFive::DataSet> dataSetPtr, std::string attributeField)


### PR DESCRIPTION
The time functions deleted in this PR are obsolete, since we already provide generic function to read/write attributes from/to datasets or data groups: 
https://github.com/agri-gaia/seerep/blob/8b4f5d1a31086df502ba278e8fbca0dd3d30aa7a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/impl/hdf5_core_general.hpp#L5-L19
https://github.com/agri-gaia/seerep/blob/8b4f5d1a31086df502ba278e8fbca0dd3d30aa7a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/impl/hdf5_core_general.hpp#L21-L33

