### PR TITLE
Fix ccache in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,6 @@ jobs:
       with:
         path: src
 
-    - run: apt update
-    - name: Ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        create-symlink: true
-
     - name: Build Packages
       run: |
         source /opt/ros/noetic/setup.bash
@@ -59,12 +53,6 @@ jobs:
         apt install -y python3.8
         ln -s `which python3.8` /usr/local/bin/python
       shell: bash
-
-    - run: apt update
-    - name: Ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        create-symlink: true
 
     - name: Build SEEREP
       run: |

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -17,6 +17,9 @@ COPY docker/server/start_server.sh src/start_server.sh
 
 RUN /bin/bash -c "source /opt/ros/noetic/setup.bash; catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release; catkin build"
 
+# also remove the configuration next to the actual cache
+RUN rm -r $(ccache -k cache_dir)
+
 EXPOSE 9090
 
 ENTRYPOINT ["/bin/bash", "src/start_server.sh"]


### PR DESCRIPTION
I forgot that ccache would already be included by the base image. Thus, installing it as another step causes problems when creating the symbolic links. 
Additionally, I also added the removal of the ccache cache after building the release, which saves around 100 MB in the final server image.  