### PR TITLE
Add C/C++ compiler cache Ccache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,71 +4,63 @@ on:
   push:
 
 jobs:
-  hdf5-interface:
-    name: HDF5 Interface
+  Unit-Tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/agri-gaia/seerep_base:latest
     steps:
-    - name: Checkout code
+
+    - name: Checkout Code
       uses: actions/checkout@v4
       with:
         path: src
-    - name: Build seerep_hdf5 packages
+
+    - name: Build Packages
       run: |
         source /opt/ros/noetic/setup.bash
-        catkin build seerep_hdf5_* --workspace $GITHUB_WORKSPACE/
+        catkin build seerep_hdf5_fb seerep_hdf5_pb seerep_ros_conversions_fb --workspace $GITHUB_WORKSPACE/
         source $GITHUB_WORKSPACE/devel/setup.bash
       shell: bash
-    - name: Run flatbuffer tests
+
+    - name: HDF5 Flatbuffer Unit Tests
       run: catkin test seerep_hdf5_fb
       shell: bash
-    - name: Run protobuf tests
+
+    - name: HDF5 Protobuf Unit Tests
       run: catkin test seerep_hdf5_pb
       shell: bash
 
-  ros-converions:
-    name: ROS Conversions
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/agri-gaia/seerep_base:latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        path: src
-    - name: Build seerep_ros packages
-      run: |
-        source /opt/ros/noetic/setup.bash
-        catkin build seerep_ros_* --workspace $GITHUB_WORKSPACE/
-        source $GITHUB_WORKSPACE/devel/setup.bash
-      shell: bash
-    - name: Test flatbuffer conversions
+    - name: ROS Conversions Unit Tests
       run: catkin test seerep_ros_conversions_fb
       shell: bash
 
-  integration-examples:
+  Integration-Tests:
     name: Integration Tests
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/agri-gaia/seerep_base:latest
     steps:
-    - name: Checkout code
+
+    - name: Checkout Code
       uses: actions/checkout@v4
       with:
         path: src
-    - name: Set up python 3.8
+
+    - name: Set up Python 3.8
       run: |
         apt update
         apt install -y python3.8
         ln -s `which python3.8` /usr/local/bin/python
       shell: bash
-    - name: Build seerep
+
+    - name: Build SEEREP
       run: |
         source /opt/ros/noetic/setup.bash
         catkin build --workspace $GITHUB_WORKSPACE
       shell: bash
-    - name: Execute pytest
+
+    - name: Execute Pytest
       run: |
         source $GITHUB_WORKSPACE/devel/setup.bash
         PYTHONPATH=$GITHUB_WORKSPACE/devel/include/seerep_com/fbs:$PYTHONPATH pytest --force-sugar $GITHUB_WORKSPACE/src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,12 @@ jobs:
       with:
         path: src
 
+    - run: apt update
+    - name: Ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        create-symlink: true
+
     - name: Build Packages
       run: |
         source /opt/ros/noetic/setup.bash
@@ -53,6 +59,12 @@ jobs:
         apt install -y python3.8
         ln -s `which python3.8` /usr/local/bin/python
       shell: bash
+
+    - run: apt update
+    - name: Ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        create-symlink: true
 
     - name: Build SEEREP
       run: |

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -142,8 +142,7 @@ RUN curl -LO $PB_REL/download/v$PB_VER/protobuf-cpp-3.$PB_VER.zip \
         && make -j"$(nproc)" \
         && make install \
         && cd ../.. \
-        && rm protobuf-cpp-3.$PB_VER.zip \
-        && rm -rf protobuf-$3.PB_VER
+        && rm -rf protobuf-cpp-3.$PB_VER.zip protobuf-3.$PB_VER
 
 ####################################################
 #Install GoogleTest

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -86,7 +86,7 @@ RUN wget https://github.com/ccache/ccache/releases/download/v4.9.1/ccache-4.9.1.
         && cd ../..  \
         && rm -rf ccache-4.9.1 ccache-4.9.1.tar.gz
 
-RUN ln -sf $(which ccache) /usr/local/bin/g++ && ln -sf $(which ccache) /usr/local/bin/gcc
+RUN ln -sf $(which ccache) /usr/local/bin/c++ && ln -sf $(which ccache) /usr/local/bin/cc
 
 ####################################################
 #Install HighFive

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -18,8 +18,6 @@ RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends -y \
         curl \
         cmake \
         make \
-        g++ \
-        gdb \
         unzip \
         git \
         libcgal-dev \
@@ -57,7 +55,7 @@ RUN pip3 install --upgrade pip \
         && pip3 install -r /tmp/requirements.txt --ignore-installed PyYAML --no-cache-dir \
         && rm /tmp/requirements.txt
 
