### PR TITLE
Refactoring in seerep_hdf5_core and seerep_core

### DIFF
--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_cameraintrinsics.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_cameraintrinsics.h
@@ -40,15 +40,21 @@ public:
    * @return true If camera intrinsics exist
    * @return false If camera intrinsics do not exist
    */
-  bool checkCameraIntrinsicsExists(const boost::uuids::uuid& cameraintrinsics_uuid);
+  bool cameraIntrinsicExists(const boost::uuids::uuid& camera_intrinsic_uuid) const;
 
-private:
+  /**
+   * @brief Returns the HDF5 group path for a given camera intrinsics UUID.
+
+    *@param uuid The UUID string of a camera intrinsic.
+    *@return The HDF5 group path.
+   */
   const std::string cameraIntrinsicPath(const std::string& camera_intrinsic_uuid) const;
 
 public:
-  // datatype group names in hdf5
+  /* HDF5 group name to store the camera instrinsics */
   inline static const std::string HDF5_GROUP_CAMINTRINSICS = "cameraintrinsics";
 
+  /* HDF5 attribute names to store the camera instrinsics information */
   inline static const std::string HEIGHT = "height";
   inline static const std::string WIDTH = "width";
   inline static const std::string DISTORTION_MODEL = "distortion_model";

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_cameraintrinsics.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_cameraintrinsics.h
@@ -43,7 +43,7 @@ public:
   bool checkCameraIntrinsicsExists(const boost::uuids::uuid& cameraintrinsics_uuid);
 
 private:
-  const std::string getHdf5GroupPath(const std::string& id) const;
+  const std::string cameraIntrinsicPath(const std::string& camera_intrinsic_uuid) const;
 
 public:
   // datatype group names in hdf5

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_cameraintrinsics.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_cameraintrinsics.h
@@ -48,7 +48,6 @@ private:
 public:
   // datatype group names in hdf5
   inline static const std::string HDF5_GROUP_CAMINTRINSICS = "cameraintrinsics";
-  inline static const std::string SIZE = "size";
 
   inline static const std::string HEIGHT = "height";
   inline static const std::string WIDTH = "width";

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_cameraintrinsics.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_cameraintrinsics.h
@@ -43,7 +43,6 @@ public:
   bool checkCameraIntrinsicsExists(const boost::uuids::uuid& cameraintrinsics_uuid);
 
 private:
-  const std::shared_ptr<HighFive::DataSet> generateDatasetPointer(const std::string& attribute);
   const std::string getHdf5GroupPath(const std::string& id) const;
 
 public:

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_cameraintrinsics.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_cameraintrinsics.h
@@ -45,7 +45,6 @@ public:
 private:
   const std::shared_ptr<HighFive::DataSet> generateDatasetPointer(const std::string& attribute);
   const std::string getHdf5GroupPath(const std::string& id) const;
-  const std::string getHdf5DataSetPath(const std::string& id) const;
 
 public:
   // datatype group names in hdf5

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
@@ -222,30 +222,43 @@ public:
   std::shared_ptr<HighFive::Group> getHdf5Group(const std::string& group_path, bool create = true);
 
   /**
-   * @brief Get a shared pointer to a hdf5 data set specified by the hdf5DataSetPath
+   * @brief Returns a shared pointer to a HighFive::DataSet object for the given dataset path.
    *
-   * @tparam T type of the dataset
-   * @param hdf5DataSetPath path to the dataset
-   * @param dataSpace the data space to specify the dimensions of the dataset
-   * @return std::shared_ptr<HighFive::DataSet> shared pointer to the data set
+   * @param dataset_path The path to the dataset.
+   * @return std::shared_ptr<HighFive::DataSet> A shared pointer to the dataset object. Nullptr if the dataset does not exist.
    */
-  template <class T>
-  std::shared_ptr<HighFive::DataSet> getHdf5DataSet(const std::string& hdf5DataSetPath, HighFive::DataSpace& dataSpace);
+  std::shared_ptr<HighFive::DataSet> getHdf5DataSet(const std::string& dataset_path);
 
   /**
-   * @brief Get a shared pointer to a hdf5 data set specified by the hdf5DataSetPath
+   * @brief Returns a shared pointer to a HighFive::DataSet object for the given dataset path and data space.
    *
-   * @tparam T type of the dataset
-   * @param hdf5DataSetPath path to the dataset
-   * @param dataSpace the data space to specify the dimensions of the dataset
-   * @param createProps properties for creation of the dataset
-   * @return std::shared_ptr<HighFive::DataSet> shared pointer to the data set
+   * A new dataset will be created if it does not already exist.
+   *
+   * @tparam T The data type of the dataset.
+   * @param dataset_path The path to the dataset.
+   * @param dataspace The data space of the dataset.
+   * @return std::shared_ptr<HighFive::DataSet> A shared pointer to the HighFive dataset object.
    */
   template <class T>
-  std::shared_ptr<HighFive::DataSet> getHdf5DataSet(const std::string& hdf5DataSetPath, HighFive::DataSpace& dataSpace,
-                                                    HighFive::DataSetCreateProps& createProps);
+  std::shared_ptr<HighFive::DataSet> getHdf5DataSet(const std::string& dataset_path,
+                                                    const HighFive::DataSpace& dataspace);
 
-  std::shared_ptr<HighFive::DataSet> getHdf5DataSet(const std::string& hdf5DataSetPath);
+  /**
+   * @brief Get a shared pointer to a HighFive::Dataset object for the given path, dataspace, and properties.
+   *
+   * A new dataset will be created if it does not already exist.
+   *
+   * @tparam T The datatype of the dataset.
+   * @param dataset_path The path to the dataset.
+   * @param dataspace The dataspace of the dataset.
+   * @param properties The properties of the dataset.
+   * @return std::shared_ptr<HighFive::DataSet> A shared pointer to the HDF5 dataset.
+   */
+  template <class T>
+  std::shared_ptr<HighFive::DataSet> getHdf5DataSet(const std::string& dataset_path,
+                                                    const HighFive::DataSpace& dataspace,
+                                                    const HighFive::DataSetCreateProps& properties);
+
   /**
    * @brief get the labels of a group/dataset matching the general prefix (label type) and return the labels matching
    * the specified type. Also extract the category from the postfix

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
@@ -57,10 +57,11 @@ public:
   //  Attributes
   // ################
   template <typename T, class C>
-  T readAttributeFromHdf5(const std::string& id, const HighFive::AnnotateTraits<C>& object, std::string attributeField);
+  T readAttributeFromHdf5(const HighFive::AnnotateTraits<C>& object, const std::string& attribute_name,
+                          const std::string& path);
 
   template <typename T, class C>
-  void writeAttributeToHdf5(HighFive::AnnotateTraits<C>& object, std::string attributeField, T attributeValue);
+  void writeAttributeToHdf5(HighFive::AnnotateTraits<C>& object, const std::string& attribute_name, T attribute_val);
 
   template <class C>
   std::string readFrameId(const std::string& id, const HighFive::AnnotateTraits<C>& object,

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
@@ -268,7 +268,9 @@ public:
 protected:
   std::shared_ptr<HighFive::File> m_file;
   std::shared_ptr<std::mutex> m_write_mtx;
-  boost::log::sources::severity_logger<boost::log::trivial::severity_level> m_logger;
+
+  /* The logger does not change the state of the object, thus we can make it mutable, to use it in const functions */
+  mutable boost::log::sources::severity_logger<boost::log::trivial::severity_level> m_logger;
 };
 
 }  // namespace seerep_hdf5_core

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
@@ -78,10 +78,35 @@ public:
   template <typename T, class C>
   void writeAttributeToHdf5(HighFive::AnnotateTraits<C>& object, const std::string& attribute_name, T attribute_val);
 
