### PR TITLE
Fix calculation of image extension in hdf5-pb

### DIFF
--- a/seerep_hdf5/seerep_hdf5_pb/src/hdf5_pb_image.cpp
+++ b/seerep_hdf5/seerep_hdf5_pb/src/hdf5_pb_image.cpp
@@ -16,7 +16,7 @@ void Hdf5PbImage::writeImage(const std::string& id, const seerep::pb::Image& ima
   std::string hdf5GroupPath = getHdf5GroupPath(id);
   std::string hdf5DataSetPath = getHdf5DataSetPath(id);
 
-  HighFive::DataSpace dataSpace({ image.height() * image.width() * 3 });
+  HighFive::DataSpace dataSpace({ image.height() * image.step() });
   auto dataGroupPtr = getHdf5Group(hdf5GroupPath);
   auto dataSetPtr = getHdf5DataSet<uint8_t>(hdf5DataSetPath, dataSpace);
 


### PR DESCRIPTION
Bug: The calculation of the dataset size in `hdf5-pb` assumed that every image has 3 channels. 

Fix: Use the number of rows (height) times the size of each row in bytes for the calculation.