-        #Install seerep dependencies from apt
+#Install seerep dependencies from apt
 RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends -y \
         ros-noetic-tf \
         ros-noetic-vision-msgs \
@@ -72,7 +70,23 @@ RUN apt-get update -qq && apt-get -qq install -y --no-install-recommends \
                 ruby shellcheck \
                 clang-format-15 \
                 python3-catkin-lint \
-        && rm -rf /var/lib/apt/lists/*
+                && rm -rf /var/lib/apt/lists/*
+
+####################################################
+#Install CCACHE
+####################################################
+
+RUN wget https://github.com/ccache/ccache/releases/download/v4.9.1/ccache-4.9.1.tar.gz \
+        && tar -xf ccache-4.9.1.tar.gz \
+        && mkdir -p ccache-4.9.1/build \
+        && cd ccache-4.9.1/build \
+        && cmake -D CMAKE_BUILD_TYPE=Release .. \
+        && make -j"$(nproc)" \
+        && make install \
+        && cd ../..  \
+        && rm -rf ccache-4.9.1 ccache-4.9.1.tar.gz
+
+RUN ln -sf $(which ccache) /usr/local/bin/g++ && ln -sf $(which ccache) /usr/local/bin/gcc
 
 ####################################################
 #Install HighFive
@@ -90,7 +104,7 @@ RUN git clone --depth 1 -b v2.4.0 $HDF5_REL.git \
         && rm -rf HighFive
 
 ####################################################
-#Install flatbuffer
+#Install Flatbuffers
 ####################################################
 RUN wget https://github.com/google/flatbuffers/archive/refs/tags/v2.0.0.tar.gz \
         && tar -xf v2.0.0.tar.gz \
@@ -117,7 +131,7 @@ RUN git clone --recurse-submodules --depth 1 -b v1.35.0 https://github.com/grpc/
         && rm -rf grpc
 
 ####################################################
-#Install protobuf from github
+#Install Protobuf
 ####################################################
 RUN curl -LO $PB_REL/download/v$PB_VER/protobuf-cpp-3.$PB_VER.zip \
         && unzip protobuf-cpp-3.$PB_VER.zip \
@@ -132,7 +146,7 @@ RUN curl -LO $PB_REL/download/v$PB_VER/protobuf-cpp-3.$PB_VER.zip \
         && rm -rf protobuf-$3.PB_VER
 
 ####################################################
-#Install current googletest release
+#Install GoogleTest
 ####################################################
 
 RUN git clone https://github.com/google/googletest.git -b release-1.12.0 \
@@ -146,10 +160,9 @@ RUN git clone https://github.com/google/googletest.git -b release-1.12.0 \
         && rm -rf googletest
 
 ####################################################
-#Install documentation dependencies
+#Install Doxygen
 ####################################################
 
-#Install doxygen
 RUN wget ${DOX_REL}/${DOX_VER}.tar.gz \
         && tar -xf ${DOX_VER}.tar.gz \
         && mkdir -p doxygen-${DOX_VER}/build \
@@ -173,6 +186,6 @@ RUN echo "source /opt/ros/noetic/setup.bash" >> /home/docker/.bashrc \
         && echo "[[ -e /seerep/devel/setup.bash ]] && source /seerep/devel/setup.bash" >> /home/docker/.bashrc \
         && echo "[[ -e /seerep/devel/setup.zsh ]] && source /seerep/devel/setup.zsh" >> /home/docker/.zshrc
 
-RUN echo 'export PYTHONPATH="${PYTHONPATH}:/seerep/devel/lib:/seerep/devel/include/seerep_com/fbs/"' >> /home/docker/.bashrc
+ENV PYTHONPATH="${PYTHONPATH}:/seerep/devel/lib:/seerep/devel/include/seerep_com/fbs/"
 
 ENTRYPOINT [ "/bin/sh", "-c", "while sleep 1000; do :; done" ]


### PR DESCRIPTION
Summary:

- Remove Protocol Buffers source zip from the Docker base image. Saves around 0.5 GB :astonished:
- Combine unit test into one job in the test action (goal is to avoid compiling the same code twice)
- Add Ccache into Dev-Container
- Add Ccache into test action

The speed-up from using [Cache](https://ccache.dev/) in the Dev-Container is quite large:

| Scenario | Time |
| ------------- | ------------- |
| catkin build | 2m 5s  |
| catkin build with ccache|2m 23s|
| catkin build with ccache (warmed up) | 30s |

The same applies to the test action:

|Test Case | without ccache | with ccache |
| ------------- | ------------- | ------------- |
| Unit Tests | 4m 30s | 2m 2s|
| Integration Tests| 8m 16s   | 4m |

I didn't integrate the cache into the Docker image builds, since they are run so rarely (caches that have not been accessed for more than 7 days will be removed).