-  template <class C>
-  std::string readFrameId(const std::string& id, const HighFive::AnnotateTraits<C>& object,
-                          const std::string& frame_field);
+  /**
+   * @brief Returns a tf2 compliant frame ID.
+   *
+   * @param frame_id The frame ID to check.
+   * @return The corresponding tf2 frame ID.
+   */
+  const std::string tf2_frame_id(const std::string& frame_id) const;
 
+  /**
+   * @brief Reads a tf2 compliant frame ID from an HDF5 object.
+   *
+   * @tparam C The type of the HDF5 object to read from.
+   * @param object The HDF5 object to read from.
+   * @param frame_field The name of HDF5 attribute to read the frame ID from.
+   * @param id The path to the HDF5 object, only used for logging.
+   * @return The frame ID as a string.
+   */
+  template <class C>
+  std::string readFrameId(const HighFive::AnnotateTraits<C>& object, const std::string& frame_field,
+                          const std::string& path);
+
+  /**
+   * @brief Writes a tf2 compliant frame ID to an HDF5 object.
+   *
+   * @tparam C The type of the HDF5 object to write to.
+   * @param object The HDF5 object to write to.
+   * @param frame_field The name of the HDF5 attribute to write the frame ID to.
+   * @param frame_id The frame ID to write.
+   */
   template <class C>
   void writeFrameId(HighFive::AnnotateTraits<C>& object, const std::string& frame_field, const std::string& frame_id);
 
@@ -110,14 +135,6 @@ public:
    */
   template <class T>
   void writeHeader(HighFive::AnnotateTraits<T>& object, seerep_core_msgs::Header header);
-
-  /*
-   * @brief Corrects a frame_id to be valid for tf2.
-   *
-   * @param [in] frame_id frame_id to check
-   * @param [out] frame_id which complies with tf2
-   */
-  const std::string tf2_frame_id(std::string frame_id);
 
   /**
    * @brief Read header from a group within an hd5f file

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
@@ -53,13 +53,30 @@ public:
   bool exists(const std::string& path) const;
 
   std::optional<std::string> readFrameId(const std::string& datatypeGroup, const std::string& uuid);
-  // ################
-  //  Attributes
-  // ################
+
+  /**
+   * @brief Reads an attribute from an HDF5 object.
+   *
+   * @tparam T The type of the attribute to read.
+   * @tparam C The type of the HDF5 object to read from.
+   * @param object The HDF5 object to read from.
+   * @param attribute_name The name of the attribute to read.
+   * @param path The path to the HDF5 object, only used for logging.
+   * @return T The value of the attribute.
+   */
   template <typename T, class C>
   T readAttributeFromHdf5(const HighFive::AnnotateTraits<C>& object, const std::string& attribute_name,
                           const std::string& path);
 
+  /**
+   * @brief Writes an attribute to an HDF5 object.
+   *
+   * @tparam T The type of the attribute to write.
+   * @tparam C The type of the HDF5 object.
+   * @param object The HDF5 object to write the attribute to.
+   * @param attribute_name The name of the attribute.
+   * @param attribute_val The value of the attribute.
+   */
   template <typename T, class C>
   void writeAttributeToHdf5(HighFive::AnnotateTraits<C>& object, const std::string& attribute_name, T attribute_val);
 

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
@@ -52,8 +52,6 @@ public:
    */
   bool exists(const std::string& path) const;
 
-  std::optional<std::string> readFrameId(const std::string& datatypeGroup, const std::string& uuid);
-
   /**
    * @brief Reads an attribute from an HDF5 object.
    *

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
@@ -62,8 +62,6 @@ public:
   template <typename T, class C>
   void writeAttributeToHdf5(HighFive::AnnotateTraits<C>& object, std::string attributeField, T attributeValue);
 
-  void deleteAttribute(const std::shared_ptr<HighFive::DataSet> dataSetPtr, std::string attributeField);
-
   template <class C>
   std::string readFrameId(const std::string& id, const HighFive::AnnotateTraits<C>& object,
                           const std::string& frame_field);

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
@@ -211,17 +211,15 @@ public:
    */
   std::optional<seerep_core_msgs::GeodeticCoordinates> readGeodeticLocation();
 
-  // ################
-  //  Hdf5
-  // ################
   /**
-   * @brief Get a shared pointer to a hdf5 group
+   * @brief Returns a shared pointer to an HDF5 group object.
    *
-   * @param hdf5GroupPath path to the data group
-   * @param create create a new group if the group path can't be found?
-   * @return std::shared_ptr<HighFive::Group> shared pointer to the group
+   * @param group_path The path to the HDF5 group.
+   * @param create If true, the group will be created if it does not already exist.
+   * @return std::shared_ptr<HighFive::Group> A shared pointer to the HDF5 group object. Nullptr if the group does not
+   * exist and create is false.
    */
-  std::shared_ptr<HighFive::Group> getHdf5Group(const std::string& hdf5GroupPath, bool create = true);
+  std::shared_ptr<HighFive::Group> getHdf5Group(const std::string& group_path, bool create = true);
 
   /**
    * @brief Get a shared pointer to a hdf5 data set specified by the hdf5DataSetPath

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
@@ -43,11 +43,14 @@ public:
   void checkExists(const std::string& id);
 
   /**
-   * @brief Checks if a DataSet or DataGroup exists in the file
-   * @param id The id of the DataSet or DataGroup
-   * @return true if the DataSet or DataGroup exists
+   * @brief Checks if a HDF5 path exists in the file.
+   *
+   * Wrapper around HighFive::File::exist() for logging purposes.
+   *
+   * @param path The HDF5 path to check
+   * @return True if the dataset exists, false otherwise.
    */
-  bool exists(const std::string& id);
+  bool exists(const std::string& path) const;
 
   std::optional<std::string> readFrameId(const std::string& datatypeGroup, const std::string& uuid);
   // ################

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_general.h
@@ -195,19 +195,21 @@ public:
   void writeVersion(const std::string& version);
   const std::optional<std::string> readVersion();
 
-  // ################
-  //  Geodetic Coordinates
-  // ################
   /**
-   * @brief Writes Geodetic location of the project to its HDF5 file.
+   * @brief Writes a geodetic coordinate to an HDF5 file.
    *
-   * @param geocoords seerep_core_msgs Geodetic Coordinates object.
+   * Note: The data is written to the root group of the HDF5 file, since the geo-reference applies to complete project.
+   *
+   * @param geo_coordinates The geodetic coordinate to write to the file.
    */
