### PR TITLE
Fix multiple CMake warnings

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends -y \
         libtool \
         wget \
         curl \
+        cmake \
         make \
         g++ \
         gdb \
@@ -76,17 +77,6 @@ RUN apt-get update -qq && apt-get -qq install -y --no-install-recommends \
                 clang-format-15 \
                 python3-catkin-lint \
         && rm -rf /var/lib/apt/lists/*
-
-####################################################
-#Install cmake
-####################################################
-RUN curl -s https://apt.kitware.com/kitware-archive.sh -o kitware-archive.sh \
-        && chmod +x kitware-archive.sh \
-        && /kitware-archive.sh \
-        && rm /kitware-archive.sh \
-        && apt-get update -qq && apt-get -qq install --no-install-recommends -y cmake \
-        && rm -rf /var/lib/apt/lists/*
-
 
 ####################################################
 #Install HighFive

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends -y \
         bash-completion \
         autoconf \
         automake \
-        libtool \
         wget \
         curl \
         cmake \
@@ -32,11 +31,8 @@ RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends -y \
         libproj-dev \
         python3-catkin-tools \
         python3-osrf-pycommon \
-        libfile-pushd-perl \
         ros-noetic-vision-msgs \
         ros-noetic-geographic-msgs \
-        libgeographic-dev \
-        libfile-pushd-perl \
         python3-pip \
         flex \
         bison \

--- a/seerep_srv/seerep_core/CMakeLists.txt
+++ b/seerep_srv/seerep_core/CMakeLists.txt
@@ -27,9 +27,7 @@ find_package(
 find_package(catkin REQUIRED COMPONENTS tf2)
 
 find_package(CGAL REQUIRED)
-
-# https://github.com/OSGeo/PROJ/issues/3682
-pkg_check_modules(PROJ REQUIRED IMPORTED_TARGET)
+set(CGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE TRUE)
 
 configure_file(include/SeerepCoreConfig.h.in SeerepCoreConfig.h)
 

--- a/seerep_srv/seerep_core/src/core_project.cpp
+++ b/seerep_srv/seerep_core/src/core_project.cpp
@@ -82,7 +82,7 @@ seerep_core_msgs::Polygon2D CoreProject::transformToMapFrame(const seerep_core_m
   // we traverse the polygon and apply the transform
   for (seerep_core_msgs::Point2D p : polygon.vertices)
   {
-    PJ_COORD c = proj_coord(p.get<0>(), p.get<1>(), NULL, NULL);
+    PJ_COORD c = proj_coord(p.get<0>(), p.get<1>(), 0, 0);
     PJ_COORD t_coord = proj_trans(to_topographic, direction, c);
 
     seerep_core_msgs::Point2D transformed_p;


### PR DESCRIPTION
Summary:

- Downgrade CMake to a version distributed with Ubuntu 20.04 due to incompatibilities with ROS noetic
- Fix CMake warnings generated by CGAL
- Remove unused dependencies from Docker base image

Some warnings will still be around:

```bash
 warning: missing initializer for member ‘seerep_hdf5_core::ImageAttributes::cameraIntrinsicsUuid’ [-Wmissing-field-initializers]
```

`seerep_hdf5_py` has to be updated to support camera intrinsic #305


```bash
warning: unused parameter ‘options’ [-Wunused-parameter]
   25 | std::unique_ptr< ImageService::Stub> ImageService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) 
...
```

The code is generated by `flatc`. Maybe updating to a more recent version would help? Something for a different PR. 