### PR TITLE
Fix: wrong docker image in server compose file

### DIFF
--- a/docker/server/docker-compose.yml
+++ b/docker/server/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - seerep_log:${SEEREP_LOG_PATH}
     command: chown -R ${USER_ID}:${GROUP_ID} ${SEEREP_DATA_FOLDER} ${SEEREP_LOG_PATH}
   seerep:
-    image: ghcr.io/agri-gaia/seerep_base:latest
+    image: ghcr.io/agri-gaia/seerep_server:latest
     user: "${USER_ID}:${GROUP_ID}"
     tty: true
     container_name: seerep_server


### PR DESCRIPTION
Was wondering all afternoon why the server wouldn't respond :expressionless:
Introduced by 0fb83ee16ae759223bbca0ed1a0ad1ca6a4c91b2, blame on me. 