-  void writeGeodeticLocation(const seerep_core_msgs::GeodeticCoordinates geocoords);
+  void writeGeodeticLocation(const seerep_core_msgs::GeodeticCoordinates& geo_coordinates);
+
   /**
-   * @brief Read Geodetic location of the project from its HDF5 file.
+   * @brief Reads a geodetic coodrinate from HDF5 file.
    *
-   * @return std::optional<seerep_core_msgs::GeodeticCoordinates> Optional return of Geodetic Coordinates
+   * Note: The data is expected to be stored in the root group of the HDF5 file.
+   *
+   * @return std::optional<seerep_core_msgs::GeodeticCoordinates> Geodetic coordinate if available, empty optional otherwise.
    */
   std::optional<seerep_core_msgs::GeodeticCoordinates> readGeodeticLocation();
 

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/impl/hdf5_core_general.hpp
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/impl/hdf5_core_general.hpp
@@ -3,32 +3,32 @@
 namespace seerep_hdf5_core
 {
 template <typename T, class C>
-T Hdf5CoreGeneral::readAttributeFromHdf5(const std::string& id, const HighFive::AnnotateTraits<C>& object,
-                                         std::string attributeField)
+T Hdf5CoreGeneral::readAttributeFromHdf5(const HighFive::AnnotateTraits<C>& object, const std::string& attribute_name,
+                                         const std::string& path)
 {
-  T attributeValue;
-  if (object.hasAttribute(attributeField))
+  T attribute_value;
+  if (object.hasAttribute(attribute_name))
   {
-    object.getAttribute(attributeField).read(attributeValue);
+    object.getAttribute(attribute_name).read(attribute_value);
   }
   else
   {
-    throw std::invalid_argument("id " + id + " has no attribute " + attributeField);
+    throw std::invalid_argument("Path: " + path + " has no attribute:" + attribute_name);
   }
-  return attributeValue;
+  return attribute_value;
 }
 
 template <typename T, class C>
-void Hdf5CoreGeneral::writeAttributeToHdf5(HighFive::AnnotateTraits<C>& object, std::string attributeField,
-                                           T attributeValue)
+void Hdf5CoreGeneral::writeAttributeToHdf5(HighFive::AnnotateTraits<C>& object, const std::string& attribute_name,
+                                           T attribute_val)
 {
-  if (object.hasAttribute(attributeField))
+  if (object.hasAttribute(attribute_name))
   {
-    object.getAttribute(attributeField).write(attributeValue);
+    object.getAttribute(attribute_name).write(attribute_val);
   }
   else
   {
-    object.createAttribute(attributeField, attributeValue);
+    object.createAttribute(attribute_name, attribute_val);
   }
 }
 
@@ -36,7 +36,7 @@ template <class C>
 std::string Hdf5CoreGeneral::readFrameId(const std::string& uuid, const HighFive::AnnotateTraits<C>& object,
                                          const std::string& frame_field)
 {
-  return tf2_frame_id(readAttributeFromHdf5<std::string>(uuid, object, frame_field));
+  return tf2_frame_id(readAttributeFromHdf5<std::string>(object, frame_field, uuid));
 }
 
 template <class C>
@@ -92,9 +92,9 @@ void Hdf5CoreGeneral::readHeader(const std::string& id, HighFive::AnnotateTraits
   std::string uuidproject_str = std::filesystem::path(m_file->getName()).filename().stem();
   header.uuidProject = boost::lexical_cast<boost::uuids::uuid>(uuidproject_str);
 
-  header.timestamp.seconds = Hdf5CoreGeneral::readAttributeFromHdf5<int32_t>(id, object, HEADER_STAMP_SECONDS);
-  header.timestamp.nanos = Hdf5CoreGeneral::readAttributeFromHdf5<int32_t>(id, object, HEADER_STAMP_NANOS);
+  header.timestamp.seconds = Hdf5CoreGeneral::readAttributeFromHdf5<int32_t>(object, HEADER_STAMP_SECONDS, id);
+  header.timestamp.nanos = Hdf5CoreGeneral::readAttributeFromHdf5<int32_t>(object, HEADER_STAMP_NANOS, id);
   header.frameId = Hdf5CoreGeneral::readFrameId(id, object, HEADER_FRAME_ID);
-  header.sequence = Hdf5CoreGeneral::readAttributeFromHdf5<int32_t>(id, object, HEADER_SEQ);
+  header.sequence = Hdf5CoreGeneral::readAttributeFromHdf5<int32_t>(object, HEADER_SEQ, id);
 }
 }  // namespace seerep_hdf5_core

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/impl/hdf5_core_general.hpp
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/impl/hdf5_core_general.hpp
@@ -48,30 +48,21 @@ void Hdf5CoreGeneral::writeFrameId(HighFive::AnnotateTraits<C>& object, const st
 
 template <class T>
 std::shared_ptr<HighFive::DataSet> Hdf5CoreGeneral::getHdf5DataSet(const std::string& hdf5DataSetPath,
-                                                                   HighFive::DataSpace& dataSpace)
+                                                                   const HighFive::DataSpace& dataSpace)
 {
-  HighFive::DataSetCreateProps emptyProps;
-  return getHdf5DataSet<T>(hdf5DataSetPath, dataSpace, emptyProps);
+  return getHdf5DataSet<T>(hdf5DataSetPath, dataSpace, HighFive::DataSetCreateProps());
 }
 
 template <class T>
-std::shared_ptr<HighFive::DataSet> Hdf5CoreGeneral::getHdf5DataSet(const std::string& hdf5DataSetPath,
-                                                                   HighFive::DataSpace& dataSpace,
-                                                                   HighFive::DataSetCreateProps& createProps)
+std::shared_ptr<HighFive::DataSet> Hdf5CoreGeneral::getHdf5DataSet(const std::string& dataset_path,
+                                                                   const HighFive::DataSpace& dataspace,
+                                                                   const HighFive::DataSetCreateProps& properties)
 {
-  try
+  if (exists(dataset_path))
   {
-    checkExists(hdf5DataSetPath);
-    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace)
-        << "hdf5 group" << hdf5DataSetPath << " already exists!";
-    return std::make_shared<HighFive::DataSet>(m_file->getDataSet(hdf5DataSetPath));
+    return std::make_shared<HighFive::DataSet>(m_file->getDataSet(dataset_path));
   }
-  catch (std::invalid_argument const& e)
-  {
-    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace)
-        << "hdf5 group " << hdf5DataSetPath << " does not exist! Creating a new group";
-    return std::make_shared<HighFive::DataSet>(m_file->createDataSet<T>(hdf5DataSetPath, dataSpace, createProps));
-  }
+  return std::make_shared<HighFive::DataSet>(m_file->createDataSet<T>(dataset_path, dataspace, properties));
 }
 
 template <class T>

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/impl/hdf5_core_general.hpp
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/impl/hdf5_core_general.hpp
@@ -33,10 +33,10 @@ void Hdf5CoreGeneral::writeAttributeToHdf5(HighFive::AnnotateTraits<C>& object, 
 }
 
 template <class C>
