### PR TITLE
Fix: grpcio-tools not installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ MANIFEST
 
 # mkdocs-material privacy plugin
 .cache
+
+# logs
+*.log

--- a/seerep_com/cmake/ProtobufGenerateGrpcPython.cmake
+++ b/seerep_com/cmake/ProtobufGenerateGrpcPython.cmake
@@ -21,7 +21,21 @@ function(GRPC_GENERATE_PYTHON SRCS)
     ERROR_VARIABLE _pygrpc_output
   )
 
-  if(NOT (${_pygrpc_output} STREQUAL "Missing input file.\n"))
+  string(
+    REPLACE "\n"
+            ";"
+            _pygrpc_output
+            ${_pygrpc_output}
+  )
+
+  list(
+    GET
+    _pygrpc_output
+    0
+    _pygrpc_output
+  )
+
+  if(NOT (${_pygrpc_output} STREQUAL "Missing input file."))
     message(
       SEND_ERROR
         "Error: grpcio_tools not installed\ntry: sudo pip install grpcio_tools"


### PR DESCRIPTION
This should fix the currently failing builds. Deprecation warnings will still be printed afterward.
A thorough description is in the commit message. 