### PR TITLE
Fix minor bugs in the Datumaro integration

### DIFF
--- a/seerep_msgs/core/label.h
+++ b/seerep_msgs/core/label.h
@@ -4,15 +4,16 @@
 #include <string.h>
 
 #include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
 
 namespace seerep_core_msgs
 {
 struct Label
 {
-  std::string label;
-  int labelIdDatumaro;
-  boost::uuids::uuid uuidInstance;
-  int instanceIdDatumaro;
+  std::string label = "";
+  int labelIdDatumaro = -1;
+  boost::uuids::uuid uuidInstance = boost::uuids::nil_uuid();
+  int instanceIdDatumaro = -1;
 };
 
 } /* namespace seerep_core_msgs */

--- a/seerep_srv/seerep_core_fb/src/core_fb_conversion.cpp
+++ b/seerep_srv/seerep_core_fb/src/core_fb_conversion.cpp
@@ -704,7 +704,7 @@ void CoreFbConversion::fromFbDataLabels(
               .label = label->label()->str(),
               .labelIdDatumaro = label->labelIdDatumaro(),
               .uuidInstance = uuidInstance,
-              .instanceIdDatumaro = label->labelIdDatumaro() });
+              .instanceIdDatumaro = label->instanceIdDatumaro() });
         }
         labelDatumaroPtr->datumaroJson =
             labelsCategories->datumaroJson()->str();


### PR DESCRIPTION
- https://github.com/agri-gaia/seerep/commit/9a0b7822a33f2b86aaaf81d6357b58dc3f71b321 fixes the incorrect assignment of the `labelID` as the `instanceID` in the Flatbuffer core conversions
- https://github.com/agri-gaia/seerep/commit/b498056895370cae820cd722eb7d7be17913b824 adds default values to the core label message, otherwise an unset UUID will be interpreted as a valid `instanceID` that doesn't exist. 