-std::string Hdf5CoreGeneral::readFrameId(const std::string& uuid, const HighFive::AnnotateTraits<C>& object,
-                                         const std::string& frame_field)
+std::string Hdf5CoreGeneral::readFrameId(const HighFive::AnnotateTraits<C>& object, const std::string& frame_field,
+                                         const std::string& path)
 {
-  return tf2_frame_id(readAttributeFromHdf5<std::string>(object, frame_field, uuid));
+  return tf2_frame_id(readAttributeFromHdf5<std::string>(object, frame_field, path));
 }
 
 template <class C>
@@ -94,7 +94,7 @@ void Hdf5CoreGeneral::readHeader(const std::string& id, HighFive::AnnotateTraits
 
   header.timestamp.seconds = Hdf5CoreGeneral::readAttributeFromHdf5<int32_t>(object, HEADER_STAMP_SECONDS, id);
   header.timestamp.nanos = Hdf5CoreGeneral::readAttributeFromHdf5<int32_t>(object, HEADER_STAMP_NANOS, id);
-  header.frameId = Hdf5CoreGeneral::readFrameId(id, object, HEADER_FRAME_ID);
+  header.frameId = Hdf5CoreGeneral::readFrameId(object, HEADER_FRAME_ID, id);
   header.sequence = Hdf5CoreGeneral::readAttributeFromHdf5<int32_t>(object, HEADER_SEQ, id);
 }
 }  // namespace seerep_hdf5_core

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_cameraintrinsics.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_cameraintrinsics.cpp
@@ -12,7 +12,7 @@ void Hdf5CoreCameraIntrinsics::writeCameraIntrinsics(const seerep_core_msgs::cam
 {
   // the storage path has to be determined using the uuid of the cam intriniscs, which is available inside the header
   std::string id = boost::lexical_cast<std::string>(camIntrinsics.header.uuidData);
-  std::string hdf5GroupPath = getHdf5GroupPath(id);
+  std::string hdf5GroupPath = cameraIntrinsicPath(id);
 
   std::shared_ptr<HighFive::Group> dataGroupPtr = getHdf5Group(hdf5GroupPath, true);
 
@@ -67,7 +67,7 @@ Hdf5CoreCameraIntrinsics::readCameraIntrinsics(const boost::uuids::uuid& camerai
 
   std::string id = boost::lexical_cast<std::string>(cameraintrinsics_uuid);
 
-  std::string hdf5GroupPath = getHdf5GroupPath(id);
+  std::string hdf5GroupPath = cameraIntrinsicPath(id);
 
   auto dataGroupPtr = getHdf5Group(hdf5GroupPath, false);
 
@@ -130,7 +130,7 @@ bool Hdf5CoreCameraIntrinsics::checkCameraIntrinsicsExists(const boost::uuids::u
     // call check exists for the provided camera intrinsics id
     std::string id = boost::lexical_cast<std::string>(cameraintrinsics_uuid);
 
-    std::string cameraIntrinsicsGroupPath = getHdf5GroupPath(id);
+    std::string cameraIntrinsicsGroupPath = cameraIntrinsicPath(id);
 
     checkExists(cameraIntrinsicsGroupPath);
   }
@@ -143,9 +143,9 @@ bool Hdf5CoreCameraIntrinsics::checkCameraIntrinsicsExists(const boost::uuids::u
   return true;
 }
 
-const std::string Hdf5CoreCameraIntrinsics::getHdf5GroupPath(const std::string& id) const
+const std::string Hdf5CoreCameraIntrinsics::cameraIntrinsicPath(const std::string& camera_instrinsic_uuid) const
 {
-  return HDF5_GROUP_CAMINTRINSICS + "/" + id;
+  return HDF5_GROUP_CAMINTRINSICS + "/" + camera_instrinsic_uuid;
 }
 
 }  // namespace seerep_hdf5_core

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_cameraintrinsics.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_cameraintrinsics.cpp
@@ -77,10 +77,10 @@ Hdf5CoreCameraIntrinsics::readCameraIntrinsics(const boost::uuids::uuid& camerai
   {
     readHeader(id, *dataGroupPtr, ci.header);
 
-    ci.height = readAttributeFromHdf5<uint32_t>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::HEIGHT);
-    ci.width = readAttributeFromHdf5<uint32_t>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::WIDTH);
+    ci.height = readAttributeFromHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::HEIGHT, id);
+    ci.width = readAttributeFromHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::WIDTH, id);
     ci.distortion_model = readAttributeFromHdf5<std::string>(
-        id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::DISTORTION_MODEL);
+        *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::DISTORTION_MODEL, id);
 
     // read distortion
     dataGroupPtr->getAttribute(seerep_hdf5_core::Hdf5CoreCameraIntrinsics::DISTORTION)
@@ -99,23 +99,23 @@ Hdf5CoreCameraIntrinsics::readCameraIntrinsics(const boost::uuids::uuid& camerai
         .read<std::vector<double>>(ci.projection_matrix);
 
     ci.binning_x =
-        readAttributeFromHdf5<uint32_t>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::BINNING_X);
+        readAttributeFromHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::BINNING_X, id);
     ci.binning_y =
-        readAttributeFromHdf5<uint32_t>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::BINNING_Y);
+        readAttributeFromHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::BINNING_Y, id);
 
     ci.region_of_interest.x_offset = readAttributeFromHdf5<uint32_t>(
-        id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::REGION_OF_INTEREST_X_OFFSET);
+        *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::REGION_OF_INTEREST_X_OFFSET, id);
     ci.region_of_interest.y_offset = readAttributeFromHdf5<uint32_t>(
-        id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::REGION_OF_INTEREST_Y_OFFSET);
+        *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::REGION_OF_INTEREST_Y_OFFSET, id);
     ci.region_of_interest.height = readAttributeFromHdf5<uint32_t>(
-        id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::REGION_OF_INTEREST_HEIGHT);
+        *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::REGION_OF_INTEREST_HEIGHT, id);
     ci.region_of_interest.width = readAttributeFromHdf5<uint32_t>(
-        id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::REGION_OF_INTEREST_WIDTH);
+        *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::REGION_OF_INTEREST_WIDTH, id);
     ci.region_of_interest.do_rectify = readAttributeFromHdf5<bool>(
-        id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::REGION_OF_INTEREST_DO_RECTIFY);
+        *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::REGION_OF_INTEREST_DO_RECTIFY, id);
 
     ci.maximum_viewing_distance = readAttributeFromHdf5<double>(
-        id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::MAX_VIEWING_DISTANCE);
+        *dataGroupPtr, seerep_hdf5_core::Hdf5CoreCameraIntrinsics::MAX_VIEWING_DISTANCE, id);
   }
 
   return ci;

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_cameraintrinsics.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_cameraintrinsics.cpp
@@ -121,26 +121,9 @@ Hdf5CoreCameraIntrinsics::readCameraIntrinsics(const boost::uuids::uuid& camerai
   return ci;
 }
 
