### PR TITLE
fb_to_dict.py refactoring

### DIFF
--- a/docker/base/requirements.txt
+++ b/docker/base/requirements.txt
@@ -15,3 +15,4 @@ matplotlib==3.6.3
 open3d==0.17.0
 pytest==7.4.2
 pytest-sugar==0.9.7
+boltons==23.0.0

--- a/examples/python/gRPC/images/gRPC_fb_addBoundingBox.py
+++ b/examples/python/gRPC/images/gRPC_fb_addBoundingBox.py
@@ -120,7 +120,7 @@ def add_bb(
 
 
 if __name__ == "__main__":
-    bb_list = add_bb(add_bb())
+    bb_list = add_bb()
     for img_uuid, bbs_img in bb_list:
         print(
             f"Added bounding boxes to image with uuid {img_uuid}, with the following center points and spatial extents:"

--- a/examples/python/gRPC/images/gRPC_fb_addBoundingBox.py
+++ b/examples/python/gRPC/images/gRPC_fb_addBoundingBox.py
@@ -26,9 +26,9 @@ from seerep.util.fb_helper import (
 )
 
 
-def add_bb(
+def add_bb_raw(
     target_proj_uuid: Optional[str] = None, grpc_channel: Channel = get_gRPC_channel()
-) -> List[Tuple[str, BoundingBoxes2DLabeledStamped.BoundingBoxes2DLabeledStamped]]:
+) -> List[Tuple[str, bytearray]]:
     builder = flatbuffers.Builder(1024)
 
     target_proj_uuid = getProject(builder, grpc_channel, "testproject")
@@ -100,7 +100,7 @@ def add_bb(
         bb_list.append(
             (
                 img_uuid,
-                BoundingBoxes2DLabeledStamped.BoundingBoxes2DLabeledStamped.GetRootAs(buf),
+                buf,
             )
         )
 
@@ -110,8 +110,17 @@ def add_bb(
     return bb_list
 
 
+def add_bb(
+    target_proj_uuid: Optional[str] = None, grpc_channel: Channel = get_gRPC_channel()
+) -> List[Tuple[str, BoundingBoxes2DLabeledStamped.BoundingBoxes2DLabeledStamped]]:
+    return [
+        (img_uuid, BoundingBoxes2DLabeledStamped.BoundingBoxes2DLabeledStamped.GetRootAs(bbbuf))
+        for img_uuid, bbbuf in add_bb_raw(target_proj_uuid, grpc_channel)
+    ]
+
+
 if __name__ == "__main__":
-    bb_list = add_bb()
+    bb_list = add_bb(add_bb())
     for img_uuid, bbs_img in bb_list:
         print(
             f"Added bounding boxes to image with uuid {img_uuid}, with the following center points and spatial extents:"

--- a/examples/python/gRPC/images/gRPC_fb_addCameraIntrinsics.py
+++ b/examples/python/gRPC/images/gRPC_fb_addCameraIntrinsics.py
@@ -16,15 +16,24 @@ from seerep.util.fb_helper import (
     createRegionOfInterest,
     createTimeStamp,
 )
-from seerep.util.fb_to_dict import fb_flatc_dict
 
 
 # Default server is localhost !
-def add_camintrins(
+def add_camintrins_raw(
     ciuuid: Optional[str] = "fa2f27e3-7484-48b0-9f21-ec362075baca",
     target_proj_uuid: Optional[str] = None,
     grpc_channel: Channel = get_gRPC_channel(),
-) -> Optional[CameraIntrinsics.CameraIntrinsics]:
+) -> Optional[bytearray]:
+    """
+    Creates a example cameraintrinsics object and sends it to a SEEREP server instance.
+
+    Args:
+        ciuuid: the uuid of the CameraIntrinsics object to be send
+        target_proj_uuid: the project uuid to which project to send the CameraIntrinsics object to
+        grpc_channel: the grpc channel to a SEEREP server
+
+    Returns: bytearray which contains the serialized type seerep.fb.CameraInstrinsics.CameraIntrinsics
+    """
     if ciuuid is None:
         ciuuid = str(uuid.uuid4())
 
@@ -71,7 +80,15 @@ def add_camintrins(
     buf = builder.Output()
 
     stub.TransferCameraIntrinsics(bytes(buf))
-    return CameraIntrinsics.CameraIntrinsics.GetRootAs(buf)
+    return buf
+
+
+def add_camintrins(
+    ciuuid: Optional[str] = "fa2f27e3-7484-48b0-9f21-ec362075baca",
+    target_proj_uuid: Optional[str] = None,
+    grpc_channel: Channel = get_gRPC_channel(),
+) -> Optional[CameraIntrinsics.CameraIntrinsics]:
+    return CameraIntrinsics.CameraIntrinsics.GetRootAs(add_camintrins_raw(ciuuid, target_proj_uuid, grpc_channel))
 
 
 if __name__ == "__main__":

--- a/examples/python/gRPC/images/gRPC_fb_addCameraIntrinsics.py
+++ b/examples/python/gRPC/images/gRPC_fb_addCameraIntrinsics.py
@@ -16,6 +16,7 @@ from seerep.util.fb_helper import (
     createRegionOfInterest,
     createTimeStamp,
 )
+from seerep.util.fb_to_dict import fb_flatc_dict
 
 
 # Default server is localhost !

--- a/examples/python/gRPC/images/gRPC_fb_getCameraIntrinsics.py
+++ b/examples/python/gRPC/images/gRPC_fb_getCameraIntrinsics.py
@@ -10,11 +10,11 @@ from seerep.util.common import get_gRPC_channel
 from seerep.util.fb_helper import createCameraIntrinsicsQuery, getProject
 
 
-def get_camintrins(
+def get_camintrins_raw(
     ciuuid: str = "fa2f27e3-7484-48b0-9f21-ec362075baca",
     target_proj_uuid: Optional[str] = None,
     grpc_channel: Channel = get_gRPC_channel(),
-) -> Optional[CameraIntrinsics.CameraIntrinsics]:
+) -> Optional[bytearray]:
     builder = flatbuffers.Builder(1000)
 
     # 1. Get all projects from the server when no target specified
@@ -33,9 +33,15 @@ def get_camintrins(
 
     ret = stub.GetCameraIntrinsics(bytes(buf))
 
-    retrieved_ci = CameraIntrinsics.CameraIntrinsics.GetRootAs(ret)
+    return ret
 
-    return retrieved_ci
+
+def get_camintrins(
+    ciuuid: str = "fa2f27e3-7484-48b0-9f21-ec362075baca",
+    target_proj_uuid: Optional[str] = None,
+    grpc_channel: Channel = get_gRPC_channel(),
+) -> Optional[CameraIntrinsics.CameraIntrinsics]:
+    return CameraIntrinsics.CameraIntrinsics(get_camintrins_raw(ciuuid, target_proj_uuid, grpc_channel))
 
 
 if __name__ == "__main__":

--- a/examples/python/gRPC/images/gRPC_fb_queryImage.py
+++ b/examples/python/gRPC/images/gRPC_fb_queryImage.py
@@ -19,9 +19,9 @@ from seerep.util.fb_helper import (
 )
 
 
-def query_images(
+def query_images_raw(
     target_proj_uuid: Optional[str] = None, grpc_channel: Channel = get_gRPC_channel()
-) -> List[Image.Image]:
+) -> List[bytearray]:
     builder = flatbuffers.Builder(1024)
     if target_proj_uuid is None:
         # 1. Get all projects from the server
@@ -81,15 +81,16 @@ def query_images(
     builder.Finish(query)
     buf = builder.Output()
 
-    # save the queried images in a list
-    queried_images = []
-
     # 5. Query the server for images matching the query and iterate over them
-    for responseBuf in stub.GetImage(bytes(buf)):
-        response = Image.Image.GetRootAs(responseBuf)
-        queried_images.append(response)
+    queried_images = stub.GetImage(bytes(buf))
 
     return queried_images
+
+
+def query_images(
+    target_proj_uuid: Optional[str] = None, grpc_channel: Channel = get_gRPC_channel()
+) -> List[Image.Image]:
+    return [Image.Image.GetRootAs(img) for img in query_images_raw(target_proj_uuid, grpc_channel)]
 
 
 if __name__ == "__main__":

--- a/examples/python/gRPC/meta/gRPC_fb_createGeodeticCoordProject.py
+++ b/examples/python/gRPC/meta/gRPC_fb_createGeodeticCoordProject.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 import flatbuffers
 from grpc import Channel
 from seerep.fb import ProjectInfo
@@ -7,9 +6,9 @@ from seerep.util.common import get_gRPC_channel
 from seerep.util.fb_helper import createProjectRaw
 
 
-def create_geo_proj(
+def create_geo_proj_raw(
     grpc_channel: Channel = get_gRPC_channel(),
-) -> ProjectInfo.ProjectInfo:
+) -> bytearray:
     builder = flatbuffers.Builder(1024)
 
     response = createProjectRaw(
@@ -24,6 +23,10 @@ def create_geo_proj(
     )
 
     return response
+
+
+def create_geo_proj(grpc_channel: Channel = get_gRPC_channel()) -> ProjectInfo.ProjectInfo:
+    return ProjectInfo.ProjectInfo.GetRootAs(create_geo_proj_raw(grpc_channel))
 
 
 if __name__ == "__main__":

--- a/examples/python/gRPC/meta/gRPC_fb_getProjects.py
+++ b/examples/python/gRPC/meta/gRPC_fb_getProjects.py
@@ -10,7 +10,10 @@ from seerep.util.common import get_gRPC_channel
 
 def get_projects(
     grpc_channel: Channel = get_gRPC_channel(),
-) -> List[ProjectInfo.ProjectInfo]:
+) -> bytearray:
+    """
+    Returns: bytearray of type ProjectInfos
+    """
     stub = metaOperations.MetaOperationsStub(grpc_channel)
 
     builder = flatbuffers.Builder(1024)
@@ -20,19 +23,17 @@ def get_projects(
     buf = builder.Output()
 
     responseBuf = stub.GetProjects(bytes(buf))
-    response = ProjectInfos.ProjectInfos.GetRootAs(responseBuf)
+    return responseBuf
+
+
+if __name__ == "__main__":
+    response = ProjectInfos.ProjectInfos.GetRootAs(get_projects())
 
     projects_list: List[ProjectInfo.ProjectInfo] = []
 
     for i in range(response.ProjectsLength()):
         projects_list.append(response.Projects(i))
 
-    return projects_list
-
-
-if __name__ == "__main__":
-    projects = get_projects()
-
     print("The server has the following projects (name/uuid):")
-    for project in projects:
+    for project in projects_list:
         print("\t" + project.Name().decode("utf-8") + " " + project.Uuid().decode("utf-8"))

--- a/examples/python/gRPC/pointcloud/gRPC_fb_sendPointCloud.py
+++ b/examples/python/gRPC/pointcloud/gRPC_fb_sendPointCloud.py
@@ -139,9 +139,7 @@ def createTF(numOf, projectUuid, theTime):
         yield bytes(builderTf.Output())
 
 
-def send_pointcloud(
-    target_proj_uuid: str = None, grpc_channel: Channel = get_gRPC_channel()
-) -> List[PointCloud2.PointCloud2]:
+def send_pointcloud_raw(target_proj_uuid: str = None, grpc_channel: Channel = get_gRPC_channel()) -> List[bytearray]:
     builder = flatbuffers.Builder(1024)
     theTime = 1686038855
 
@@ -161,9 +159,13 @@ def send_pointcloud(
     # but this would consume the generator and then the pc list cannot be returned, therefore use a iterator
     stub.TransferPointCloud2(iter(pc_list))
 
-    pc_list = [PointCloud2.PointCloud2.GetRootAs(p) for p in pc_list]
-
     return pc_list
+
+
+def send_pointcloud(
+    target_proj_uuid: str = None, grpc_channel: Channel = get_gRPC_channel()
+) -> List[PointCloud2.PointCloud2]:
+    return [PointCloud2.PointCloud2.GetRootAs(p) for p in send_pointcloud_raw(target_proj_uuid, grpc_channel)]
 
 
 if __name__ == "__main__":

--- a/examples/python/gRPC/util/common.py
+++ b/examples/python/gRPC/util/common.py
@@ -39,20 +39,12 @@ def get_gRPC_channel(target="local"):
 
 
 # based on https://github.com/jpvanhal/inflection
-def to_snake_case(string: str):
-    """
-    Tries to convert a common string to snake case.
-
-    """
-    string = re.sub(r"((?<=[a-z0-9])[A-Z]|(?!^)(?<!_)[A-Z](?=[a-z]))", r"_\1", string)
-    string = string.replace("-", "_")
-    return string.lower()
-
-
 # function to pass to boltons.iterutils.remap
 def remap_to_snake_case(p, k, v):
     if isinstance(k, str):
-        return to_snake_case(k), v
+        k = re.sub(r"((?<=[a-z0-9])[A-Z]|(?!^)(?<!_)[A-Z](?=[a-z]))", r"_\1", k)
+        k = k.replace("-", "_")
+        return k.lower(), v
     return k, v
 
 

--- a/examples/python/gRPC/util/fb_helper.py
+++ b/examples/python/gRPC/util/fb_helper.py
@@ -139,22 +139,23 @@ def createProjectRaw(
     buf = builder.Output()
 
     responseBuf = stubMeta.CreateProject(bytes(buf))
-    response = ProjectInfo.ProjectInfo.GetRootAs(responseBuf)
-    return response
+    return responseBuf
 
 
 def createProject(channel, builder, name, frameId, coordSys, altitude, latitude, longitude) -> str:
     """Create a project from the parameters"""
     return (
-        createProjectRaw(
-            channel,
-            builder,
-            name,
-            frameId,
-            coordSys,
-            altitude,
-            latitude,
-            longitude,
+        ProjectInfo.ProjectInfo.GetRootAs(
+            createProjectRaw(
+                channel,
+                builder,
+                name,
+                frameId,
+                coordSys,
+                altitude,
+                latitude,
+                longitude,
+            )
         )
         .Uuid()
         .decode("utf-8")

--- a/examples/python/gRPC/util/fb_helper.py
+++ b/examples/python/gRPC/util/fb_helper.py
@@ -111,9 +111,7 @@ def getProjectInfo(builder, channel, name):
     return None
 
 
-def createProjectRaw(
-    channel, builder, name, frameId, coordSys, altitude, latitude, longitude
-) -> ProjectInfo.ProjectInfo:
+def createProjectRaw(channel, builder, name, frameId, coordSys, altitude, latitude, longitude) -> bytearray:
     stubMeta = metaOperations.MetaOperationsStub(channel)
 
     frameIdBuf = builder.CreateString(frameId)

--- a/examples/python/gRPC/util/fb_to_dict.py
+++ b/examples/python/gRPC/util/fb_to_dict.py
@@ -8,141 +8,14 @@ from typing import Dict, Final
 SCHEMA_FOLDER: Final[str] = "seerep_msgs/fbs/"
 
 
-<<<<<<< HEAD
-
-def get_func_lists_wparams(func_list, *endings) -> Dict[str, Tuple[bool, int]]:
-    """
-    Returns a list of tuples of functions that have versions of them with certain endings.
-    The first element of the tuple is the function name, the following elements are the results of the extra functions.
-    based on the function existence, the corresponding function is assumed to be a array.
-    the contained tuple are of the form (array, array_is_none, array_length)
-    """
-    if not isinstance(endings, Iterable):
-        raise ValueError("endings must be iterable")
-
-    # this will have the form (array, array_is_none, array_length)
-    dict_tuples = {}
-    # collect all functions that end with certain strings
-
-    # count found endings and check if all endings are found
-    for func in func_list:
-        inner_tuple = []
-        for ending in endings:
-            if func + ending not in func_list:
-                break
-            else:
-                inner_tuple.append(func + ending)
-        else:
-            dict_tuples[func] = inner_tuple
-    return dict_tuples
-
-
-def unpack_union_type(
-    enclosing_table_obj,
-    union_type_mapping: Dict[Type, Tuple[str, List[Tuple[int, Type]]]],
-    snake_case=False,
-    remappings: Dict[str, str] = {},
-) -> Dict:
-    union_field, field_nums_types = union_type_mapping[type(enclosing_table_obj)]
-
-    # extract value type
-    union_type = getattr(enclosing_table_obj, f"{union_field}Type")()
-    union_obj = getattr(enclosing_table_obj, union_field)()
-
-    for field_num, field_type in field_nums_types:
-        if union_type == field_num:
-            union_val = field_type()
-            union_val.Init(union_obj.Bytes, union_obj.Pos)
-
-            union_val = union_val.Data()
-
-            if isinstance(union_val, bytes):
-                try:
-                    union_val = union_val.decode()
-                except UnicodeDecodeError:
-                    pass
-
-            if isinstance(union_val, (int, float, str, bool)):
-                return union_val
-
-            return fb_obj_to_dict(union_val, snake_case, remappings, union_type_mapping)
-    else:
-        # ruff: noqa: PLW0120
-        raise ValueError(f"union type {union_type} not in {field_nums_types} of table {type(enclosing_table_obj)}")
-
-
-# todo: improve interface and rework functionality for more robustness
-def fb_obj_to_dict(
-    obj,
-    snake_case=False,
-    remappings: Dict[str, str] = {},
-    union_type_mapping: Dict[Type, Tuple[str, List[Tuple[int, Type]]]] = {},
-) -> Dict:
-=======
 def fb_flatc_dict(fb_obj: bytearray, schema_file_name: str) -> Dict:
->>>>>>> 2fdd6c52... cleanup of initial working fb_to_dict.py
     """
     Converts a binary flatbuffers object to a python dictionary using it's IDL file.
     This implementation uses temporary files in /tmp for conversion.
 
     Args:
-<<<<<<< HEAD
-        obj: The flatbuffer object to convert.
-        snake_case: If the resulting dictionary keys (flatbuffer field names) should be converted to snake case.
-        remappings: A dictionary of remappings for the resulting flatbuffer field names.
-        union_type_mapping:
-            union_type_mapping{ t: (field: str, [(num_type1, t_type1), (num_type2, t_type2), ...]) }
-            where t is the parent table of the union (the table in which the union is a field of).
-            The field is the name of the field containing the union.
-            num_type1, num_type2, ... are the possible numbers identifying the type of the union.
-            t_type1, t_type2, ... are the possible types of the union,
-              which have to correpondend to num_type1, num_type2, ...
-            For example:
-                union_type_mapping: Dict[Type, Tuple[str, List[Tuple[int, Type]]]] = {
-                    UnionMapEntry.UnionMapEntry: (
-                        "Value",
-                        [
-                            (Datatypes.Datatypes().Boolean, Boolean.Boolean),
-                            (Datatypes.Datatypes().Integer, Integer.Integer),
-                            (Datatypes.Datatypes().Double, Double.Double),
-                            (Datatypes.Datatypes().String, String.String),
-                        ],
-                    )
-                }
-    """
-    # get all non dunder functions of the object
-    funcs = [func for func in dir(obj) if callable(getattr(obj, func)) and not func.startswith("__")]
-
-    # filter out the functions that are not needed
-    funcs = [func for func in funcs if not any(func.startswith(x) for x in FB_FILTEROUT_STARTS_WITH)]
-    funcs = [func for func in funcs if not any(func.endswith(x) for x in FB_FILTEROUT_ENDS_WITH)]
-    # ruff: noqa: PLR1714
-    funcs = [func for func in funcs if not any(func == x for x in FB_FILTEROUT_IS)]
-    funcs = [func for func in funcs if not (func == "GetRootAs" or func == f"GetRootAs{type(obj).__name__}")]
-
-    # group arrays and array functions together, so that arrays can be handled separately
-    # e.g. (Distortion, DistortionIsNone, DistortionLength)
-    farr_dict: Dict[str, Tuple] = get_func_lists_wparams(funcs, *FB_GROUP_LIST_ENDS_WITH)
-
-    # filter funcs with endings out which are already in f_list
-    funcs = [
-        func
-        for func in funcs
-        if not any(func.endswith(x) if func.split(x)[0] in farr_dict else False for x in FB_GROUP_LIST_ENDS_WITH)
-    ]
-    funcs = [func for func in funcs if func not in farr_dict]
-
-    res_dict = {}
-    # get function results, if the result is a complex flatbuffer object, recursively call this function
-    # ruff: noqa: PLW2901
-    for func in funcs:
-        if type(obj) in union_type_mapping and func == union_type_mapping[type(obj)][0]:
-            res_dict[func] = unpack_union_type(obj, union_type_mapping, snake_case, remappings)
-            continue
-=======
         fb_obj: The bytearray object as returned by builder.Output().
         schema_file_name: The filename of the fb schema file.
->>>>>>> 2fdd6c52... cleanup of initial working fb_to_dict.py
 
     Returns:
         A python dictionary containing the objects attribute information.

--- a/examples/python/gRPC/util/fb_to_dict.py
+++ b/examples/python/gRPC/util/fb_to_dict.py
@@ -5,7 +5,8 @@ import tempfile as tf
 from pathlib import Path
 from typing import Dict, Final
 
-SCHEMA_FOLDER: Final[str] = "/seerep/src/seerep_msgs/fbs/"
+ROS_SCHEMA_PKG: Final[str] = "seerep_msgs"
+ROS_SCHEMA_SUBDIR: Final[str] = "fbs"
 
 
 class SchemaFileNames:
@@ -73,9 +74,41 @@ class SchemaFileNames:
     VECTOR3_STAMPED: Final[str] = "vector3_stamped.fbs"
 
 
+def catkin_find_schema_dir(ros_pkg_name: str, sub_dir: str) -> Path:
+    """
+    Tries to find the schema directory on the system using `catkin locate`.
+
+    Args:
+        ros_pkg_name: The name of the ros package containing the relevant schema files
+        sub_dir: The name of the subdir of the package dir containing the relevant schema files
+
+    Returns:
+        The schema directory on the system if found.
+
+    Raises:
+        FileNotFoundError: If the path on the system is not present.
+        ChildProcessError: If `catkin locate` returns something on stderr or failed otherwise
+    """
+
+    catkin_proc = sp.Popen(["catkin", "locate", ros_pkg_name], encoding="utf-8", stdout=sp.PIPE, stderr=sp.PIPE)
+    catkin_out, catkin_err = catkin_proc.communicate()
+
+    if catkin_proc.returncode != 0 or catkin_err != "":
+        raise ChildProcessError(f"Catkin call errored! {catkin_err}")
+
+    # splitlines needs to be used otherwise catkin_out contains \n at the end
+    fbs_path: Path = Path(catkin_out.splitlines()[0]) / sub_dir
+
+    if not fbs_path.is_dir():
+        raise FileNotFoundError(f"The path for seerep flatbuffers schema files is not present! Should be {fbs_path}")
+
+    return fbs_path
+
+
 def fb_flatc_dict(fb_obj: bytearray, schema_file_name: str) -> Dict:
     """
     Converts a binary flatbuffers object to a python dictionary using it's IDL file.
+
     This implementation uses temporary files in /tmp for conversion.
 
     Args:
@@ -84,8 +117,12 @@ def fb_flatc_dict(fb_obj: bytearray, schema_file_name: str) -> Dict:
 
     Returns:
         A python dictionary containing the objects attribute information.
+
+    Raises:
+        FileNotFoundError: If the schema file on the system couldn't be found.
+        ChildProcessError: If something went wrong using the flatc subcommand.
     """
-    schema_path = Path(SCHEMA_FOLDER + schema_file_name).absolute()
+    schema_path = catkin_find_schema_dir(ROS_SCHEMA_PKG, ROS_SCHEMA_SUBDIR) / schema_file_name
 
     if not schema_path.is_file():
         raise FileNotFoundError(f"The schema file at {schema_path} does not exist!")

--- a/examples/python/gRPC/util/fb_to_dict.py
+++ b/examples/python/gRPC/util/fb_to_dict.py
@@ -5,7 +5,72 @@ import tempfile as tf
 from pathlib import Path
 from typing import Dict, Final
 
-SCHEMA_FOLDER: Final[str] = "seerep_msgs/fbs/"
+SCHEMA_FOLDER: Final[str] = "/seerep/src/seerep_msgs/fbs/"
+
+
+class SchemaFileNames:
+    ATTRIBUTES_STAMPED: Final[str] = "attributes_stamped.fbs"
+    BOUNDINGBOX2D: Final[str] = "boundingbox2d.fbs"
+    BOUNDINGBOX2D_LABELED: Final[str] = "boundingbox2d_labeled.fbs"
+    BOUNDINGBOX2D_LABELED_WITH_CATEGORY: Final[str] = "boundingbox2d_labeled_with_category.fbs"
+    BOUNDINGBOX2D_STAMPED: Final[str] = "boundingbox2d_stamped.fbs"
+    BOUNDINGBOXES2D_LABELED_STAMPED: Final[str] = "boundingboxes2d_labeled_stamped.fbs"
+    BOUNDINGBOXES_LABELED_STAMPED: Final[str] = "boundingboxes_labeled_stamped.fbs"
+    BOUNDINGBOX: Final[str] = "boundingbox.fbs"
+    BOUNDINGBOX_LABELED: Final[str] = "boundingbox_labeled.fbs"
+    BOUNDINGBOX_LABELED_WITH_CATEGORY: Final[str] = "boundingbox_labeled_with_category.fbs"
+    BOUNDINGBOX_STAMPED: Final[str] = "boundingbox_stamped.fbs"
+    CAMERA_INTRINSICS: Final[str] = "camera_intrinsics.fbs"
+    CAMERA_INTRINSICS_QUERY: Final[str] = "camera_intrinsics_query.fbs"
+    CATEGORIES: Final[str] = "categories.fbs"
+    DATATYPE: Final[str] = "datatype.fbs"
+    EMPTY: Final[str] = "empty.fbs"
+    FRAME_INFOS: Final[str] = "frame_infos.fbs"
+    FRAME_QUERY: Final[str] = "frame_query.fbs"
+    GEODETICCOORDINATES: Final[str] = "geodeticCoordinates.fbs"
+    HEADER: Final[str] = "header.fbs"
+    IMAGE: Final[str] = "image.fbs"
+    LABEL: Final[str] = "label.fbs"
+    LABELS: Final[str] = "labels.fbs"
+    LABELS_WITH_CATEGORY: Final[str] = "labels_with_category.fbs"
+    LABELS_WITH_INSTANCE_WITH_CATEGORY: Final[str] = "labels_with_instance_with_category.fbs"
+    LABEL_WITH_INSTANCE: Final[str] = "label_with_instance.fbs"
+    POINT2D: Final[str] = "point2d.fbs"
+    POINT_CLOUD_2: Final[str] = "point_cloud_2.fbs"
+    POINT: Final[str] = "point.fbs"
+    POINT_FIELD: Final[str] = "point_field.fbs"
+    POINT_STAMPED: Final[str] = "point_stamped.fbs"
+    POLYGON2D: Final[str] = "polygon2d.fbs"
+    POLYGON: Final[str] = "polygon.fbs"
+    POLYGON_STAMPED: Final[str] = "polygon_stamped.fbs"
+    POSE: Final[str] = "pose.fbs"
+    POSE_STAMPED: Final[str] = "pose_stamped.fbs"
+    PROJECTCREATION: Final[str] = "projectCreation.fbs"
+    PROJECT_INFO: Final[str] = "project_info.fbs"
+    PROJECT_INFOS: Final[str] = "project_infos.fbs"
+    QUATERNION: Final[str] = "quaternion.fbs"
+    QUATERNION_STAMPED: Final[str] = "quaternion_stamped.fbs"
+    QUERY: Final[str] = "query.fbs"
+    QUERY_INSTANCE: Final[str] = "query_instance.fbs"
+    REGION_OF_INTEREST: Final[str] = "region_of_interest.fbs"
+    SERVER_RESPONSE: Final[str] = "server_response.fbs"
+    SPARQL_QUERY: Final[str] = "sparql_query.fbs"
+    TIME_INTERVAL: Final[str] = "time_interval.fbs"
+    TIMESTAMP: Final[str] = "timestamp.fbs"
+    TRANSFORM: Final[str] = "transform.fbs"
+    TRANSFORM_STAMPED: Final[str] = "transform_stamped.fbs"
+    TRANSFORM_STAMPED_QUERY: Final[str] = "transform_stamped_query.fbs"
+    TWIST: Final[str] = "twist.fbs"
+    TWIST_STAMPED: Final[str] = "twist_stamped.fbs"
+    TWIST_WITH_COVARIANCE: Final[str] = "twist_with_covariance.fbs"
+    TWIST_WITH_COVARIANCE_STAMPED: Final[str] = "twist_with_covariance_stamped.fbs"
+    UNION_MAP_ENTRY: Final[str] = "union_map_entry.fbs"
+    UUID_DATATYPE_PAIR: Final[str] = "uuid_datatype_pair.fbs"
+    UUID_DATATYPE_WITH_CATEGORY: Final[str] = "uuid_datatype_with_category.fbs"
+    UUIDS_PER_PROJECT: Final[str] = "uuids_per_project.fbs"
+    UUIDS_PROJECT_PAIR: Final[str] = "uuids_project_pair.fbs"
+    VECTOR3: Final[str] = "vector3.fbs"
+    VECTOR3_STAMPED: Final[str] = "vector3_stamped.fbs"
 
 
 def fb_flatc_dict(fb_obj: bytearray, schema_file_name: str) -> Dict:
@@ -22,23 +87,34 @@ def fb_flatc_dict(fb_obj: bytearray, schema_file_name: str) -> Dict:
     """
     schema_path = Path(SCHEMA_FOLDER + schema_file_name).absolute()
 
-    with tf.NamedTemporaryFile(delete=False) as tmp_f:
-        tmp_f.write(fb_obj)
-        temp_fname = tmp_f.name
-        flatc_proc = sp.Popen(
-            ["flatc", "--json", "--raw-binary", "--strict-json", schema_path, "--", temp_fname], cwd="/tmp"
-        )
-
-    flatc_proc.wait()
-
-    temp_json = temp_fname + ".json"
-    with open(temp_json, "r") as tmp_f:
-        json_dict = json.loads(tmp_f.read())
+    if not schema_path.is_file():
+        raise FileNotFoundError(f"The schema file at {schema_path} does not exist!")
 
     try:
-        os.remove(temp_json)
-        os.remove(temp_fname)
-    except FileNotFoundError:
-        pass
+        with tf.NamedTemporaryFile(delete=False) as tmp_f:
+            tmp_f.write(fb_obj)
+            temp_fname = tmp_f.name
+            flatc_proc = sp.Popen(
+                ["flatc", "--json", "--raw-binary", "--strict-json", schema_path, "--", temp_fname], cwd="/tmp"
+            )
+
+        sp_ret_code = flatc_proc.wait()
+
+        temp_json = temp_fname + ".json"
+
+        if sp_ret_code != 0 or not Path(temp_json).is_file():
+            raise ChildProcessError(
+                f"A problem occured during flatbuffers object to json conversion using flatc!\
+                The file {temp_json} was not properly created. Has the fbs schema file the `root_type` directive set?"
+            )
+
+        with open(temp_json, "r") as tmp_f:
+            json_dict = json.loads(tmp_f.read())
+    finally:
+        try:
+            os.remove(temp_fname)
+            os.remove(temp_json)
+        except (FileNotFoundError, UnboundLocalError):
+            pass
 
     return json_dict

--- a/seerep_msgs/fbs/attributes_stamped.fbs
+++ b/seerep_msgs/fbs/attributes_stamped.fbs
@@ -7,3 +7,5 @@ table AttributesStamped {
   header:Header;
   attribute:[UnionMapEntry];
 }
+
+root_type AttributesStamped;

--- a/seerep_msgs/fbs/boundingbox.fbs
+++ b/seerep_msgs/fbs/boundingbox.fbs
@@ -1,4 +1,3 @@
-
 include "point.fbs";
 include "quaternion.fbs";
 
@@ -9,3 +8,5 @@ table Boundingbox {
   spatial_extent:Point;
   rotation:Quaternion;
 }
+
+root_type Boundingbox;

--- a/seerep_msgs/fbs/boundingbox2d.fbs
+++ b/seerep_msgs/fbs/boundingbox2d.fbs
@@ -1,4 +1,3 @@
-
 include "point2d.fbs";
 
 namespace seerep.fb;
@@ -8,3 +7,5 @@ table Boundingbox2D {
   spatial_extent:Point2D;
   rotation:float;
 }
+
+root_type Boundingbox2D;

--- a/seerep_msgs/fbs/boundingbox2d_labeled.fbs
+++ b/seerep_msgs/fbs/boundingbox2d_labeled.fbs
@@ -1,4 +1,3 @@
-
 include "boundingbox2d.fbs";
 include "label_with_instance.fbs";
 
@@ -8,3 +7,5 @@ table BoundingBox2DLabeled {
   labelWithInstance:LabelWithInstance;
   bounding_box:seerep.fb.Boundingbox2D;
 }
+
+root_type BoundingBox2DLabeled;

--- a/seerep_msgs/fbs/boundingbox2d_labeled_with_category.fbs
+++ b/seerep_msgs/fbs/boundingbox2d_labeled_with_category.fbs
@@ -1,4 +1,3 @@
-
 include "boundingbox2d_labeled.fbs";
 
 namespace seerep.fb;
@@ -7,3 +6,5 @@ table BoundingBox2DLabeledWithCategory {
   category:string;
   boundingBox2dLabeled:[BoundingBox2DLabeled];
 }
+
+root_type BoundingBox2DLabeledWithCategory;

--- a/seerep_msgs/fbs/boundingbox2d_stamped.fbs
+++ b/seerep_msgs/fbs/boundingbox2d_stamped.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "boundingbox2d.fbs";
 
@@ -8,3 +7,5 @@ table Boundingbox2DStamped {
   header:seerep.fb.Header;
   boundingbox2D:seerep.fb.Boundingbox2D;
 }
+
+root_type Boundingbox2DStamped;

--- a/seerep_msgs/fbs/boundingbox_labeled.fbs
+++ b/seerep_msgs/fbs/boundingbox_labeled.fbs
@@ -1,4 +1,3 @@
-
 include "boundingbox.fbs";
 include "label_with_instance.fbs";
 
@@ -8,3 +7,5 @@ table BoundingBoxLabeled {
   labelWithInstance:LabelWithInstance;
   bounding_box:seerep.fb.Boundingbox;
 }
+
+root_type BoundingBoxLabeled;

--- a/seerep_msgs/fbs/boundingbox_labeled_with_category.fbs
+++ b/seerep_msgs/fbs/boundingbox_labeled_with_category.fbs
@@ -1,4 +1,3 @@
-
 include "boundingbox_labeled.fbs";
 include "label_with_instance.fbs";
 
@@ -8,3 +7,5 @@ table BoundingBoxLabeledWithCategory {
   category:string;
   boundingBoxLabeled:[BoundingBoxLabeled];
 }
+
+root_type BoundingBoxLabeledWithCategory;

--- a/seerep_msgs/fbs/boundingbox_stamped.fbs
+++ b/seerep_msgs/fbs/boundingbox_stamped.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "boundingbox.fbs";
 
@@ -8,3 +7,5 @@ table BoundingboxStamped {
   header:seerep.fb.Header;
   boundingbox:seerep.fb.Boundingbox;
 }
+
+root_type BoundingboxStamped;

--- a/seerep_msgs/fbs/boundingboxes2d_labeled_stamped.fbs
+++ b/seerep_msgs/fbs/boundingboxes2d_labeled_stamped.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "boundingbox2d_labeled_with_category.fbs";
 
@@ -8,3 +7,5 @@ table BoundingBoxes2DLabeledStamped {
   header:seerep.fb.Header;
   labels_bb:[seerep.fb.BoundingBox2DLabeledWithCategory];
 }
+
+root_type BoundingBoxes2DLabeledStamped;

--- a/seerep_msgs/fbs/boundingboxes_labeled_stamped.fbs
+++ b/seerep_msgs/fbs/boundingboxes_labeled_stamped.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "boundingbox_labeled_with_category.fbs";
 
@@ -8,3 +7,5 @@ table BoundingBoxesLabeledStamped {
   header:seerep.fb.Header;
   labels_bb:[seerep.fb.BoundingBoxLabeledWithCategory];
 }
+
+root_type BoundingBoxesLabeledStamped;

--- a/seerep_msgs/fbs/camera_intrinsics.fbs
+++ b/seerep_msgs/fbs/camera_intrinsics.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "region_of_interest.fbs";
 

--- a/seerep_msgs/fbs/camera_intrinsics.fbs
+++ b/seerep_msgs/fbs/camera_intrinsics.fbs
@@ -19,3 +19,5 @@ table CameraIntrinsics
     region_of_interest:RegionOfInterest;
     maximum_viewing_distance:double;
 }
+
+root_type CameraIntrinsics;

--- a/seerep_msgs/fbs/camera_intrinsics_query.fbs
+++ b/seerep_msgs/fbs/camera_intrinsics_query.fbs
@@ -1,7 +1,8 @@
-
 namespace seerep.fb;
 
 table CameraIntrinsicsQuery {
     uuid_camera_intrinsics:string;
     uuid_project:string;
 }
+
+root_type CameraIntrinsicsQuery;

--- a/seerep_msgs/fbs/categories.fbs
+++ b/seerep_msgs/fbs/categories.fbs
@@ -1,6 +1,7 @@
-
 namespace seerep.fb;
 
 table Categories {
   categories:[string];
 }
+
+root_type Categories;

--- a/seerep_msgs/fbs/datatype.fbs
+++ b/seerep_msgs/fbs/datatype.fbs
@@ -1,4 +1,3 @@
-
 namespace seerep.fb;
 
 enum Datatype:byte {

--- a/seerep_msgs/fbs/empty.fbs
+++ b/seerep_msgs/fbs/empty.fbs
@@ -1,5 +1,6 @@
-
 namespace seerep.fb;
 
 table Empty {
 }
+
+root_type Empty;

--- a/seerep_msgs/fbs/frame_infos.fbs
+++ b/seerep_msgs/fbs/frame_infos.fbs
@@ -4,3 +4,5 @@ table FrameInfos
 {
   frames:[string];
 }
+
+root_type FrameInfos;

--- a/seerep_msgs/fbs/frame_query.fbs
+++ b/seerep_msgs/fbs/frame_query.fbs
@@ -4,3 +4,5 @@ table FrameQuery
 {
   projectuuid:string;
 }
+
+root_type FrameQuery;

--- a/seerep_msgs/fbs/geodeticCoordinates.fbs
+++ b/seerep_msgs/fbs/geodeticCoordinates.fbs
@@ -9,3 +9,5 @@ table GeodeticCoordinates {
     latitude:double; // latitude measured in radians
     altitude:double; // ellipsoidal height measured as a distance
 }
+
+root_type GeodeticCoordinates;

--- a/seerep_msgs/fbs/header.fbs
+++ b/seerep_msgs/fbs/header.fbs
@@ -9,3 +9,5 @@ table Header {
   uuid_project:string;
   uuid_msgs:string;
 }
+
+root_type Header;

--- a/seerep_msgs/fbs/image.fbs
+++ b/seerep_msgs/fbs/image.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "boundingbox2d_labeled_with_category.fbs";
 include "labels_with_instance_with_category.fbs";
@@ -17,3 +16,5 @@ table Image {
   labels_bb:[BoundingBox2DLabeledWithCategory];
   uuid_cameraintrinsics:string;
 }
+
+root_type Image;

--- a/seerep_msgs/fbs/label.fbs
+++ b/seerep_msgs/fbs/label.fbs
@@ -1,7 +1,8 @@
-
 namespace seerep.fb;
 
 table Label {
   label:string;
   confidence:float;
 }
+
+root_type Label;

--- a/seerep_msgs/fbs/label_with_instance.fbs
+++ b/seerep_msgs/fbs/label_with_instance.fbs
@@ -1,4 +1,3 @@
-
 include "label.fbs";
 
 namespace seerep.fb;
@@ -7,3 +6,5 @@ table LabelWithInstance {
   label:Label;
   instanceUuid:string;
 }
+
+root_type LabelWithInstance;

--- a/seerep_msgs/fbs/labels.fbs
+++ b/seerep_msgs/fbs/labels.fbs
@@ -1,6 +1,7 @@
-
 namespace seerep.fb;
 
 table Labels {
   labels:[string];
 }
+
+root_type Labels;

--- a/seerep_msgs/fbs/labels_with_category.fbs
+++ b/seerep_msgs/fbs/labels_with_category.fbs
@@ -1,4 +1,3 @@
-
 include "label.fbs";
 
 namespace seerep.fb;
@@ -7,3 +6,5 @@ table LabelsWithCategory {
   category:string;
   labels:[Label];
 }
+
+root_type LabelsWithCategory;

--- a/seerep_msgs/fbs/labels_with_instance_with_category.fbs
+++ b/seerep_msgs/fbs/labels_with_instance_with_category.fbs
@@ -1,4 +1,3 @@
-
 include "label_with_instance.fbs";
 
 namespace seerep.fb;
@@ -7,3 +6,5 @@ table LabelsWithInstanceWithCategory {
   category:string;
   labelsWithInstance:[LabelWithInstance];
 }
+
+root_type LabelsWithInstanceWithCategory;

--- a/seerep_msgs/fbs/point.fbs
+++ b/seerep_msgs/fbs/point.fbs
@@ -6,3 +6,5 @@ table Point {
   y:double;
   z:double;
 }
+
+root_type Point;

--- a/seerep_msgs/fbs/point.fbs
+++ b/seerep_msgs/fbs/point.fbs
@@ -1,4 +1,3 @@
-
 namespace seerep.fb;
 
 table Point {

--- a/seerep_msgs/fbs/point2d.fbs
+++ b/seerep_msgs/fbs/point2d.fbs
@@ -1,7 +1,8 @@
-
 namespace seerep.fb;
 
 table Point2D {
   x:double;
   y:double;
 }
+
+root_type Point2D;

--- a/seerep_msgs/fbs/point_cloud_2.fbs
+++ b/seerep_msgs/fbs/point_cloud_2.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "boundingbox_labeled_with_category.fbs";
 include "labels_with_instance_with_category.fbs";
@@ -19,3 +18,5 @@ table PointCloud2 {
   labels_general:[LabelsWithInstanceWithCategory];
   labels_bb:[BoundingBoxLabeledWithCategory];
 }
+
+root_type PointCloud2;

--- a/seerep_msgs/fbs/point_field.fbs
+++ b/seerep_msgs/fbs/point_field.fbs
@@ -1,4 +1,3 @@
-
 namespace seerep.fb;
 
 enum Point_Field_Datatype : int {
@@ -19,3 +18,5 @@ table PointField {
   datatype:Point_Field_Datatype;
   count:uint;
 }
+
+root_type PointField;

--- a/seerep_msgs/fbs/point_stamped.fbs
+++ b/seerep_msgs/fbs/point_stamped.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "point.fbs";
 include "labels_with_instance_with_category.fbs";
@@ -12,3 +11,5 @@ table PointStamped {
   labels_general:[LabelsWithInstanceWithCategory];
   attribute:[UnionMapEntry];
 }
+
+root_type PointStamped;

--- a/seerep_msgs/fbs/polygon.fbs
+++ b/seerep_msgs/fbs/polygon.fbs
@@ -1,4 +1,3 @@
-
 include "point.fbs";
 
 namespace seerep.fb;
@@ -6,3 +5,5 @@ namespace seerep.fb;
 table Polygon {
   points:[seerep.fb.Point];
 }
+
+root_type Polygon;

--- a/seerep_msgs/fbs/polygon2d.fbs
+++ b/seerep_msgs/fbs/polygon2d.fbs
@@ -1,4 +1,3 @@
-
 include "point2d.fbs";
 
 namespace seerep.fb;
@@ -8,3 +7,5 @@ table Polygon2D {
     z:double;
     height:double;
 }
+
+root_type Polygon2D;

--- a/seerep_msgs/fbs/polygon_stamped.fbs
+++ b/seerep_msgs/fbs/polygon_stamped.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "polygon.fbs";
 
@@ -8,3 +7,5 @@ table PolygonStamped {
   header:seerep.fb.Header;
   polygon:seerep.fb.Polygon;
 }
+
+root_type PolygonStamped;

--- a/seerep_msgs/fbs/pose.fbs
+++ b/seerep_msgs/fbs/pose.fbs
@@ -1,4 +1,3 @@
-
 include "point.fbs";
 include "quaternion.fbs";
 
@@ -8,3 +7,5 @@ table Pose {
   position:seerep.fb.Point;
   orientation:seerep.fb.Quaternion;
 }
+
+root_type Pose;

--- a/seerep_msgs/fbs/pose_stamped.fbs
+++ b/seerep_msgs/fbs/pose_stamped.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "pose.fbs";
 
@@ -8,3 +7,5 @@ table PoseStamped {
   header:seerep.fb.Header;
   pose:seerep.fb.Pose;
 }
+
+root_type PoseStamped;

--- a/seerep_msgs/fbs/projectCreation.fbs
+++ b/seerep_msgs/fbs/projectCreation.fbs
@@ -7,3 +7,5 @@ table ProjectCreation {
   map_frame_id:string;
   geodetic_position:seerep.fb.GeodeticCoordinates;
 }
+
+root_type ProjectCreation;

--- a/seerep_msgs/fbs/project_info.fbs
+++ b/seerep_msgs/fbs/project_info.fbs
@@ -10,3 +10,5 @@ table ProjectInfo
   geodetic_position:seerep.fb.GeodeticCoordinates;
   version:string;
 }
+
+root_type ProjectInfo;

--- a/seerep_msgs/fbs/project_infos.fbs
+++ b/seerep_msgs/fbs/project_infos.fbs
@@ -6,3 +6,5 @@ table ProjectInfos
 {
   projects:[seerep.fb.ProjectInfo];
 }
+
+root_type ProjectInfos;

--- a/seerep_msgs/fbs/quaternion.fbs
+++ b/seerep_msgs/fbs/quaternion.fbs
@@ -1,4 +1,3 @@
-
 namespace seerep.fb;
 
 table Quaternion {
@@ -7,3 +6,5 @@ table Quaternion {
   z:double;
   w:double;
 }
+
+root_type Quaternion;

--- a/seerep_msgs/fbs/quaternion_stamped.fbs
+++ b/seerep_msgs/fbs/quaternion_stamped.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "quaternion.fbs";
 
@@ -8,3 +7,5 @@ table QuaternionStamped {
   header:seerep.fb.Header;
   quaternion:seerep.fb.Quaternion;
 }
+
+root_type QuaternionStamped;

--- a/seerep_msgs/fbs/query.fbs
+++ b/seerep_msgs/fbs/query.fbs
@@ -1,4 +1,3 @@
-
 include "time_interval.fbs";
 include "labels_with_category.fbs";
 include "polygon2d.fbs";
@@ -22,3 +21,5 @@ table Query {
   maxNumData:uint;
   sortByTime:bool;
 }
+
+root_type Query;

--- a/seerep_msgs/fbs/query_instance.fbs
+++ b/seerep_msgs/fbs/query_instance.fbs
@@ -1,4 +1,3 @@
-
 include "datatype.fbs";
 include "query.fbs";
 
@@ -8,3 +7,5 @@ table QueryInstance {
   datatype:Datatype;
   query:Query;
 }
+
+root_type QueryInstance;

--- a/seerep_msgs/fbs/region_of_interest.fbs
+++ b/seerep_msgs/fbs/region_of_interest.fbs
@@ -1,4 +1,3 @@
-
 namespace seerep.fb;
 
 table RegionOfInterest
@@ -9,3 +8,5 @@ table RegionOfInterest
     width:uint32;
     do_rectify:bool;
 }
+
+root_type RegionOfInterest;

--- a/seerep_msgs/fbs/server_response.fbs
+++ b/seerep_msgs/fbs/server_response.fbs
@@ -1,4 +1,3 @@
-
 include "timestamp.fbs";
 
 namespace seerep.fb;
@@ -14,3 +13,5 @@ table ServerResponse {
   message:string;
   transmission_state:seerep.fb.TRANSMISSION_STATE;
 }
+
+root_type ServerResponse;

--- a/seerep_msgs/fbs/sparql_query.fbs
+++ b/seerep_msgs/fbs/sparql_query.fbs
@@ -1,4 +1,3 @@
-
 namespace seerep.fb;
 
 table SparqlQuery {
@@ -6,3 +5,5 @@ table SparqlQuery {
   sparql:string;
   variableNameOfCategory:string;
 }
+
+root_type SparqlQuery;

--- a/seerep_msgs/fbs/time_interval.fbs
+++ b/seerep_msgs/fbs/time_interval.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "timestamp.fbs";
 
@@ -9,3 +8,5 @@ table TimeInterval {
   time_min:seerep.fb.Timestamp;
   time_max:seerep.fb.Timestamp;
 }
+
+root_type TimeInterval;

--- a/seerep_msgs/fbs/timestamp.fbs
+++ b/seerep_msgs/fbs/timestamp.fbs
@@ -1,4 +1,3 @@
-
 namespace seerep.fb;
 
 // https://github.com/ros2/rcl_interfaces/blob/master/builtin_interfaces/msg/Time.msg
@@ -6,3 +5,5 @@ table Timestamp {
   seconds:int32;
   nanos:uint32;
 }
+
+root_type Timestamp;

--- a/seerep_msgs/fbs/transform.fbs
+++ b/seerep_msgs/fbs/transform.fbs
@@ -1,4 +1,3 @@
-
 include "vector3.fbs";
 include "quaternion.fbs";
 
@@ -8,3 +7,5 @@ table Transform {
   translation:seerep.fb.Vector3;
   rotation:seerep.fb.Quaternion;
 }
+
+root_type Transform;

--- a/seerep_msgs/fbs/transform_stamped.fbs
+++ b/seerep_msgs/fbs/transform_stamped.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "transform.fbs";
 
@@ -10,3 +9,5 @@ table TransformStamped {
   transform:seerep.fb.Transform;
   is_static:bool;
 }
+
+root_type TransformStamped;

--- a/seerep_msgs/fbs/transform_stamped_query.fbs
+++ b/seerep_msgs/fbs/transform_stamped_query.fbs
@@ -7,3 +7,5 @@ table TransformStampedQuery
   header:seerep.fb.Header;
   child_frame_id:string;
 }
+
+root_type TransformStampedQuery;

--- a/seerep_msgs/fbs/twist.fbs
+++ b/seerep_msgs/fbs/twist.fbs
@@ -1,4 +1,3 @@
-
 include "vector3.fbs";
 
 namespace seerep.fb;
@@ -7,3 +6,5 @@ table Twist {
   linear:seerep.fb.Vector3;
   angular:seerep.fb.Vector3;
 }
+
+root_type Twist;

--- a/seerep_msgs/fbs/twist_stamped.fbs
+++ b/seerep_msgs/fbs/twist_stamped.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "twist.fbs";
 
@@ -8,3 +7,5 @@ table TwistStamped {
   header:seerep.fb.Header;
   twist:seerep.fb.Twist;
 }
+
+root_type TwistStamped;

--- a/seerep_msgs/fbs/twist_with_covariance.fbs
+++ b/seerep_msgs/fbs/twist_with_covariance.fbs
@@ -1,4 +1,3 @@
-
 include "twist.fbs";
 
 namespace seerep.fb;
@@ -7,3 +6,5 @@ table TwistWithCovariance {
   twist:seerep.fb.Twist;
   covariance:[double];
 }
+
+root_type TwistWithCovariance;

--- a/seerep_msgs/fbs/twist_with_covariance_stamped.fbs
+++ b/seerep_msgs/fbs/twist_with_covariance_stamped.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "twist_with_covariance.fbs";
 
@@ -8,3 +7,5 @@ table TwistWithCovarianceStamped {
   header:seerep.fb.Header;
   twist:seerep.fb.TwistWithCovariance;
 }
+
+root_type TwistWithCovarianceStamped;

--- a/seerep_msgs/fbs/uuid_datatype_pair.fbs
+++ b/seerep_msgs/fbs/uuid_datatype_pair.fbs
@@ -1,4 +1,3 @@
-
 include "datatype.fbs";
 
 namespace seerep.fb;
@@ -7,3 +6,5 @@ table UuidDatatypePair {
     projectuuid:string;
     datatype:Datatype;
 }
+
+root_type UuidDatatypePair;

--- a/seerep_msgs/fbs/uuid_datatype_with_category.fbs
+++ b/seerep_msgs/fbs/uuid_datatype_with_category.fbs
@@ -1,4 +1,3 @@
-
 include "uuid_datatype_pair.fbs";
 
 namespace seerep.fb;
@@ -7,3 +6,5 @@ table UuidDatatypeWithCategory {
     category:string;
     UuidAndDatatype:UuidDatatypePair;
 }
+
+root_type UuidDatatypeWithCategory;

--- a/seerep_msgs/fbs/uuids_per_project.fbs
+++ b/seerep_msgs/fbs/uuids_per_project.fbs
@@ -1,4 +1,3 @@
-
 include "uuids_project_pair.fbs";
 
 namespace seerep.fb;
@@ -6,3 +5,5 @@ namespace seerep.fb;
 table UuidsPerProject {
   uuidsPerProject:[seerep.fb.UuidsProjectPair];
 }
+
+root_type UuidsPerProject;

--- a/seerep_msgs/fbs/uuids_project_pair.fbs
+++ b/seerep_msgs/fbs/uuids_project_pair.fbs
@@ -1,7 +1,8 @@
-
 namespace seerep.fb;
 
 table UuidsProjectPair {
   projectUuid:string;
   uuids:[string];
 }
+
+root_type UuidsProjectPair;

--- a/seerep_msgs/fbs/vector3.fbs
+++ b/seerep_msgs/fbs/vector3.fbs
@@ -1,4 +1,3 @@
-
 namespace seerep.fb;
 
 table Vector3 {
@@ -6,3 +5,5 @@ table Vector3 {
   y:double;
   z:double;
 }
+
+root_type Vector3;

--- a/seerep_msgs/fbs/vector3_stamped.fbs
+++ b/seerep_msgs/fbs/vector3_stamped.fbs
@@ -1,4 +1,3 @@
-
 include "header.fbs";
 include "vector3.fbs";
 
@@ -8,3 +7,5 @@ table Vector3Stamped {
   header:seerep.fb.Header;
   vector:seerep.fb.Vector3;
 }
+
+root_type Vector3Stamped;

--- a/tests/python/gRPC/images/test_gRPC_fb_addAndGetCameraIntrinsics.py
+++ b/tests/python/gRPC/images/test_gRPC_fb_addAndGetCameraIntrinsics.py
@@ -4,16 +4,16 @@
 
 from gRPC.images import gRPC_fb_addCameraIntrinsics as add_ci
 from gRPC.images import gRPC_fb_getCameraIntrinsics as get_ci
-from seerep.util import fb_to_dict
+from seerep.util.fb_to_dict import SchemaFileNames, fb_flatc_dict
 
 
 def test_addAndGetCameraIntrinsics(grpc_channel, project_setup):
     _, proj_uuid = project_setup
 
-    sent_ci = add_ci.add_camintrins(target_proj_uuid=proj_uuid, grpc_channel=grpc_channel)
+    sent_ci = add_ci.add_camintrins_raw(target_proj_uuid=proj_uuid, grpc_channel=grpc_channel)
 
-    sent_ci_dict = fb_to_dict.fb_obj_to_dict(sent_ci)
+    sent_ci_dict = fb_flatc_dict(sent_ci, SchemaFileNames.CAMERA_INTRINSICS)
 
-    queried_ci = get_ci.get_camintrins(sent_ci_dict["Header"]["UuidMsgs"], proj_uuid, grpc_channel)
+    queried_ci = get_ci.get_camintrins_raw(sent_ci_dict["header"]["uuid_msgs"], proj_uuid, grpc_channel)
 
-    assert sent_ci_dict == fb_to_dict.fb_obj_to_dict(queried_ci)
+    assert sent_ci_dict == fb_flatc_dict(queried_ci, SchemaFileNames.CAMERA_INTRINSICS)

--- a/tests/python/gRPC/meta/test_gRPC_fb_createGeodeticCoordProject.py
+++ b/tests/python/gRPC/meta/test_gRPC_fb_createGeodeticCoordProject.py
@@ -1,54 +1,51 @@
 # test file for
-#   gRPC_fb_createGeodeticCoordProject.py
+# gRPC_fb_createGeodeticCoordProject.py
 # requires:
-#   gRPC_fb_getProjects.py
-from typing import List
-
+# gRPC_fb_getProjects.py
 import flatbuffers
+from boltons.iterutils import remap
 from gRPC.meta import gRPC_fb_createGeodeticCoordProject as project_creation
 from gRPC.meta import gRPC_fb_getProjects as projects_query
-from seerep.fb import ProjectInfo as PI
-from seerep.util import fb_helper, fb_to_dict
+from seerep.util import common, fb_helper
+from seerep.util.fb_to_dict import SchemaFileNames, fb_flatc_dict
 
 
 def test_gRPC_fb_createGeoProjectAndGetProjects(grpc_channel):
     # get already created projects
-    current_projects = projects_query.get_projects(grpc_channel)
+    current_projects = remap(
+        fb_flatc_dict(projects_query.get_projects(grpc_channel), SchemaFileNames.PROJECT_INFOS)["projects"],
+        visit=common.remap_to_snake_case,
+    )
 
-    # contains the flatbuffers buffer objects of the projects
-    created_projects: List[PI.ProjectInfo] = []
     # create_project returns Tuple[str, str] = (<project_name>, <project_uuid>)
-    created_projects.append(project_creation.create_geo_proj(grpc_channel))
-    created_projects.append(project_creation.create_geo_proj(grpc_channel))
+    created_project = remap(
+        fb_flatc_dict(project_creation.create_geo_proj_raw(grpc_channel), SchemaFileNames.PROJECT_INFO),
+        visit=common.remap_to_snake_case,
+    )
 
     # get a list of all created projects
-    projects_list: List[PI.ProjectInfo] = projects_query.get_projects(grpc_channel)
-
-    created_projects_dicts = [fb_to_dict.fb_obj_to_dict(p_dict) for p_dict in created_projects]
-    queried_projects_dicts = [fb_to_dict.fb_obj_to_dict(p_dict) for p_dict in projects_list]
+    projects_list = remap(
+        fb_flatc_dict(projects_query.get_projects(grpc_channel), SchemaFileNames.PROJECT_INFOS)["projects"],
+        visit=common.remap_to_snake_case,
+    )
 
     # check if count of created projects matches the count of the newly queried projects,
     # returned by the gRPC_pb_getProjects example
-    assert len(projects_list) - len(current_projects) == len(created_projects)
+    assert len(projects_list) - len(current_projects) == 1
 
     # manually check if the project parameters are correct
-    for proj_info in created_projects:
-        proj_name = proj_info.Name().decode("utf-8")
-        proj_uuid = proj_info.Uuid().decode("utf-8")
-        assert proj_name == "geodeticProject"
-        assert proj_uuid != ""
-        assert proj_info.Frameid().decode("utf-8") == "2"
-        assert proj_info.GeodeticPosition().CoordinateSystem().decode("utf-8") == "EPSG::4326"
-        # missing
-        # assert proj_info.Datum().decode("utf-8") == "EPSG::7030"
-        assert proj_info.GeodeticPosition().Altitude() == 4.0
-        assert proj_info.GeodeticPosition().Latitude() == 6.0
-        assert proj_info.GeodeticPosition().Longitude() == 7.0
-        assert proj_info.Version() is not None
+    assert created_project["name"] == "geodeticProject"
+    assert created_project["uuid"] != ""
+    assert created_project["frameid"] == "2"
 
-    for proj_info in created_projects_dicts:
-        assert proj_info in queried_projects_dicts
+    assert created_project["geodetic_position"]["coordinate_system"] == "EPSG::4326"
+    assert created_project["geodetic_position"]["altitude"] == 4.0
+    assert created_project["geodetic_position"]["latitude"] == 6.0
+    assert created_project["geodetic_position"]["longitude"] == 7.0
+    assert created_project["version"] is not None
 
-        # teardown
-        builder = flatbuffers.Builder(1024)
-        fb_helper.deleteProject(grpc_channel, builder, proj_info["Name"], proj_info["Uuid"])
+    assert created_project in projects_list
+
+    # teardown
+    builder = flatbuffers.Builder(1024)
+    fb_helper.deleteProject(grpc_channel, builder, created_project["name"], created_project["uuid"])

--- a/tests/python/gRPC/point/test_gRPC_fb_sendAndQueryPoints.py
+++ b/tests/python/gRPC/point/test_gRPC_fb_sendAndQueryPoints.py
@@ -3,21 +3,15 @@
 #   gRPC_fb_sendPointsBasedOnImageInstances.py
 # requires:
 #   gRPC_pb_sendLabeledImageGrid.py
-from typing import Dict, List, Tuple, Type
+from typing import List
 
 from gRPC.images import gRPC_pb_sendLabeledImageGrid as send_grid
 from gRPC.point import gRPC_fb_queryPoints as query_points
 from gRPC.point import gRPC_fb_sendPointsBasedOnImageInstances as send_points
 from seerep.fb import (
-    Boolean,
-    Datatypes,
-    Double,
-    Integer,
     PointStamped,
-    String,
-    UnionMapEntry,
 )
-from seerep.util import fb_to_dict
+from seerep.util.fb_to_dict import SchemaFileNames, fb_flatc_dict
 
 
 # todo: test query dependant on tf
@@ -27,51 +21,39 @@ def test_sendAndQueryPoints(grpc_channel, project_setup):
     # send images to the project
     send_grid.send_labeled_image_grid(proj_uuid, grpc_channel)
 
-    # send points to the project
-    sent_points_dict: Dict = send_points.send_points(proj_uuid, grpc_channel)
-
     # extract the sent points to a list
-    sent_plist: List[PointStamped.PointStamped] = sorted(
-        [p for ls in sent_points_dict.values() for p in ls],
-        key=lambda p: p.Header().UuidMsgs().decode(),
+    sent_points: List[PointStamped.PointStamped] = sorted(
+        [
+            fb_flatc_dict(p, SchemaFileNames.POINT_STAMPED)
+            for ls in send_points.send_points_raw(proj_uuid, grpc_channel).values()
+            for p in ls
+        ],
+        key=lambda p: p["header"]["uuid_msgs"],
     )
 
     # query points from the project
     queried_points: List[PointStamped.PointStamped] = sorted(
-        query_points.get_points(proj_uuid, grpc_channel),
-        key=lambda p: p.Header().UuidMsgs().decode(),
+        [
+            fb_flatc_dict(point, SchemaFileNames.POINT_STAMPED)
+            for point in query_points.get_points_raw(proj_uuid, grpc_channel)
+        ],
+        key=lambda p: p["header"]["uuid_msgs"],
     )
 
-    assert len(sent_plist) == len(queried_points)
-
-    # build union type mapping
-    union_type_mapping: Dict[Type, Tuple[str, List[Tuple[int, Type]]]] = {
-        UnionMapEntry.UnionMapEntry: (
-            "Value",
-            [
-                (Datatypes.Datatypes().Boolean, Boolean.Boolean),
-                (Datatypes.Datatypes().Integer, Integer.Integer),
-                (Datatypes.Datatypes().Double, Double.Double),
-                (Datatypes.Datatypes().String, String.String),
-            ],
-        )
-    }
+    assert len(sent_points) == len(queried_points)
 
     # Fix current discrepancy between the sent and queried points in the attributes,
     # because the queried points contain the header additionally
-    # convert fb objects to dicts
-    sent_pdicts_list = [fb_to_dict.fb_obj_to_dict(p, union_type_mapping=union_type_mapping) for p in sent_plist]
-    queried_pdicts_list = [fb_to_dict.fb_obj_to_dict(p, union_type_mapping=union_type_mapping) for p in queried_points]
 
     # remove the header entries of the queried points from the attributes
-    for p in queried_pdicts_list:
+    for p in queried_points:
         # sort attribute lists
-        p["Attribute"] = sorted(p["Attribute"], key=lambda a: a["Key"])
+        p["attribute"] = sorted(p["attribute"], key=lambda a: a["key"])
 
-        p_l = p["Attribute"]
+        p_l = p["attribute"]
         idx = 0
         while idx < len(p_l):
-            if p_l[idx]["Key"] in [
+            if p_l[idx]["key"] in [
                 "frame_id",
                 "header_seq",
                 "stamp_nanos",
@@ -82,9 +64,7 @@ def test_sendAndQueryPoints(grpc_channel, project_setup):
                 idx += 1
 
     # sort attribute lists
-    for p in sent_pdicts_list:
-        p["Attribute"] = sorted(p["Attribute"], key=lambda a: a["Key"])
+    for p in sent_points:
+        p["attribute"] = sorted(p["attribute"], key=lambda a: a["key"])
 
-    # check if the queried points are the same as the sent points
-    assert len(queried_pdicts_list) == len(sent_pdicts_list)
-    assert queried_pdicts_list == sent_pdicts_list
+    assert sent_points == queried_points

--- a/tests/python/gRPC/pointcloud/test_gRPC_fb_addBoundingBoxPcl.py
+++ b/tests/python/gRPC/pointcloud/test_gRPC_fb_addBoundingBoxPcl.py
@@ -6,7 +6,7 @@
 from gRPC.pointcloud import gRPC_fb_addBoundingBox as add_bb
 from gRPC.pointcloud import gRPC_fb_queryPointCloud as query_pc
 from gRPC.pointcloud import gRPC_fb_sendPointCloud as send_pc
-from seerep.util import fb_to_dict
+from seerep.util.fb_to_dict import SchemaFileNames, fb_flatc_dict
 
 
 def test_addBoundingBoxToPCs(grpc_channel, project_setup):
@@ -16,40 +16,39 @@ def test_addBoundingBoxToPCs(grpc_channel, project_setup):
     send_pc.send_pointcloud(proj_uuid, grpc_channel)
 
     # add bbs to the point clouds
-    bbs_ls = [
-        fb_to_dict.fb_obj_to_dict(elem)
-        for elem in sorted(
-            add_bb.add_pc_bounding_boxes(proj_uuid, grpc_channel),
-            key=lambda bb: bb.Header().UuidMsgs().decode(),
-        )
-    ]
+    bbs_ls = sorted(
+        [
+            fb_flatc_dict(bb, SchemaFileNames.BOUNDINGBOXES_LABELED_STAMPED)
+            for bb in add_bb.add_pc_bounding_boxes_raw(proj_uuid, grpc_channel)
+        ],
+        key=lambda bb: bb["header"]["uuid_msgs"],
+    )
 
     # query pointclouds
-    queried_pcs = [
-        fb_to_dict.fb_obj_to_dict(elem)
-        for elem in sorted(
-            query_pc.query_pcs(proj_uuid, grpc_channel),
-            key=lambda pc: pc.Header().UuidMsgs().decode(),
-        )
-    ]
+    queried_pcs = sorted(
+        [fb_flatc_dict(pcl, SchemaFileNames.POINT_CLOUD_2) for pcl in query_pc.query_pcs_raw(proj_uuid, grpc_channel)],
+        key=lambda pcl: pcl["header"]["uuid_msgs"],
+    )
 
-    default_rot = {"W": 1.0, "X": 0.0, "Y": 0.0, "Z": 0.0}
+    default_rot = {"w": 1.0}
 
     # sort inner bb list and add rotation to the values as this is set with default values by the server
     for bbs in bbs_ls:
-        for label in bbs["LabelsBb"]:
-            label["BoundingBoxLabeled"].sort(key=lambda bb: bb["LabelWithInstance"]["InstanceUuid"])
-            for bb in label["BoundingBoxLabeled"]:
-                bb["BoundingBox"]["Rotation"] = default_rot
+        for label in bbs["labels_bb"]:
+            label["boundingBoxLabeled"].sort(key=lambda bb: bb["labelWithInstance"]["instanceUuid"])
+            for bb in label["boundingBoxLabeled"]:
+                bb["bounding_box"]["rotation"] = default_rot
 
     for bbs in queried_pcs:
-        for label in bbs["LabelsBb"]:
-            label["BoundingBoxLabeled"].sort(key=lambda bb: bb["LabelWithInstance"]["InstanceUuid"])
+        for label in bbs["labels_bb"]:
+            label["boundingBoxLabeled"].sort(key=lambda bb: bb["labelWithInstance"]["instanceUuid"])
 
     assert len(queried_pcs) == len(bbs_ls)
 
     for idx, pc in enumerate(queried_pcs):
         # filter for labels in category laterAddedBB
-        pc_labeled_bb_with_category = [elem for elem in pc["LabelsBb"] if elem["Category"] == "laterAddedBB"]
-        assert pc["Header"]["UuidMsgs"] == bbs_ls[idx]["Header"]["UuidMsgs"]
-        assert pc_labeled_bb_with_category == bbs_ls[idx]["LabelsBb"]
+        pc_labeled_bb_with_category = [elem for elem in pc["labels_bb"] if elem["category"] == "laterAddedBB"]
+        assert pc["header"]["uuid_msgs"] == bbs_ls[idx]["header"]["uuid_msgs"]
+        print(pc_labeled_bb_with_category)
+        print(bbs_ls[idx]["labels_bb"])
+        assert pc_labeled_bb_with_category == bbs_ls[idx]["labels_bb"]

--- a/tests/python/gRPC/pointcloud/test_gRPC_fb_sendAndQueryPointCloud.py
+++ b/tests/python/gRPC/pointcloud/test_gRPC_fb_sendAndQueryPointCloud.py
@@ -3,7 +3,7 @@
 #   gRPC_fb_sendPointCloud.py
 from gRPC.pointcloud import gRPC_fb_queryPointCloud as query_pc
 from gRPC.pointcloud import gRPC_fb_sendPointCloud as send_pc
-from seerep.util import fb_to_dict
+from seerep.util.fb_to_dict import SchemaFileNames, fb_flatc_dict
 
 
 # todo: test query dependant on tf
@@ -11,19 +11,17 @@ def test_sendAndQueryPCs(grpc_channel, project_setup):
     _, proj_uuid = project_setup
 
     # send pointclouds to the project
-    sent_pcs = [
-        fb_to_dict.fb_obj_to_dict(elem)
-        for elem in sorted(
-            send_pc.send_pointcloud(proj_uuid, grpc_channel),
-            key=lambda pc: pc.Header().UuidMsgs().decode(),
-        )
-    ]
-    queried_pcs = [
-        fb_to_dict.fb_obj_to_dict(elem)
-        for elem in sorted(
-            query_pc.query_pcs(proj_uuid, grpc_channel),
-            key=lambda pc: pc.Header().UuidMsgs().decode(),
-        )
-    ]
+    sent_pcs = sorted(
+        [
+            fb_flatc_dict(pcl, SchemaFileNames.POINT_CLOUD_2)
+            for pcl in send_pc.send_pointcloud_raw(proj_uuid, grpc_channel)
+        ],
+        key=lambda pc: pc["header"]["uuid_msgs"],
+    )
+
+    queried_pcs = sorted(
+        [fb_flatc_dict(pcl, SchemaFileNames.POINT_CLOUD_2) for pcl in query_pc.query_pcs_raw(proj_uuid, grpc_channel)],
+        key=lambda pc: pc["header"]["uuid_msgs"],
+    )
 
     assert queried_pcs == sent_pcs


### PR DESCRIPTION
This PR changes the implementation for `fb_to_dict.py` from a self build unrobust solution to a more flatbuffers native approach. This lessens the amount of complicated code to maintain. For the conversion functionality the flatbuffers compiler `flatc` is invoked using a subprocess.
Also a new utility package [boltons](https://pypi.org/project/boltons/) is introduced to handle recursively renaming dictionary keys to ease comparisons in the tests.

For this the flatbuffers schema files have been edited to include their `root_type`, which is apparently required for `flatc` to recognize the proper type of a buffer. 

Some caveats using this approach over the other are the dependence on a command line tool using the schema files and intermediate temporary files in `/tmp`.