### PR TITLE
Defer index creation when storing pointclouds using the flatbuffers service

### DIFF
--- a/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_pointcloud.h
+++ b/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_pointcloud.h
@@ -77,7 +77,7 @@ public:
    *
    * @see seerep_core_fb::CoreFbPointCloud::addDataToHdf5
    */
-  void buildIndices(std::unordered_map<std::string, std::vector<boost::uuids::uuid>> projectPclUuids);
+  void buildIndices(std::vector<std::pair<std::string, boost::uuids::uuid>>& projectPclUuids);
 
   /**
    * @brief Adds bounding box based labels to an existing pointcloud

--- a/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_pointcloud.h
+++ b/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_pointcloud.h
@@ -61,10 +61,10 @@ public:
   /**
    * @brief Write the pointcloud data to hdf5
    *
-   * @param pc the point cloud message to index and save
+   * @param pcl the point cloud message to write
    * @return boost::uuids::uuid the uuid of the stored pointcloud
    */
-  boost::uuids::uuid addDataToHdf5(const seerep::fb::PointCloud2& pc);
+  boost::uuids::uuid addDataToHdf5(const seerep::fb::PointCloud2& pcl);
 
   /**
    * @brief Extract pointcloud data from hdf5 and build the indices.
@@ -73,7 +73,8 @@ public:
    * the data has been added to hdf5. The data for the indices is retrieved from hdf5 and added to the indices to the
    * core.
    *
-   * @param projectPclUuids a mapping from a project uuid to possibly multiple pointcloud2 uuids
+   * @param projectPclUuids a vector of pairs of first project uuids and second pointcloud uuids, where the pointcloud
+   * belongs to the specified project
    *
    * @see seerep_core_fb::CoreFbPointCloud::addDataToHdf5
    */

--- a/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_pointcloud.h
+++ b/seerep_srv/seerep_core_fb/include/seerep_core_fb/core_fb_pointcloud.h
@@ -59,12 +59,26 @@ public:
   void getData(const seerep::fb::Query* query,
                grpc::ServerWriter<flatbuffers::grpc::Message<seerep::fb::PointCloud2>>* const writer);
   /**
-   * @brief Add a point cloud to the indices and write the data to hdf5
+   * @brief Write the pointcloud data to hdf5
    *
    * @param pc the point cloud message to index and save
    * @return boost::uuids::uuid the uuid of the stored pointcloud
    */
-  boost::uuids::uuid addData(const seerep::fb::PointCloud2& pc);
+  boost::uuids::uuid addDataToHdf5(const seerep::fb::PointCloud2& pc);
+
+  /**
+   * @brief Extract pointcloud data from hdf5 and build the indices.
+   *
+   * This method complements @ref addDataToHdf5 and should be called after
+   * the data has been added to hdf5. The data for the indices is retrieved from hdf5 and added to the indices to the
+   * core.
+   *
+   * @param projectPclUuids a mapping from a project uuid to possibly multiple pointcloud2 uuids
+   *
+   * @see seerep_core_fb::CoreFbPointCloud::addDataToHdf5
+   */
+  void buildIndices(std::unordered_map<std::string, std::vector<boost::uuids::uuid>> projectPclUuids);
+
   /**
    * @brief Adds bounding box based labels to an existing pointcloud
    * @param bbslabeled the flatbuffer message containing bounding box based labels

--- a/seerep_srv/seerep_core_fb/src/core_fb_pointcloud.cpp
+++ b/seerep_srv/seerep_core_fb/src/core_fb_pointcloud.cpp
@@ -49,11 +49,10 @@ boost::uuids::uuid CoreFbPointCloud::addDataToHdf5(const seerep::fb::PointCloud2
 void CoreFbPointCloud::buildIndices(std::vector<std::pair<std::string, boost::uuids::uuid>>& projectPclUuids)
 {
   seerep_core_msgs::AABB bb;
-  std::string uuidStr;
   for (auto [projectUuid, pclUuid] : projectPclUuids)
   {
     auto hdf5io = CoreFbGeneral::getHdf5(projectUuid, m_seerepCore, m_hdf5IoMap);
-    uuidStr = boost::lexical_cast<std::string>(pclUuid);
+    auto uuidStr = boost::lexical_cast<std::string>(pclUuid);
 
     auto optionalPcl = hdf5io->readPointCloud2(uuidStr, true);
     hdf5io->readAABB(seerep_hdf5_core::Hdf5CorePointCloud::HDF5_GROUP_POINTCLOUD, uuidStr, bb);

--- a/seerep_srv/seerep_server/src/fb_point_cloud_service.cpp
+++ b/seerep_srv/seerep_server/src/fb_point_cloud_service.cpp
@@ -97,7 +97,7 @@ grpc::Status FbPointCloudService::TransferPointCloud2(
       const std::string& uuidProject = pointCloud->header()->uuid_project()->str();
       if (!uuidProject.empty())
       {
-        pointCloudFb->addData(*pointCloud);
+        pointCloudFb->addDataToHdf5(*pointCloud);
       }
       else
       {

--- a/seerep_srv/seerep_server/src/fb_point_cloud_service.cpp
+++ b/seerep_srv/seerep_server/src/fb_point_cloud_service.cpp
@@ -87,6 +87,7 @@ grpc::Status FbPointCloudService::TransferPointCloud2(
   flatbuffers::grpc::Message<seerep::fb::PointCloud2> pointCloudMsg;
   std::vector<std::pair<std::string, boost::uuids::uuid>> projectPclUuids;
 
+  // write pointcloud data to hdf5
   while (reader->Read(&pointCloudMsg))
   {
     BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::info) << "received flatbuffers point cloud";
@@ -131,8 +132,8 @@ grpc::Status FbPointCloudService::TransferPointCloud2(
       return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, msg);
     }
   }
-  seerep_server_util::createResponseFb(answer, seerep::fb::TRANSMISSION_STATE_SUCCESS, response);
 
+  // build the indices from the written data
   try
   {
     pointCloudFb->buildIndices(projectPclUuids);
@@ -161,6 +162,8 @@ grpc::Status FbPointCloudService::TransferPointCloud2(
     seerep_server_util::createResponseFb(msg, seerep::fb::TRANSMISSION_STATE_FAILURE, response);
     return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, msg);
   }
+
+  seerep_server_util::createResponseFb(answer, seerep::fb::TRANSMISSION_STATE_SUCCESS, response);
 
   return grpc::Status::OK;
 }


### PR DESCRIPTION
This is part of #350.

Changes:
- addData() for fb pointclouds is now split in two methods addDataToHdf5() and buildIndices()
- addDataToHdf5() only writes one pointcloud to hdf5
- When all pointclouds from a stream have been written to hdf5, buildIndices() can be called to create the indices for the by uuid specified projects and pointclouds

This lead to a improvement of roughly 15s in time to store 5000 pointclouds using the `gRPC_fb_sendPointCloud.py` script on my Intel® Core™ i5-8250U system, compared to the method before which took about 39s for that task.