### PR TITLE
Add check for the correct layout of camera intrinsics matrices.

### DIFF
--- a/examples/python/gRPC/images/gRPC_fb_addCameraIntrinsics.py
+++ b/examples/python/gRPC/images/gRPC_fb_addCameraIntrinsics.py
@@ -38,8 +38,15 @@ ts = createTimeStamp(builder, 4, 3)
 header = createHeader(builder, ts, "map", projectuuid, ciuuid)
 roi = createRegionOfInterest(builder, 3, 5, 6, 7, True)
 
-matrix = [4, 5, 6]
-ci = createCameraIntrinsics(builder, header, 3, 4, "plump_bob", matrix, matrix, matrix, matrix, 4, 5, roi, 5)
+
+distortion_matrix = [4, 5, 6, 7, 8, 9, 10, 11, 12]
+rect_matrix = [4, 5, 6, 7, 8, 9, 10, 11, 12]
+intrins_matrix = [4, 5, 6, 7, 8, 9, 10, 11, 12]
+proj_matrix = [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+
+ci = createCameraIntrinsics(
+    builder, header, 3, 4, "plumb_bob", distortion_matrix, intrins_matrix, rect_matrix, proj_matrix, 4, 5, roi, 5
+)
 builder.Finish(ci)
 
 buf = builder.Output()

--- a/examples/python/gRPC/images/gRPC_pb_addCameraIntrinsics.py
+++ b/examples/python/gRPC/images/gRPC_pb_addCameraIntrinsics.py
@@ -60,13 +60,13 @@ camin.region_of_interest.do_rectify = 4
 camin.height = 5
 camin.width = 4
 
-camin.distortion_model = "plump_bob"
+camin.distortion_model = "plumb_bob"
 
 camin.distortion.extend([3, 4, 5])
 
-camin.intrinsic_matrix.extend([3, 4, 5])
-camin.rectification_matrix.extend([3, 4, 5])
-camin.projection_matrix.extend([3, 4, 5])
+camin.intrinsic_matrix.extend([3, 4, 5, 6, 7, 8, 9, 10, 11])
+camin.rectification_matrix.extend([3, 4, 5, 6, 7, 8, 9, 10, 11])
+camin.projection_matrix.extend([3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])
 
 camin.binning_x = 6
 camin.binning_y = 7

--- a/examples/python/gRPC/images/gRPC_pb_sendLabeledImage.py
+++ b/examples/python/gRPC/images/gRPC_pb_sendLabeledImage.py
@@ -78,13 +78,13 @@ camin.region_of_interest.do_rectify = 4
 camin.height = 5
 camin.width = 4
 
-camin.distortion_model = "plump_bob"
+camin.distortion_model = "plumb_bob"
 
 camin.distortion.extend([3, 4, 5])
 
-camin.intrinsic_matrix.extend([3, 4, 5])
-camin.rectification_matrix.extend([3, 4, 5])
-camin.projection_matrix.extend([3, 4, 5])
+camin.intrinsic_matrix.extend([3, 4, 5, 6, 7, 8, 9, 10, 11])
+camin.rectification_matrix.extend([3, 4, 5, 6, 7, 8, 9, 10, 11])
+camin.projection_matrix.extend([3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14])
 
 camin.binning_x = 6
 camin.binning_y = 7

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_image.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_image.h
@@ -131,7 +131,7 @@ public:
    * @param camintrinsics_uuid The UUID of the camera intrinsic parameters to use.
    * @param bb Axis aligned bounding box to store the result in.
    */
-  void computeFrusturmBB(const std::string& camintrinsics_uuid, seerep_core_msgs::AABB& bb);
+  void computeFrustumBB(const std::string& camintrinsics_uuid, seerep_core_msgs::AABB& bb);
 
 public:
   // image attribute keys

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_image.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_image.cpp
@@ -54,7 +54,7 @@ std::optional<seerep_core_msgs::DatasetIndexable> Hdf5CoreImage::readDataset(con
   }
   // lock released
 
-  computeFrusturmBB(camintrinsics_uuid, data.boundingbox);
+  computeFrustumBB(camintrinsics_uuid, data.boundingbox);
 
   return data;
 }
@@ -127,7 +127,7 @@ const std::string Hdf5CoreImage::getHdf5DataSetPath(const std::string& id) const
   return getHdf5GroupPath(id) + "/" + RAWDATA;
 }
 
