### PR TITLE
upgrade twine to resolve KeyError: 'license'

### DIFF
--- a/docker/base/requirements.dev.txt
+++ b/docker/base/requirements.dev.txt
@@ -6,7 +6,7 @@ grpcio==1.53.2
 imageio==2.20.0
 numpy==1.22.0
 numpy-quaternion==2022.4.2
-twine==4.0.2
+twine==5.1.1
 build==0.10.0
 setuptools==65.7.0
 matplotlib==3.6.3


### PR DESCRIPTION
Upgrade Twine to resolve:

```
Traceback (most recent call last):
  File "/usr/local/bin/twine", line 5, in <module>
    from twine.__main__ import main
  File "/usr/local/lib/python3.8/dist-packages/twine/__init__.py", line 43, in <module>
    __license__ = metadata["license"]
  File "/usr/local/lib/python3.8/dist-packages/importlib_metadata/_adapters.py", line 54, in __getitem__
    raise KeyError(item)
KeyError: 'license'
```