### PR TITLE
Resolve deprecation and security warnings

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout SEEREP
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download MkDocs
         shell: bash
         run: |

--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -43,20 +43,20 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push base image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           file: Dockerfile
@@ -66,7 +66,7 @@ jobs:
           cache-to: type=inline
       -
         name: Build and push server image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           push: true
           file: docker/server/Dockerfile

--- a/.github/workflows/gitlab-sync.yml
+++ b/.github/workflows/gitlab-sync.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Git Repo Sync
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - uses: wangchucheng/git-repo-sync@v0.1.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
       # check if files have changed
       - name: Get changed files
         id: changed-files-specific-docker-base
-        uses: tj-actions/changed-files@v34
+        uses: tj-actions/changed-files@v42
         with:
           files: |
             docker/base/Dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       # check if files have changed
@@ -82,11 +82,11 @@ jobs:
       -
         name: Set up Docker Buildx
         if: github.ref_type == 'tag' || steps.changed-files-specific-docker-base.outputs.any_changed == 'true'
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to Container Registry
         if: github.ref_type == 'tag' || steps.changed-files-specific-docker-base.outputs.any_changed == 'true'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -94,7 +94,7 @@ jobs:
       -
         name: Build and push base image
         if: github.ref_type == 'tag' || steps.changed-files-specific-docker-base.outputs.any_changed == 'true'
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           file: Dockerfile
           context: "{{defaultContext}}:docker/base"
@@ -111,7 +111,7 @@ jobs:
       options: --user root
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: src
           fetch-depth: 0
@@ -154,20 +154,20 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push server image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           file: docker/server/Dockerfile
           push: ${{ GitHub.event_name != 'pull_request'}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       image: ghcr.io/agri-gaia/seerep_base:latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: src
     - name: Build seerep_hdf5 packages
@@ -34,7 +34,7 @@ jobs:
       image: ghcr.io/agri-gaia/seerep_base:latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: src
     - name: Build seerep_ros packages

--- a/docker/base/requirements.txt
+++ b/docker/base/requirements.txt
@@ -1,7 +1,7 @@
 pre-commit==3.5.0
 flatbuffers==22.12.6
 protobuf== 4.21.12
-grpcio-tools==1.51.1
+grpcio-tools==1.53.0
 grpcio==1.53.0
 imageio==2.20.0
 numpy==1.22.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2","grpcio-tools==1.51.1"]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2","grpcio-tools==1.53.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -15,7 +15,7 @@ authors = [
 dependencies = [
     "protobuf == 4.21.12",
     "flatbuffers == 22.12.6",
-    "grpcio == 1.51.1",
+    "grpcio == 1.53.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Includes:
- Updating actions to use node.js 20: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
- CVE-2023-51664 (tj-actions/changed-files)
- CVE-2023-1428, CVE-2023-32731, CVE-2023-32732 (gRPC)