### PR TITLE
Defer index creation when storing images using the flatbuffers service

### DIFF
--- a/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_image.h
+++ b/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_image.h
@@ -80,11 +80,12 @@ public:
    * the data has been added to hdf5. The data for the indices is retrieved from hdf5 and added to the indices to the
    * core.
    *
-   * @param projectsImgUuids a mapping from a project uuid to possibly multiple image uuids
+   * @param projectImgUuids a vector containing image uuids mapped to the projects where they reside.
+   * The first slot contains the project uuid and the second slot the image uuid.
    *
    * @see seerep_core_fb::CoreFbImage::addDataToHdf5
    */
-  void buildIndices(const std::unordered_map<std::string, std::vector<boost::uuids::uuid>>& projectsImgUuids);
+  void buildIndices(const std::vector<std::pair<std::string, boost::uuids::uuid>>& projectImgUuids);
 
   /**
    * @brief Adds bounding box based labels to an existing image

--- a/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_image.h
+++ b/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_image.h
@@ -68,8 +68,8 @@ public:
    * @param img the flatbuffer message containing the image
    * @return the uuid of the stored image
    *
-   * The image is stored in the hdf5 file via hdf5-io-fb. The data needed for the indices is extracted and added to the
-   * core. If the uuid of image is not defined yet, a uuid is generated and returned.
+   * The image is stored in the hdf5 file via hdf5-io-fb.
+   * If the uuid of image is not defined yet, a uuid is generated and returned.
    */
   boost::uuids::uuid addDataToHdf5(const seerep::fb::Image& img);
 

--- a/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_image.h
+++ b/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_image.h
@@ -64,14 +64,28 @@ public:
   void getData(const seerep::fb::Query* query,
                grpc::ServerWriter<flatbuffers::grpc::Message<seerep::fb::Image>>* const writer);
   /**
-   * @brief Add an image to the indices and write the data to hdf5
+   * @brief Write image data to hdf5
    * @param img the flatbuffer message containing the image
    * @return the uuid of the stored image
    *
    * The image is stored in the hdf5 file via hdf5-io-fb. The data needed for the indices is extracted and added to the
    * core. If the uuid of image is not defined yet, a uuid is generated and returned.
    */
-  boost::uuids::uuid addData(const seerep::fb::Image& img);
+  boost::uuids::uuid addDataToHdf5(const seerep::fb::Image& img);
+
+  /**
+   * @brief Extract image data from hdf5 and build the indices.
+   *
+   * This method complements @ref addDataToHdf5 and should be called after
+   * the data has been added to hdf5. The data for the indices is retrieved from hdf5 and added to the indices to the
+   * core.
+   *
+   * @param projectsImgUuids a mapping from a project uuid to possibly multiple image uuids
+   *
+   * @see seerep_core_fb::CoreFbImage::addDataToHdf5
+   */
+  void buildIndices(const std::unordered_map<std::string, std::vector<boost::uuids::uuid>>& projectsImgUuids);
+
   /**
    * @brief Adds bounding box based labels to an existing image
    * @param bbs2dlabeled the flatbuffer message containing bounding box based labels

--- a/seerep_srv/seerep_core_fb/src/core_fb_image.cpp
+++ b/seerep_srv/seerep_core_fb/src/core_fb_image.cpp
@@ -67,17 +67,22 @@ void CoreFbImage::buildIndices(const std::unordered_map<std::string, std::vector
   for (auto kv : projectsImgUuids)
   {
     auto hdf5io = CoreFbGeneral::getHdf5(kv.first, m_seerepCore, m_hdf5IoMap);
+
+    // go through all uuids of the project
     for (auto uuid : kv.second)
     {
-      auto optImg = hdf5io->readImage(boost::lexical_cast<std::string>(uuid), true);
-      if (optImg.has_value())
-      {
-        auto img = optImg.value().GetRoot();
-        auto dataForIndices = CoreFbConversion::fromFb(*img);
+      auto optionalImg = hdf5io->readImage(boost::lexical_cast<std::string>(uuid), true);
 
-        hdf5io->computeFrustumBB(img->uuid_cameraintrinsics()->str(), dataForIndices.boundingbox);
-        m_seerepCore->addDataset(dataForIndices);
+      if (!optionalImg.has_value())
+      {
+        return;
       }
+
+      auto img = optionalImg.value().GetRoot();
+      auto dataForIndices = CoreFbConversion::fromFb(*img);
+
+      hdf5io->computeFrustumBB(img->uuid_cameraintrinsics()->str(), dataForIndices.boundingbox);
+      m_seerepCore->addDataset(dataForIndices);
     }
   }
 }


### PR DESCRIPTION
This is part of #350.

Changes:
- addData() for fb images is now split in two methods addDataToHdf5() and buildIndices()
- addDataToHdf5() only writes one image to hdf5
- When all images from a stream have been written to hdf5 buildIndices() can be called to create the indices for the by uuid specified projects and images