-void Hdf5CoreImage::computeFrusturmBB(const std::string& camintrinsics_uuid, seerep_core_msgs::AABB& bb)
+void Hdf5CoreImage::computeFrustumBB(const std::string& camintrinsics_uuid, seerep_core_msgs::AABB& bb)
 {
   seerep_core_msgs::camera_intrinsics ci =
       m_ioCI->readCameraIntrinsics(boost::lexical_cast<boost::uuids::uuid>(camintrinsics_uuid));

--- a/seerep_srv/seerep_core_fb/src/core_fb_image.cpp
+++ b/seerep_srv/seerep_core_fb/src/core_fb_image.cpp
@@ -54,7 +54,7 @@ boost::uuids::uuid CoreFbImage::addData(const seerep::fb::Image& img)
     auto hdf5io = CoreFbGeneral::getHdf5(dataForIndices.header.uuidProject, m_seerepCore, m_hdf5IoMap);
     hdf5io->writeImage(boost::lexical_cast<std::string>(dataForIndices.header.uuidData), img);
 
-    hdf5io->computeFrusturmBB(img.uuid_cameraintrinsics()->str(), dataForIndices.boundingbox);
+    hdf5io->computeFrustumBB(img.uuid_cameraintrinsics()->str(), dataForIndices.boundingbox);
 
     m_seerepCore->addDataset(dataForIndices);
 

--- a/seerep_srv/seerep_core_pb/src/core_pb_image.cpp
+++ b/seerep_srv/seerep_core_pb/src/core_pb_image.cpp
@@ -54,7 +54,7 @@ boost::uuids::uuid CorePbImage::addData(const seerep::pb::Image& img)
     auto hdf5io = getHdf5(dataForIndices.header.uuidProject);
     hdf5io->writeImage(boost::lexical_cast<std::string>(dataForIndices.header.uuidData), img);
 
-    hdf5io->computeFrusturmBB(img.uuid_camera_intrinsics(), dataForIndices.boundingbox);
+    hdf5io->computeFrustumBB(img.uuid_camera_intrinsics(), dataForIndices.boundingbox);
 
     m_seerepCore->addDataset(dataForIndices);
 

--- a/seerep_srv/seerep_server/include/seerep_server/fb_cameraintrinsics_service.h
+++ b/seerep_srv/seerep_server/include/seerep_server/fb_cameraintrinsics_service.h
@@ -7,6 +7,7 @@
 #include <seerep_core_fb/core_fb_camera_intrinsics.h>
 #include <seerep_core_fb/core_fb_conversion.h>
 
+#include "service_constants.h"
 #include "util.hpp"
 
 // logging

--- a/seerep_srv/seerep_server/include/seerep_server/pb_camera_intrinsics_service.h
+++ b/seerep_srv/seerep_server/include/seerep_server/pb_camera_intrinsics_service.h
@@ -6,6 +6,7 @@
 #include <seerep_core/core.h>
 #include <seerep_core_pb/core_pb_camera_intrinsics.h>
 
+#include "service_constants.h"
 #include "util.hpp"
 
 // logging

--- a/seerep_srv/seerep_server/include/seerep_server/service_constants.h
+++ b/seerep_srv/seerep_server/include/seerep_server/service_constants.h
@@ -1,0 +1,13 @@
+#ifndef SEEREP_SERVER_SERVICE_CONSTANTS_H_
+#define SEEREP_SERVER_SERVICE_CONSTANTS_H_
+
+#include <sensor_msgs/distortion_models.h>
+
+namespace seerep_server_constants
+{
+/** @brief constants for allowed distortion models*/
+inline const std::string kCameraDistortionModels[] = { sensor_msgs::distortion_models::PLUMB_BOB,
+                                                       sensor_msgs::distortion_models::RATIONAL_POLYNOMIAL,
+                                                       sensor_msgs::distortion_models::EQUIDISTANT };
+}  // namespace seerep_server_constants
+#endif  // SEEREP_SERVER_SERVICE_CONSTANTS_H_

--- a/seerep_srv/seerep_server/src/fb_cameraintrinsics_service.cpp
+++ b/seerep_srv/seerep_server/src/fb_cameraintrinsics_service.cpp
@@ -70,32 +70,27 @@ grpc::Status FbCameraIntrinsicsService::TransferCameraIntrinsics(
 
   // check if the distortion model is found in kCameraDistortionModels
   bool distortion_model_err =
-      !requestRoot->distortion_model() ||
+      requestRoot->distortion_model()->size() > 0 &&
       std::find(std::begin(seerep_server_constants::kCameraDistortionModels),
                 std::end(seerep_server_constants::kCameraDistortionModels),
                 requestRoot->distortion_model()->c_str()) == std::end(seerep_server_constants::kCameraDistortionModels);
 
-  bool distortion_mat_err = !requestRoot->distortion();
   bool intrinsics_mat_err = !requestRoot->intrinsic_matrix() || requestRoot->intrinsic_matrix()->size() != 9 ||
                             (*requestRoot->intrinsic_matrix())[0] == 0 || (*requestRoot->intrinsic_matrix())[4] == 0;
 
   bool rectification_mat_err =
-      !requestRoot->rectification_matrix() ||
+      requestRoot->rectification_matrix() &&
       (requestRoot->rectification_matrix()->size() > 0 && requestRoot->rectification_matrix()->size() != 9);
 
-  bool projection_mat_err = !requestRoot->projection_matrix() || (requestRoot->projection_matrix()->size() > 0 &&
-                                                                  requestRoot->projection_matrix()->size() != 12);
+  bool projection_mat_err = requestRoot->projection_matrix() && (requestRoot->projection_matrix()->size() > 0 &&
+                                                                 requestRoot->projection_matrix()->size() != 12);
 
-  if (distortion_model_err || distortion_mat_err || intrinsics_mat_err || rectification_mat_err || projection_mat_err)
+  if (distortion_model_err || intrinsics_mat_err || rectification_mat_err || projection_mat_err)
   {
     response_message = "";
     if (distortion_model_err)
     {
-      response_message += "The distortion model is not set or invalid. ";
-    }
-    if (distortion_mat_err)
-    {
-      response_message += "The distortion matrix is not set. ";
+      response_message += "The distortion model is set but invalid. ";
     }
     if (intrinsics_mat_err)
     {
@@ -104,11 +99,11 @@ grpc::Status FbCameraIntrinsicsService::TransferCameraIntrinsics(
     }
     if (rectification_mat_err)
     {
-      response_message += "Rectification matrix is not set or dimensions are incorrect. ";
+      response_message += "Rectification matrix dimensions are incorrect. ";
     }
     if (projection_mat_err)
     {
-      response_message += "Projection matrix is not set or dimensions are incorrect.";
+      response_message += "Projection matrix dimensions are incorrect.";
     }
     BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::error) << response_message;
     seerep_server_util::createResponseFb(response_message, seerep::fb::TRANSMISSION_STATE_FAILURE, response);

--- a/seerep_srv/seerep_server/src/pb_camera_intrinsics_service.cpp
+++ b/seerep_srv/seerep_server/src/pb_camera_intrinsics_service.cpp
@@ -17,30 +17,27 @@ grpc::Status PbCameraIntrinsicsService::TransferCameraIntrinsics(grpc::ServerCon
   std::string response_message;
 
   // check if the distortion model is found in kCameraDistortionModels
-  bool distortion_model_err = std::find(std::begin(seerep_server_constants::kCameraDistortionModels),
+  bool distortion_model_err = camintrinsics->distortion_model().size() > 0 &&
+                              std::find(std::begin(seerep_server_constants::kCameraDistortionModels),
                                         std::end(seerep_server_constants::kCameraDistortionModels),
                                         camintrinsics->distortion_model().c_str()) ==
-                              std::end(seerep_server_constants::kCameraDistortionModels);
-
-  bool distortion_mat_err = camintrinsics->distortion_size() < 1;
+                                  std::end(seerep_server_constants::kCameraDistortionModels);
 
   bool intrinsics_mat_err = camintrinsics->intrinsic_matrix_size() != 9 || camintrinsics->intrinsic_matrix()[0] == 0 ||
                             camintrinsics->intrinsic_matrix()[4] == 0;
 
-  bool rectification_mat_err = camintrinsics->rectification_matrix_size() != 9;
+  bool rectification_mat_err =
+      camintrinsics->rectification_matrix_size() > 0 && camintrinsics->rectification_matrix_size() != 9;
 
-  bool projection_mat_err = camintrinsics->projection_matrix_size() != 12;
+  bool projection_mat_err =
+      camintrinsics->projection_matrix_size() > 0 && camintrinsics->projection_matrix_size() != 12;
 
-  if (distortion_mat_err || distortion_model_err || intrinsics_mat_err || rectification_mat_err || projection_mat_err)
+  if (distortion_model_err || intrinsics_mat_err || rectification_mat_err || projection_mat_err)
   {
     response_message = "";
-    if (distortion_mat_err)
-    {
-      response_message += "The distortion matrix is not set. ";
-    }
     if (distortion_model_err)
     {
-      response_message += "The distortion model is not set or invalid. ";
+      response_message += "The distortion model is set but invalid. ";
     }
     if (intrinsics_mat_err)
     {

--- a/seerep_srv/seerep_server/src/pb_camera_intrinsics_service.cpp
+++ b/seerep_srv/seerep_server/src/pb_camera_intrinsics_service.cpp
@@ -16,6 +16,7 @@ grpc::Status PbCameraIntrinsicsService::TransferCameraIntrinsics(grpc::ServerCon
 
   std::string response_message;
 
+  /* TODO: Add common implementation between Protocol Buffers and Flatbuffers for checking the correct matrix dimensions */
   // check if the distortion model is found in kCameraDistortionModels
   bool distortion_model_err = camintrinsics->distortion_model().size() > 0 &&
                               std::find(std::begin(seerep_server_constants::kCameraDistortionModels),


### PR DESCRIPTION
Closes #342. This also corrects a typo in Frustum.

Edit:
Empty values are now allowed, except for the intrinsics matrix.