### PR TITLE
fix highfive dataset pointer having a wrong type warning when writing pointcloud rgb and rgba colors

### DIFF
--- a/seerep_hdf5/seerep_hdf5_fb/src/hdf5_fb_pointcloud.cpp
+++ b/seerep_hdf5/seerep_hdf5_fb/src/hdf5_fb_pointcloud.cpp
@@ -141,7 +141,7 @@ void Hdf5FbPointCloud::writeColorsRGB(const std::string& id, const std::vector<u
   BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace) << "writing dataset to: " << hdf5ColorsPath;
 
   HighFive::DataSpace dataSpace({ height, width, 3 });
-  std::shared_ptr<HighFive::DataSet> colorsDatasetPtr = getHdf5DataSet<float>(hdf5ColorsPath, dataSpace);
+  std::shared_ptr<HighFive::DataSet> colorsDatasetPtr = getHdf5DataSet<uint8_t>(hdf5ColorsPath, dataSpace);
 
   std::vector<std::vector<std::vector<uint8_t>>> colorsData;
   colorsData.resize(height);
@@ -171,7 +171,7 @@ void Hdf5FbPointCloud::writeColorsRGBA(const std::string& id, const std::vector<
 
   HighFive::DataSpace dataSpace({ height, width, 4 });
 
-  std::shared_ptr<HighFive::DataSet> colorsDatasetPtr = getHdf5DataSet<float>(hdf5ColorsPath, dataSpace);
+  std::shared_ptr<HighFive::DataSet> colorsDatasetPtr = getHdf5DataSet<uint8_t>(hdf5ColorsPath, dataSpace);
 
   std::vector<std::vector<std::vector<uint8_t>>> colorsData;
   colorsData.resize(height);


### PR DESCRIPTION
Currently on branch main the dataset pointers in https://github.com/agri-gaia/seerep/blob/1a83ae725bebf35ff3d14200fad2ea274e05732e/seerep_hdf5/seerep_hdf5_fb/src/hdf5_fb_pointcloud.cpp#L144 and
https://github.com/agri-gaia/seerep/blob/1a83ae725bebf35ff3d14200fad2ea274e05732e/seerep_hdf5/seerep_hdf5_fb/src/hdf5_fb_pointcloud.cpp#L174 both have the type float, while later uint_8 data is written, which causes HighFive to print the warning `HighFive WARNING "/pointclouds/66980e10-3fdd-411a-aa1f-2df2d5c99dcc/colors": data and hdf5 dataset have different types: Integer8 -> Float32`.

This PR should accommodate the warning.