### PR TITLE
Fix doxygens list of searched directories after package renaming

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -829,7 +829,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = seerep-com seerep-hdf5 seerep-msgs seerep-ros seerep-srv README.md
+INPUT                  = seerep_com seerep_hdf5 seerep_msgs seerep_ros seerep_srv README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
Missed after changing the packages to ROS naming convention. 