-bool Hdf5CoreCameraIntrinsics::checkCameraIntrinsicsExists(const boost::uuids::uuid& cameraintrinsics_uuid)
+bool Hdf5CoreCameraIntrinsics::cameraIntrinsicExists(const boost::uuids::uuid& camera_intrinsic_uuid) const
 {
-  std::string id = boost::lexical_cast<std::string>(cameraintrinsics_uuid);
-
-  try
-  {
-    // call check exists for the provided camera intrinsics id
-    std::string id = boost::lexical_cast<std::string>(cameraintrinsics_uuid);
-
-    std::string cameraIntrinsicsGroupPath = cameraIntrinsicPath(id);
-
-    checkExists(cameraIntrinsicsGroupPath);
-  }
-  catch (std::invalid_argument const& e)
-  {
-    // if an invalid arg exception is raised it does not exist, therefore return false
-    return false;
-  }
-  // otherwise return true
-  return true;
+  return exists(cameraIntrinsicPath(boost::lexical_cast<std::string>(camera_intrinsic_uuid)));
 }
 
 const std::string Hdf5CoreCameraIntrinsics::cameraIntrinsicPath(const std::string& camera_instrinsic_uuid) const

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_cameraintrinsics.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_cameraintrinsics.cpp
@@ -148,8 +148,4 @@ const std::string Hdf5CoreCameraIntrinsics::getHdf5GroupPath(const std::string& 
   return HDF5_GROUP_CAMINTRINSICS + "/" + id;
 }
 
-const std::string Hdf5CoreCameraIntrinsics::getHdf5DataSetPath(const std::string& id) const
-{
-  return getHdf5GroupPath(id) + "/" + RAWDATA;
-}
 }  // namespace seerep_hdf5_core

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
@@ -380,28 +380,17 @@ void Hdf5CoreGeneral::readInstances(const std::string& id, const std::string ins
   datasetInstances.read(instances);
 }
 
-std::shared_ptr<HighFive::Group> Hdf5CoreGeneral::getHdf5Group(const std::string& hdf5GroupPath, bool create)
+std::shared_ptr<HighFive::Group> Hdf5CoreGeneral::getHdf5Group(const std::string& group_path, bool create)
 {
-  try
+  if (exists(group_path))
   {
-    checkExists(hdf5GroupPath);
-    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace)
-        << "hdf5 group" << hdf5GroupPath << " already exists!";
-    return std::make_shared<HighFive::Group>(m_file->getGroup(hdf5GroupPath));
+    return std::make_shared<HighFive::Group>(m_file->getGroup(group_path));
   }
-  catch (std::invalid_argument const& e)
+  else if (create)
   {
-    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::trace)
-        << "hdf5 group " << hdf5GroupPath << " does not exist! Creating a new group";
-    if (create)
-    {
-      return std::make_shared<HighFive::Group>(m_file->createGroup(hdf5GroupPath));
-    }
-    else
-    {
-      return nullptr;
-    }
+    return std::make_shared<HighFive::Group>(m_file->createGroup(group_path));
   }
+  return nullptr;
 }
 
 void Hdf5CoreGeneral::writeGeodeticLocation(const seerep_core_msgs::GeodeticCoordinates geocoords)

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
@@ -52,7 +52,7 @@ void Hdf5CoreGeneral::writeProjectFrameId(const std::string& frameId)
 
 std::string Hdf5CoreGeneral::readProjectFrameId()
 {
-  return readFrameId(std::filesystem::path(m_file->getName()).filename().stem(), *m_file, PROJECTFRAMEID);
+  return readFrameId(*m_file, PROJECTFRAMEID, std::filesystem::path(m_file->getName()).filename().stem());
 }
 
 void Hdf5CoreGeneral::writeVersion(const std::string& version)
@@ -262,11 +262,12 @@ void Hdf5CoreGeneral::writeLabelsGeneral(
   m_file->flush();
 }
 
-const std::string Hdf5CoreGeneral::tf2_frame_id(std::string frame_id)
+const std::string Hdf5CoreGeneral::tf2_frame_id(const std::string& frame_id) const
 {
+  /* leading slahes are not allowed with tf2 */
   if (!frame_id.empty() && frame_id.at(0) == '/')
   {
-    return frame_id.erase(0, 1);
+    return frame_id.substr(1);
   }
   return frame_id;
 }

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
@@ -378,12 +378,12 @@ void Hdf5CoreGeneral::checkExists(const std::string& id)
   }
 }
 
