### PR TITLE
Update HDF5 point cloud dumping to produce 1-dimensional dataset

### DIFF
--- a/examples/cpp/seerep_ros_communication/CMakeLists.txt
+++ b/examples/cpp/seerep_ros_communication/CMakeLists.txt
@@ -131,12 +131,15 @@ target_link_libraries(
   ${PROJECT_NAME}_hdf5dump
   ${SeerepCom_LIBRARIES}
   ${seerep_ros_conversions_pb_LIBRARIES}
+  ${seerep_ros_conversions_fb_LIBRARIES}
   ${SeerepHdf5Pb_LIBRARIES}
+  ${SeerepHdf5Fb_LIBRARIES}
   ${SeerepHdf5Core_LIBRARIES}
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}
   ${Boost_LOG_LIBRARY}
   ${Boost_LOG_SETUP_LIBRARY}
+  gRPC::grpc++_reflection
 )
 target_link_libraries(
   ${PROJECT_NAME}_querier

--- a/examples/cpp/seerep_ros_communication/include/seerep_ros_communication/hdf5dump.h
+++ b/examples/cpp/seerep_ros_communication/include/seerep_ros_communication/hdf5dump.h
@@ -7,9 +7,10 @@
 // seerep
 #include <seerep_hdf5_core/hdf5_core_general.h>
 #include <seerep_hdf5_core/hdf5_core_image.h>
+#include <seerep_hdf5_fb/hdf5_fb_pointcloud.h>
 #include <seerep_hdf5_pb/hdf5_pb_image.h>
-#include <seerep_hdf5_pb/hdf5_pb_pointcloud.h>
 #include <seerep_hdf5_pb/hdf5_pb_tf.h>
+#include <seerep_ros_conversions_fb/conversions.h>
 #include <seerep_ros_conversions_pb/conversions.h>
 
 // uuid
@@ -56,7 +57,7 @@ private:
   std::vector<seerep_core_msgs::LabelsWithInstanceWithCategory> m_labelsWithInstanceWithCategory;
 
   std::shared_ptr<seerep_hdf5_pb::Hdf5PbTf> m_ioTf;
-  std::shared_ptr<seerep_hdf5_pb::Hdf5PbPointCloud> m_ioPointCloud;
+  std::shared_ptr<seerep_hdf5_fb::Hdf5FbPointCloud> m_ioPointCloud;
   std::shared_ptr<seerep_hdf5_pb::Hdf5PbImage> m_ioImage;
   std::shared_ptr<seerep_hdf5_core::Hdf5CoreImage> m_ioImageCore;
   ros::NodeHandle nh;

--- a/examples/cpp/seerep_ros_communication/src/hdf5dump.cpp
+++ b/examples/cpp/seerep_ros_communication/src/hdf5dump.cpp
@@ -52,7 +52,11 @@ void DumpSensorMsgs::dump(const sensor_msgs::PointCloud2::ConstPtr& msg) const
    due to the changes introduced in PR #354. It uses an NxM dimensional float dataset instead of an 1x(N*M) byte
    dataset. This workaround should be removed as soon as the Protobuf PCL storage is ported to the new layout.
     */
-    m_ioPointCloud->writePointCloud2(uuid, *seerep_ros_conversions_fb::toFlat(*msg, uuid, std::string("")).GetRoot());
+    auto pcl = seerep_ros_conversions_fb::toFlat(*msg, uuid);
+    // TODO: ... ::toFlat(*msg, uuid).GetRoot() causes a segfault when accessing the data field of the pcl?!?
+    auto [min_corner, max_corner] = m_ioPointCloud->computeBoundingBox(*pcl.GetRoot());
+    m_ioPointCloud->writeBoundingBox(uuid, min_corner, max_corner);
+    m_ioPointCloud->writePointCloud2(uuid, *pcl.GetRoot());
   }
   catch (const std::exception& e)
   {

--- a/examples/cpp/seerep_ros_communication/src/hdf5dump.cpp
+++ b/examples/cpp/seerep_ros_communication/src/hdf5dump.cpp
@@ -42,11 +42,10 @@ void DumpSensorMsgs::dump(const std_msgs::Header::ConstPtr& msg) const
 
 void DumpSensorMsgs::dump(const sensor_msgs::PointCloud2::ConstPtr& msg) const
 {
-  std::string uuid = boost::lexical_cast<std::string>(boost::uuids::random_generator()());
-  ROS_INFO_STREAM("Dump point cloud 2 with uuid: " << uuid);
   try
   {
     std::string uuid = boost::lexical_cast<std::string>(boost::uuids::random_generator()());
+    ROS_INFO_STREAM("Dump point cloud 2 with uuid: " << uuid);
     /*
    TODO: Temporary workaround because the Protobuf HDF5 PCL storage produces the wrong '\points' dataset layout,
    due to the changes introduced in PR #354. It uses an NxM dimensional float dataset instead of an 1x(N*M) byte

--- a/seerep_ros/seerep_ros_conversions_fb/include/seerep_ros_conversions_fb/conversions.h
+++ b/seerep_ros/seerep_ros_conversions_fb/include/seerep_ros_conversions_fb/conversions.h
@@ -96,7 +96,7 @@ sensor_msgs::PointField toROS(const seerep::fb::PointField& point_field);
  * @return gRPC Flatbuffer PointCloud2 message
  */
 flatbuffers::grpc::Message<seerep::fb::PointCloud2> toFlat(const sensor_msgs::PointCloud2& cloud,
-                                                           std::string projectuuid, std::string msguuid);
+                                                           std::string projectuuid, const std::string& msguuid = "");
 /**
  * @brief Converts a ROS sensor_msgs/PointCloud2 message to the corresponding
  * Flatbuffer PointCloud2 message
@@ -107,7 +107,8 @@ flatbuffers::grpc::Message<seerep::fb::PointCloud2> toFlat(const sensor_msgs::Po
  * @return Flatbuffer PointCloud2 message
  */
 flatbuffers::Offset<seerep::fb::PointCloud2> toFlat(const sensor_msgs::PointCloud2& cloud, std::string projectuuid,
-                                                    flatbuffers::grpc::MessageBuilder& builder, std::string msguuid);
+                                                    flatbuffers::grpc::MessageBuilder& builder,
+                                                    const std::string& msguuid = "");
 
 /**
  * @brief Converts a Flatbuffer PointCloud2 message to the corresponding

--- a/seerep_ros/seerep_ros_conversions_fb/src/seerep_ros_conversions_fb/conversions.cpp
+++ b/seerep_ros/seerep_ros_conversions_fb/src/seerep_ros_conversions_fb/conversions.cpp
@@ -81,7 +81,7 @@ sensor_msgs::PointField toROS(const seerep::fb::PointField& point_field)
  * PointCloud2
  */
 flatbuffers::grpc::Message<seerep::fb::PointCloud2> toFlat(const sensor_msgs::PointCloud2& cloud,
-                                                           std::string projectuuid, std::string msguuid = "")
+                                                           std::string projectuuid, const std::string& msguuid)
 {
   flatbuffers::grpc::MessageBuilder builder;
   builder.Finish(toFlat(cloud, projectuuid, builder, msguuid));
@@ -89,7 +89,7 @@ flatbuffers::grpc::Message<seerep::fb::PointCloud2> toFlat(const sensor_msgs::Po
 }
 flatbuffers::Offset<seerep::fb::PointCloud2> toFlat(const sensor_msgs::PointCloud2& cloud, std::string projectuuid,
                                                     flatbuffers::grpc::MessageBuilder& builder,
-                                                    std::string msguuid = "")
+                                                    const std::string& msguuid)
 {
   auto header = toFlat(cloud.header, projectuuid, builder, msguuid);
 


### PR DESCRIPTION
> [!NOTE]  
> Merge PR #354 first!

This PR keeps the dumper working by using the FlatBuffers storage backend for point clouds due to the changes introduced in #354. As soon as I have ported the changes to Protocol Buffers, we can revert these changes.