-bool Hdf5CoreGeneral::exists(const std::string& id)
+bool Hdf5CoreGeneral::exists(const std::string& path) const
 {
-  if (!m_file->exist(id))
+  if (!m_file->exist(path))
   {
     BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::warning)
-        << "id " << id << " does not exist in file " << m_file->getName();
+        << "HDF5 path: " << path << " does not exist in file: " << m_file->getName();
     return false;
   }
   return true;

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
@@ -35,33 +35,13 @@ std::vector<std::string> Hdf5CoreGeneral::getGroupDatasets(const std::string& id
 
 void Hdf5CoreGeneral::writeProjectname(const std::string& projectname)
 {
-  const std::scoped_lock lock(*m_write_mtx);
-
-  if (!m_file->hasAttribute(PROJECTNAME))
-  {
-    m_file->createAttribute<std::string>(PROJECTNAME, projectname);
-  }
-  else
-  {
-    m_file->getAttribute(PROJECTNAME).write(projectname);
-  }
+  writeAttributeToHdf5<std::string>(*m_file, PROJECTNAME, projectname);
   m_file->flush();
 }
 
 std::string Hdf5CoreGeneral::readProjectname()
 {
-  const std::scoped_lock lock(*m_write_mtx);
-
-  std::string projectname;
-  try
-  {
-    m_file->getAttribute(PROJECTNAME).read(projectname);
-  }
-  catch (...)
-  {
-    throw std::runtime_error("Project " + m_file->getName() + "  has no project name!");
-  }
-  return projectname;
+  return readAttributeFromHdf5<std::string>(m_file->getName(), *m_file, PROJECTNAME);
 }
 
 void Hdf5CoreGeneral::writeProjectFrameId(const std::string& frameId)
@@ -77,16 +57,7 @@ std::string Hdf5CoreGeneral::readProjectFrameId()
 
 void Hdf5CoreGeneral::writeVersion(const std::string& version)
 {
-  const std::scoped_lock lock(*m_write_mtx);
-
-  if (!m_file->hasAttribute(VERSION))
-  {
-    m_file->createAttribute<std::string>(VERSION, version);
-  }
-  else
-  {
-    m_file->getAttribute(VERSION).write(version);
-  }
+  writeAttributeToHdf5<std::string>(*m_file, VERSION, version);
   m_file->flush();
 }
 

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
@@ -41,7 +41,7 @@ void Hdf5CoreGeneral::writeProjectname(const std::string& projectname)
 
 std::string Hdf5CoreGeneral::readProjectname()
 {
-  return readAttributeFromHdf5<std::string>(m_file->getName(), *m_file, PROJECTNAME);
+  return readAttributeFromHdf5<std::string>(*m_file, PROJECTNAME, m_file->getName());
 }
 
 void Hdf5CoreGeneral::writeProjectFrameId(const std::string& frameId)
@@ -68,7 +68,7 @@ const std::optional<std::string> Hdf5CoreGeneral::readVersion()
   std::string version;
   try
   {
-    version = readAttributeFromHdf5<std::string>(m_file->getName(), *m_file, VERSION);
+    version = readAttributeFromHdf5<std::string>(*m_file, VERSION, m_file->getName());
   }
   catch (const std::exception& e)
   {

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
@@ -443,10 +443,7 @@ std::shared_ptr<HighFive::DataSet> Hdf5CoreGeneral::getHdf5DataSet(const std::st
   {
     return std::make_shared<HighFive::DataSet>(m_file->getDataSet(hdf5DataSetPath));
   }
-  else
-  {
-    return nullptr;
-  }
+  return nullptr;
 }
 
 void Hdf5CoreGeneral::getLabelCategories(std::string id, std::string labelType,

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_general.cpp
@@ -359,15 +359,6 @@ bool Hdf5CoreGeneral::hasAABB(const std::string& datatypeGroup, const std::strin
   return group.hasAttribute(AABB_FIELD);
 }
 
-void Hdf5CoreGeneral::deleteAttribute(const std::shared_ptr<HighFive::DataSet> dataSetPtr, std::string attributeField)
-{
-  if (dataSetPtr->hasAttribute(attributeField))
-  {
-    dataSetPtr->deleteAttribute(attributeField);
-    m_file->flush();
-  }
-}
-
 void Hdf5CoreGeneral::checkExists(const std::string& id)
 {
   if (!m_file->exist(id))

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_image.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_image.cpp
@@ -49,8 +49,8 @@ std::optional<seerep_core_msgs::DatasetIndexable> Hdf5CoreImage::readDataset(con
                                                                   data.labelsWithInstancesWithCategory);
 
     // fetch cam intrinsics uuid from hdf5_core_cameraintrinsics
-    camintrinsics_uuid = readAttributeFromHdf5<std::string>(hdf5DataGroupPath, *dataGroupPtr,
-                                                            seerep_hdf5_core::Hdf5CoreImage::CAMERA_INTRINSICS_UUID);
+    camintrinsics_uuid = readAttributeFromHdf5<std::string>(
+        *dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::CAMERA_INTRINSICS_UUID, hdf5DataGroupPath);
   }
   // lock released
 
@@ -104,15 +104,15 @@ ImageAttributes Hdf5CoreImage::readImageAttributes(const std::string& id)
 
   if (dataGroupPtr && dataSetPtr)
   {
-    attributes.height = readAttributeFromHdf5<uint32_t>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::HEIGHT);
-    attributes.width = readAttributeFromHdf5<uint32_t>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::WIDTH);
+    attributes.height = readAttributeFromHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::HEIGHT, id);
+    attributes.width = readAttributeFromHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::WIDTH, id);
     attributes.encoding =
-        readAttributeFromHdf5<std::string>(id, *dataSetPtr, seerep_hdf5_core::Hdf5CoreImage::ENCODING);
+        readAttributeFromHdf5<std::string>(*dataSetPtr, seerep_hdf5_core::Hdf5CoreImage::ENCODING, id);
     attributes.isBigendian =
-        readAttributeFromHdf5<bool>(id, *dataSetPtr, seerep_hdf5_core::Hdf5CoreImage::IS_BIGENDIAN);
-    attributes.step = readAttributeFromHdf5<uint32_t>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::STEP);
+        readAttributeFromHdf5<bool>(*dataSetPtr, seerep_hdf5_core::Hdf5CoreImage::IS_BIGENDIAN, id);
+    attributes.step = readAttributeFromHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::STEP, id);
     attributes.cameraIntrinsicsUuid =
-        readAttributeFromHdf5<std::string>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::CAMERA_INTRINSICS_UUID);
+        readAttributeFromHdf5<std::string>(*dataGroupPtr, seerep_hdf5_core::Hdf5CoreImage::CAMERA_INTRINSICS_UUID, id);
   }
   return attributes;
 }

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_instance.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_instance.cpp
@@ -31,7 +31,7 @@ std::optional<std::unordered_map<std::string, std::string>> Hdf5CoreInstance::re
   std::unordered_map<std::string, std::string> attributesMap;
   for (auto attributeKey : allAttributesKeys)
   {
-    std::string attributeValue = readAttributeFromHdf5<std::string>(uuid, *groupPtr, attributeKey);
+    std::string attributeValue = readAttributeFromHdf5<std::string>(*groupPtr, attributeKey, uuid);
     attributesMap.emplace(attributeKey, attributeValue);
   }
   return attributesMap;

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_tf.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_tf.cpp
@@ -48,8 +48,8 @@ std::optional<std::vector<geometry_msgs::TransformStamped>> Hdf5CoreTf::readTran
   }
 
   // read frames
-  std::string parentframe = readFrameId(id, *group_ptr, PARENT_FRAME);
-  std::string childframe = readFrameId(id, *group_ptr, CHILD_FRAME);
+  std::string parentframe = readFrameId(*group_ptr, PARENT_FRAME, id);
+  std::string childframe = readFrameId(*group_ptr, CHILD_FRAME, id);
   std::vector<std::vector<int64_t>> time = readTime(hdf5DatasetTimePath);
   std::vector<std::vector<double>> trans = readTranslation(hdf5DatasetTransPath);
   std::vector<std::vector<double>> rot = readRotation(hdf5DatasetRotPath);
@@ -84,8 +84,8 @@ std::optional<std::vector<std::string>> Hdf5CoreTf::readTransformStampedFrames(c
   BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::info) << "loading parent frame of " << hdf5GroupPath;
 
   // read frames
-  std::string parentframe = readFrameId(id, *group_ptr, PARENT_FRAME);
-  std::string childframe = readFrameId(id, *group_ptr, CHILD_FRAME);
+  std::string parentframe = readFrameId(*group_ptr, PARENT_FRAME, id);
+  std::string childframe = readFrameId(*group_ptr, CHILD_FRAME, id);
 
   return std::vector<std::string>{ parentframe, childframe };
 }

--- a/seerep_hdf5/seerep_hdf5_fb/include/seerep_hdf5_fb/impl/hdf5_fb_general.hpp
+++ b/seerep_hdf5/seerep_hdf5_fb/include/seerep_hdf5_fb/impl/hdf5_fb_general.hpp
@@ -70,12 +70,12 @@ flatbuffers::Offset<seerep::fb::Header> Hdf5FbGeneral::readHeaderAttributes(flat
   std::string uuidProject = std::filesystem::path(m_file->getName()).filename().stem();
 
   int64_t seconds =
-      readAttributeFromHdf5<int64_t>(uuidMsg, object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_SECONDS);
+      readAttributeFromHdf5<int64_t>(object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_SECONDS, uuidMsg);
   int32_t nanos =
-      readAttributeFromHdf5<int32_t>(uuidMsg, object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_NANOS);
+      readAttributeFromHdf5<int32_t>(object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_NANOS, uuidMsg);
   std::string frameId = readFrameId(uuidMsg, object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_FRAME_ID);
 
-  uint32_t seq = readAttributeFromHdf5<uint32_t>(uuidMsg, object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_SEQ);
+  uint32_t seq = readAttributeFromHdf5<uint32_t>(object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_SEQ, uuidMsg);
 
   auto timestamp = seerep::fb::CreateTimestamp(builder, seconds, nanos);
 

--- a/seerep_hdf5/seerep_hdf5_fb/include/seerep_hdf5_fb/impl/hdf5_fb_general.hpp
+++ b/seerep_hdf5/seerep_hdf5_fb/include/seerep_hdf5_fb/impl/hdf5_fb_general.hpp
@@ -73,7 +73,7 @@ flatbuffers::Offset<seerep::fb::Header> Hdf5FbGeneral::readHeaderAttributes(flat
       readAttributeFromHdf5<int64_t>(object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_SECONDS, uuidMsg);
   int32_t nanos =
       readAttributeFromHdf5<int32_t>(object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_NANOS, uuidMsg);
-  std::string frameId = readFrameId(uuidMsg, object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_FRAME_ID);
+  std::string frameId = readFrameId(object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_FRAME_ID, uuidMsg);
 
   uint32_t seq = readAttributeFromHdf5<uint32_t>(object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_SEQ, uuidMsg);
 

--- a/seerep_hdf5/seerep_hdf5_fb/src/hdf5_fb_pointcloud.cpp
+++ b/seerep_hdf5/seerep_hdf5_fb/src/hdf5_fb_pointcloud.cpp
@@ -194,26 +194,26 @@ void Hdf5FbPointCloud::readGeneralAttributes(const std::string& id, std::shared_
                                              uint32_t& height, uint32_t& width, uint32_t& pointStep, uint32_t& rowStep,
                                              bool& isBigendian, bool& isDense)
 {
-  height = readAttributeFromHdf5<uint32_t>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CorePointCloud::HEIGHT);
-  width = readAttributeFromHdf5<uint32_t>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CorePointCloud::WIDTH);
-  pointStep = readAttributeFromHdf5<uint32_t>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CorePointCloud::POINT_STEP);
-  rowStep = readAttributeFromHdf5<uint32_t>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CorePointCloud::ROW_STEP);
-  isBigendian = readAttributeFromHdf5<bool>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CorePointCloud::IS_BIGENDIAN);
-  isDense = readAttributeFromHdf5<bool>(id, *dataGroupPtr, seerep_hdf5_core::Hdf5CorePointCloud::IS_DENSE);
+  height = readAttributeFromHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CorePointCloud::HEIGHT, id);
+  width = readAttributeFromHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CorePointCloud::WIDTH, id);
+  pointStep = readAttributeFromHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CorePointCloud::POINT_STEP, id);
+  rowStep = readAttributeFromHdf5<uint32_t>(*dataGroupPtr, seerep_hdf5_core::Hdf5CorePointCloud::ROW_STEP, id);
+  isBigendian = readAttributeFromHdf5<bool>(*dataGroupPtr, seerep_hdf5_core::Hdf5CorePointCloud::IS_BIGENDIAN, id);
+  isDense = readAttributeFromHdf5<bool>(*dataGroupPtr, seerep_hdf5_core::Hdf5CorePointCloud::IS_DENSE, id);
 }
 
 void Hdf5FbPointCloud::readPointFields(const std::string& id, std::shared_ptr<HighFive::Group> dataGroupPtr,
                                        std::vector<std::string>& names, std::vector<uint32_t>& offsets,
                                        std::vector<uint32_t>& counts, std::vector<uint8_t>& datatypes)
 {
-  names = readAttributeFromHdf5<std::vector<std::string>>(id, *dataGroupPtr,
-                                                          seerep_hdf5_core::Hdf5CorePointCloud::FIELD_NAME);
-  offsets = readAttributeFromHdf5<std::vector<uint32_t>>(id, *dataGroupPtr,
-                                                         seerep_hdf5_core::Hdf5CorePointCloud::FIELD_OFFSET);
-  counts = readAttributeFromHdf5<std::vector<uint32_t>>(id, *dataGroupPtr,
-                                                        seerep_hdf5_core::Hdf5CorePointCloud::FIELD_COUNT);
-  datatypes = readAttributeFromHdf5<std::vector<uint8_t>>(id, *dataGroupPtr,
-                                                          seerep_hdf5_core::Hdf5CorePointCloud::FIELD_DATATYPE);
+  names = readAttributeFromHdf5<std::vector<std::string>>(*dataGroupPtr,
+                                                          seerep_hdf5_core::Hdf5CorePointCloud::FIELD_NAME, id);
+  offsets = readAttributeFromHdf5<std::vector<uint32_t>>(*dataGroupPtr,
+                                                         seerep_hdf5_core::Hdf5CorePointCloud::FIELD_OFFSET, id);
+  counts = readAttributeFromHdf5<std::vector<uint32_t>>(*dataGroupPtr,
+                                                        seerep_hdf5_core::Hdf5CorePointCloud::FIELD_COUNT, id);
+  datatypes = readAttributeFromHdf5<std::vector<uint8_t>>(*dataGroupPtr,
+                                                          seerep_hdf5_core::Hdf5CorePointCloud::FIELD_DATATYPE, id);
 }
 
 flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<seerep::fb::PointField>>>

--- a/seerep_hdf5/seerep_hdf5_pb/include/seerep_hdf5_pb/impl/hdf5_pb_general.hpp
+++ b/seerep_hdf5/seerep_hdf5_pb/include/seerep_hdf5_pb/impl/hdf5_pb_general.hpp
@@ -20,7 +20,7 @@ seerep::pb::Header Hdf5PbGeneral::readHeaderAttributes(HighFive::AnnotateTraits<
       readAttributeFromHdf5<int64_t>(object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_SECONDS, id));
   header.mutable_stamp()->set_nanos(
       readAttributeFromHdf5<int32_t>(object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_NANOS, id));
-  header.set_frame_id(readFrameId(id, object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_FRAME_ID));
+  header.set_frame_id(readFrameId(object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_FRAME_ID, id));
   header.set_seq(readAttributeFromHdf5<uint32_t>(object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_SEQ, id));
   header.set_uuid_project(std::filesystem::path(m_file->getName()).filename().stem());
   header.set_uuid_msgs(id);

--- a/seerep_hdf5/seerep_hdf5_pb/include/seerep_hdf5_pb/impl/hdf5_pb_general.hpp
+++ b/seerep_hdf5/seerep_hdf5_pb/include/seerep_hdf5_pb/impl/hdf5_pb_general.hpp
@@ -17,11 +17,11 @@ seerep::pb::Header Hdf5PbGeneral::readHeaderAttributes(HighFive::AnnotateTraits<
   seerep::pb::Header header;
 
   header.mutable_stamp()->set_seconds(
-      readAttributeFromHdf5<int64_t>(id, object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_SECONDS));
+      readAttributeFromHdf5<int64_t>(object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_SECONDS, id));
   header.mutable_stamp()->set_nanos(
-      readAttributeFromHdf5<int32_t>(id, object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_NANOS));
+      readAttributeFromHdf5<int32_t>(object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_STAMP_NANOS, id));
   header.set_frame_id(readFrameId(id, object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_FRAME_ID));
-  header.set_seq(readAttributeFromHdf5<uint32_t>(id, object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_SEQ));
+  header.set_seq(readAttributeFromHdf5<uint32_t>(object, seerep_hdf5_core::Hdf5CoreGeneral::HEADER_SEQ, id));
   header.set_uuid_project(std::filesystem::path(m_file->getName()).filename().stem());
   header.set_uuid_msgs(id);
 

--- a/seerep_srv/seerep_core/include/seerep_core/core.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core.h
@@ -126,7 +126,7 @@ public:
    * @return true Camera Intrinsics exist
    * @return false Camera Intrinsics do not exist
    */
-  bool checkCameraIntrinsicsExists(const seerep_core_msgs::camera_intrinsics_query& ci_query);
+  bool cameraIntrinsicExists(const seerep_core_msgs::camera_intrinsics_query& ci_query);
 
   /**
    * @brief creates a new project / HDF5 file with the given project information

--- a/seerep_srv/seerep_core/include/seerep_core/core_camera_intrinsics.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_camera_intrinsics.h
@@ -38,7 +38,7 @@ public:
    * @return true If Camera Intrinsics Exists
    * @return false If Camera Intrinsics Exists
    */
-  bool checkCameraIntrinsicsExists(boost::uuids::uuid camIntrinsicsUuid);
+  bool cameraIntrinsicExists(boost::uuids::uuid camIntrinsicsUuid);
 
 private:
   /** @brief shared pointer to the object handling the HDF5 io for Camera Intrinsics */

--- a/seerep_srv/seerep_core/include/seerep_core/core_project.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_project.h
@@ -170,7 +170,7 @@ public:
    * @return true If Camera Intrinsics Exists
    * @return false If Camera Intrinsics Exists
    */
-  bool checkCameraIntrinsicsExists(boost::uuids::uuid camIntrinsicsUuid);
+  bool cameraIntrinsicExists(boost::uuids::uuid camIntrinsicsUuid);
 
   std::vector<std::string> getFrames();
 

--- a/seerep_srv/seerep_core/src/core.cpp
+++ b/seerep_srv/seerep_core/src/core.cpp
@@ -205,12 +205,12 @@ Core::getCameraIntrinsics(const seerep_core_msgs::camera_intrinsics_query& ci_qu
   }
 }
 
-bool Core::checkCameraIntrinsicsExists(const seerep_core_msgs::camera_intrinsics_query& ci_query)
+bool Core::cameraIntrinsicExists(const seerep_core_msgs::camera_intrinsics_query& ci_query)
 {
   try
   {
     auto project = findProject(ci_query.uuidProject);
-    return project->second->checkCameraIntrinsicsExists(ci_query.uuidCameraIntrinsics);
+    return project->second->cameraIntrinsicExists(ci_query.uuidCameraIntrinsics);
   }
   catch (const std::runtime_error& e)
   {

--- a/seerep_srv/seerep_core/src/core_camera_intrinsics.cpp
+++ b/seerep_srv/seerep_core/src/core_camera_intrinsics.cpp
@@ -27,9 +27,9 @@ std::optional<seerep_core_msgs::camera_intrinsics> CoreCameraIntrinsics::getData
   }
 }
 
-bool CoreCameraIntrinsics::checkCameraIntrinsicsExists(boost::uuids::uuid camIntrinsicsUuid)
+bool CoreCameraIntrinsics::cameraIntrinsicExists(boost::uuids::uuid camIntrinsicsUuid)
 {
-  return m_hdf5_io->checkCameraIntrinsicsExists(camIntrinsicsUuid);
+  return m_hdf5_io->cameraIntrinsicExists(camIntrinsicsUuid);
 }
 
 }  // namespace seerep_core

--- a/seerep_srv/seerep_core/src/core_project.cpp
+++ b/seerep_srv/seerep_core/src/core_project.cpp
@@ -170,9 +170,9 @@ std::optional<seerep_core_msgs::camera_intrinsics> CoreProject::getCameraIntrins
   return m_coreCameraIntrinsics->getData(camIntrinsicsUuid);
 }
 
-bool CoreProject::checkCameraIntrinsicsExists(boost::uuids::uuid camIntrinsicsUuid)
+bool CoreProject::cameraIntrinsicExists(boost::uuids::uuid camIntrinsicsUuid)
 {
-  return m_coreCameraIntrinsics->checkCameraIntrinsicsExists(camIntrinsicsUuid);
+  return m_coreCameraIntrinsics->cameraIntrinsicExists(camIntrinsicsUuid);
 }
 
 std::shared_ptr<std::mutex> CoreProject::getHdf5FileMutex()

--- a/seerep_srv/seerep_core_fb/src/core_fb_image.cpp
+++ b/seerep_srv/seerep_core_fb/src/core_fb_image.cpp
@@ -49,7 +49,7 @@ boost::uuids::uuid CoreFbImage::addData(const seerep::fb::Image& img)
   camintrinsics_query.uuidProject = gen(img.header()->uuid_project()->str());
   camintrinsics_query.uuidCameraIntrinsics = gen(img.uuid_cameraintrinsics()->str());
 
-  if (m_seerepCore->checkCameraIntrinsicsExists(camintrinsics_query))
+  if (m_seerepCore->cameraIntrinsicExists(camintrinsics_query))
   {
     auto hdf5io = CoreFbGeneral::getHdf5(dataForIndices.header.uuidProject, m_seerepCore, m_hdf5IoMap);
     hdf5io->writeImage(boost::lexical_cast<std::string>(dataForIndices.header.uuidData), img);

--- a/seerep_srv/seerep_core_pb/src/core_pb_image.cpp
+++ b/seerep_srv/seerep_core_pb/src/core_pb_image.cpp
@@ -49,7 +49,7 @@ boost::uuids::uuid CorePbImage::addData(const seerep::pb::Image& img)
   camintrinsics_query.uuidProject = gen(img.header().uuid_project());
   camintrinsics_query.uuidCameraIntrinsics = gen(img.uuid_camera_intrinsics());
 
-  if (m_seerepCore->checkCameraIntrinsicsExists(camintrinsics_query))
+  if (m_seerepCore->cameraIntrinsicExists(camintrinsics_query))
   {
     auto hdf5io = getHdf5(dataForIndices.header.uuidProject);
     hdf5io->writeImage(boost::lexical_cast<std::string>(dataForIndices.header.uuidData), img);


### PR DESCRIPTION
PR for several small improvements in the `seerep_hdf5_core`  and `seerep_core` classes, which mainly involve:

- Removing unused code
- Renaming methods and variables to be more meaningful
- Refactoring methods by using already existing templates