### PR TITLE
docs: gRPC API documentation

### DIFF
--- a/docs/mkdocs/reference/api.md
+++ b/docs/mkdocs/reference/api.md
@@ -1,0 +1,5 @@
+<!-- markdownlint-disable-file -->
+
+--8<--
+seerep_com/README.md
+--8<--

--- a/docs/mkdocs/tutorials/images.md
+++ b/docs/mkdocs/tutorials/images.md
@@ -83,10 +83,10 @@ geodesic coordinates of the project into the map frame beforehand.
 
 === "Flatbuffers"
 
-    Source: [examples/python/gRPC/images/gRPC_fb_queryImage.py](https://github.com/agri-gaia/seerep/blob/main/examples/python/gRPC/images/gRPC_fb_queryImage.py)
+    Source: [examples/python/gRPC/images/gRPC_fb_queryImage.py](https://github.com/agri-gaia/seerep/blob/main/examples/python/gRPC/images/gRPC_fb_queryImages.py)
 
     ```python
-    --8<-- "https://raw.githubusercontent.com/agri-gaia/seerep/main/examples/python/gRPC/images/gRPC_fb_queryImage.py"
+    --8<-- "https://raw.githubusercontent.com/agri-gaia/seerep/main/examples/python/gRPC/images/gRPC_fb_queryImages.py"
     ```
 
     After sending the images, executing the query script results in the following output:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
     - Test Setup: 'getting-started/tests.md'
     - Kown Issues: 'getting-started/known_issues.md'
   - Reference:
+    - gRPC API: reference/api.md
     - Package Overview: 'reference/packages.md'
     - Flatbuffers Abstractions: 'reference/pytests-message-abstractions.md'
     - Python Helpers: 'reference/python-helpers.md'

--- a/seerep_com/README.md
+++ b/seerep_com/README.md
@@ -1,0 +1,111 @@
+<!-- markdownlint-disable-file MD024 -->
+# gRPC API
+
+This page gives an overview of the avaible gRPC services of SEEREP.
+It is **recommended to use FlatBuffers for serializatzion**, as the lastest
+updates and features are implemented in it.
+Some features might be missing in Protocol Buffers, and it may even be
+discontinued in the future, see
+[issue#372](https://github.com/agri-gaia/seerep/issues/372).
+The implementation of the services is located in the
+[seerep_server](https://github.com/agri-gaia/seerep/tree/main/seerep_srv/seerep_server/src)
+package.
+
+The *streaming* column in the following tables indicates whether the client or
+server can send `1 ... N` messages during the service call.
+
+## Flatbuffers
+
+### MetaOperations
+
+| Service                | Description              | Request Message                                                                                          | Response Message | Streaming |
+|------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|------------------|-----------|
+| [CreateProject](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Create a new SEEREP project    | [ProjectCreation](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/projectCreation.fbs)     | [ProjetInfo](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/project_info.fbs) | - |
+| [GetProjects](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Get all current projects    | [Empty](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/empty.fbs)     | [ProjetInfos](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/project_info.fbs) | - |
+| [LoadProjects](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Load all unindexed projects    | [Empty](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/empty.fbs)     | [ProjetInfos](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/project_info.fbs) | - |
+| [DeleteProject](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Delete a project   | [ProjectInfo](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/project_info.fbs)     | [Empty](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/empty.fbs) | - |
+| [GetOverallTimeInterval](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Get the total timespan of a data type   | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/uuid_datatype_pair.fbs)     | [TimeInterval](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/time_interval.fbs) | - |
+| [GetOverallBoundingBox](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Get the full extend of a data type  | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/uuid_datatype_pair.fbs)     | [Boundingbox](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/boundingbox.fbs) | - |
+| [GetOverallCategories](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Get all categories of a data type   | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/uuid_datatype_pair.fbs)     | [StringVector](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/string_vector.fbs) | - |
+| [GetOverallLabels](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Get all labels in a category of a data type   | [UuidDatatypeWithCategory](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/uuid_datatype_with_category.fbs)     | [StringVector](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/string_vector.fbs) | - |
+
+### ImageService
+
+| Service                | Description              | Request Message                                                                                          | Response Message | Streaming |
+|------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|------------------|-----------|
+| [GetImage](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/image_service.fbs)    | Get images based on a query   | [Query](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/query.fbs)     | [Image](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/image.fbs) | Server |
+| [TransferImage](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/image_service.fbs)    | Transfer images to SEEREP   | [Image](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/image.fbs)     | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/server_response.fbs) | Client |
+| [AddLabels](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/image_service.fbs)    | Add labels to existing images| [DatasetUuidLabel](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/dataset_uuid_label.fbs)     | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/server_response.fbs) | Client |
+
+### CameraIntrinsicsService
+
+| Service                | Description              | Request Message                                                                                          | Response Message | Streaming |
+|------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|------------------|-----------|
+| [GetCameraIntrinsics](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/camera_intrinsics_service.fbs)    | Get a specific camera instrinic    | [CameraIntrinsicsQuery](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/camera_intrinsics_query.fbs) | [CameraIntrinsics](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/camera_intrinsics.fbs) | - |
+| [TransferCameraIntrinsics](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/camera_intrinsics_service.fbs)    | Transfer camera intrinsics to SEEREP   |  [CameraIntrinsics](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/camera_intrinsics.fbs) | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/server_response.fbs) | - |
+
+### PointCloudService
+
+| Service                | Description              | Request Message                                                                                          | Response Message | Streaming |
+|------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|------------------|-----------|
+| [GetPointCloud2](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/point_cloud_service.fbs)    | Get point clouds based on a query   | [Query](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/query.fbs)     | [PointCloud2](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/point_cloud_2.fbs) | Server |
+| [TransferPointCloud2](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/point_cloud_service.fbs)    | Transfer point clouds to SEEREP   | [PointCloud2](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/point_cloud_2.fbs)     | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/server_response.fbs) | Client |
+| [AddLabels](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/point_cloud_service.fbs)    | Add labels to existing point clouds | [DatasetUuidLabel](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/dataset_uuid_label.fbs)     | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/server_response.fbs) | Client |
+
+### TfService
+
+| Service                | Description              | Request Message                                                                                          | Response Message | Streaming |
+|------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|------------------|-----------|
+| [TransferTransformStamped](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/tf_service.fbs)    | Add a transformation to SEEREP  | [TransformStamped](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/transform_stamped.fbs)     | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/server_response.fbs) | Client |
+| [GetFrames](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/tf_service.fbs)    | Get all frames of a project   | [FrameQuery](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/frame_query.fbs)     |  [StringVector](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/string_vector.fbs) | - |
+| [GetTransformStamped](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/tf_service.fbs)    | Get a transformation from SEEREP | [TransformStampedQuery](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/transform_stamped_query.fbs)     | [TransformStamped](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/transform_stamped.fbs) | - |
+
+### PointService
+
+| Service                | Description              | Request Message                                                                                          | Response Message | Streaming |
+|------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|------------------|-----------|
+| [GetPoint](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/point_service.fbs)    | Get points based in a query  | [Query](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/query.fbs)      | [PointStamped](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/point_stamped.fbs) | Server |
+| [TransferPoint](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/point_service.fbs)    | Transfer points to SEEREP   | [PointStamped](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/point_stamped.fbs)   | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/server_response.fbs)  | Client |
+| [AddAttribute](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/point_service.fbs)    | Add attribute to existing points | [AttributesStamped](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/attributes_stamped.fbs) | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/server_response.fbs) | Client |
+
+## Protocol Buffers
+
+### MetaOperations
+
+| Service                | Description              | Request Message                                                                                          | Response Message | Streaming |
+|------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|------------------|-----------|
+| [CreateProject](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Create a new SEEREP project    | [ProjectCreation](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/projectCreation.proto)     | [ProjetInfo](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/project_info.proto) | - |
+| [GetProjects](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Get all current projects    | [Empty](https://protobuf.dev/reference/protobuf/google.protobuf/#empty)     | [ProjetInfos](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/project_infos.proto) | - |
+| [GetOverallTimeInterval](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Get the total timespan of a data type   | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/uuid_datatype_pair.proto)     | [TimeInterval](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/time_interval.protos) | - |
+| [GetOverallBoundingBox](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Get the full extend of a data type  | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/uuid_datatype_pair.proto)     | [Boundingbox](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/boundingbox.proto) | - |
+| [GetOverallCategories](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Get all categories of a data type   | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/uuid_datatype_pair.proto)     | [StringVector](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/string_vector.proto) | - |
+| [GetOverallLabels](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Get all labels in a category of a data type   | [UuidDatatypeWithCategory](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/uuid_datatype_with_category.proto)     | [StringVector](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/string_vector.proto) | - |
+
+### ImageService
+
+| Service                | Description              | Request Message                                                                                          | Response Message | Streaming |
+|------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|------------------|-----------|
+| [GetImage](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/image_service.proto)    | Get images based on a query   | [Query](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/query.proto)     | [Image](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/image.proto) | Server |
+| [TransferImage](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/image_service.proto)    | Transfer images to SEEREP   | [Image](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/image.proto)     | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/server_response.proto) | - |
+
+### CameraIntrinsicsService
+
+| Service                | Description              | Request Message                                                                                          | Response Message | Streaming |
+|------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|------------------|-----------|
+| [GetCameraIntrinsics](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/camera_intrinsics_service.proto)    | Get a specific camera instrinic    | [CameraIntrinsicsQuery](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/camera_intrinsics_query.proto) | [CameraIntrinsics](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/camera_intrinsics.proto) | - |
+| [TransferCameraIntrinsics](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/camera_intrinsics_service.protos)    | Transfer camera intrinsics to SEEREP   |  [CameraIntrinsics](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/camera_intrinsics.protos) | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/server_response.proto) | - |
+
+### PointCloudService
+
+| Service                | Description              | Request Message                                                                                          | Response Message | Streaming |
+|------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|------------------|-----------|
+| [GetPointCloud2](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/point_cloud_service.proto)    | Get point clouds based on a query   | [Query](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/query.proto)     | [PointCloud2](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/point_cloud_2.proto) | Server |
+| [TransferPointCloud2](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/point_cloud_service.proto)    | Transfer point clouds to SEEREP   | [PointCloud2](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/point_cloud_2.proto)     | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/server_response.proto) | - |
+
+### TfService
+
+| Service                | Description              | Request Message                                                                                          | Response Message | Streaming |
+|------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|------------------|-----------|
+| [TransferTransformStamped](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/tf_service.proto)    | Add a transformation to SEEREP  | [TransformStamped](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/transform_stamped.proto)     | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/server_response.proto) | - |
+| [GetFrames](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/tf_service.proto)    | Get all frames of a project   | [FrameQuery](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/frame_query.proto)     |  [StringVector](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/string_vector.proto) | - |
+| [GetTransformStamped](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/tf_service.proto)    | Get a transformation from SEEREP | [TransformStampedQuery](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/transform_stamped_query.proto)     | [TransformStamped](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/transform_stamped.proto) | - |

--- a/seerep_com/README.md
+++ b/seerep_com/README.md
@@ -1,14 +1,13 @@
 <!-- markdownlint-disable-file MD024 -->
 # gRPC API
 
-This page gives an overview of the avaible gRPC services of SEEREP.
-It is **recommended to use FlatBuffers for serializatzion**, as the lastest
-updates and features are implemented in it.
-Some features might be missing in Protocol Buffers, and it may even be
-discontinued in the future, see
+This page provides a summary of the available gRPC services offered by SEEREP.
+It is **recommended to use FlatBuffers for serialization**, as the latest
+updates and features utilize it.
+Protocol Buffers might lack certain features and could potentially be
+discontinued in the future, as indicated by
 [issue#372](https://github.com/agri-gaia/seerep/issues/372).
-The implementation of the services is located in the
-[seerep_server](https://github.com/agri-gaia/seerep/tree/main/seerep_srv/seerep_server/src)
+The services are implemented in the [seerep_server](https://github.com/agri-gaia/seerep/tree/main/seerep_srv/seerep_server/src)
 package.
 
 The *streaming* column in the following tables indicates whether the client or
@@ -21,13 +20,13 @@ server can send `1 ... N` messages during the service call.
 | Service                | Description              | Request Message                                                                                          | Response Message | Streaming |
 |------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|------------------|-----------|
 | [CreateProject](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Create a new SEEREP project    | [ProjectCreation](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/projectCreation.fbs)     | [ProjetInfo](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/project_info.fbs) | - |
-| [GetProjects](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Get all current projects    | [Empty](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/empty.fbs)     | [ProjetInfos](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/project_info.fbs) | - |
-| [LoadProjects](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Load all unindexed projects    | [Empty](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/empty.fbs)     | [ProjetInfos](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/project_info.fbs) | - |
+| [GetProjects](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Get all current projects    | [Empty](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/empty.fbs)     | [ProjetInfos](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/project_infos.fbs) | - |
+| [LoadProjects](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Load all unindexed projects    | [Empty](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/empty.fbs)     | [ProjetInfos](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/project_infos.fbs) | - |
 | [DeleteProject](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Delete a project   | [ProjectInfo](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/project_info.fbs)     | [Empty](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/empty.fbs) | - |
 | [GetOverallTimeInterval](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Get the total timespan of a data type   | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/uuid_datatype_pair.fbs)     | [TimeInterval](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/time_interval.fbs) | - |
-| [GetOverallBoundingBox](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Get the full extend of a data type  | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/uuid_datatype_pair.fbs)     | [Boundingbox](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/boundingbox.fbs) | - |
-| [GetOverallCategories](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Get all categories of a data type   | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/uuid_datatype_pair.fbs)     | [StringVector](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/string_vector.fbs) | - |
-| [GetOverallLabels](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Get all labels in a category of a data type   | [UuidDatatypeWithCategory](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/uuid_datatype_with_category.fbs)     | [StringVector](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/string_vector.fbs) | - |
+| [GetOverallBoundingBox](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Get the full extent of a data type  | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/uuid_datatype_pair.fbs)     | [Boundingbox](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/boundingbox.fbs) | - |
+| [GetAllCategories](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Get all categories of a data type   | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/uuid_datatype_pair.fbs)     | [StringVector](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/string_vector.fbs) | - |
+| [GetAllLabels](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/meta_operations.fbs)    | Get all labels in a category of a data type   | [UuidDatatypeWithCategory](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/uuid_datatype_with_category.fbs)     | [StringVector](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/string_vector.fbs) | - |
 
 ### ImageService
 
@@ -64,7 +63,7 @@ server can send `1 ... N` messages during the service call.
 
 | Service                | Description              | Request Message                                                                                          | Response Message | Streaming |
 |------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|------------------|-----------|
-| [GetPoint](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/point_service.fbs)    | Get points based in a query  | [Query](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/query.fbs)      | [PointStamped](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/point_stamped.fbs) | Server |
+| [GetPoint](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/point_service.fbs)    | Get points based on a query  | [Query](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/query.fbs)      | [PointStamped](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/point_stamped.fbs) | Server |
 | [TransferPoint](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/point_service.fbs)    | Transfer points to SEEREP   | [PointStamped](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/point_stamped.fbs)   | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/server_response.fbs)  | Client |
 | [AddAttribute](https://github.com/agri-gaia/seerep/blob/main/seerep_com/fbs/point_service.fbs)    | Add attribute to existing points | [AttributesStamped](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/attributes_stamped.fbs) | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/fbs/server_response.fbs) | Client |
 
@@ -76,10 +75,10 @@ server can send `1 ... N` messages during the service call.
 |------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|------------------|-----------|
 | [CreateProject](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Create a new SEEREP project    | [ProjectCreation](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/projectCreation.proto)     | [ProjetInfo](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/project_info.proto) | - |
 | [GetProjects](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Get all current projects    | [Empty](https://protobuf.dev/reference/protobuf/google.protobuf/#empty)     | [ProjetInfos](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/project_infos.proto) | - |
-| [GetOverallTimeInterval](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Get the total timespan of a data type   | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/uuid_datatype_pair.proto)     | [TimeInterval](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/time_interval.protos) | - |
-| [GetOverallBoundingBox](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Get the full extend of a data type  | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/uuid_datatype_pair.proto)     | [Boundingbox](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/boundingbox.proto) | - |
-| [GetOverallCategories](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Get all categories of a data type   | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/uuid_datatype_pair.proto)     | [StringVector](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/string_vector.proto) | - |
-| [GetOverallLabels](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Get all labels in a category of a data type   | [UuidDatatypeWithCategory](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/uuid_datatype_with_category.proto)     | [StringVector](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/string_vector.proto) | - |
+| [GetOverallTimeInterval](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Get the total timespan of a data type   | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/uuid_datatype_pair.proto)     | [TimeInterval](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/time_interval.proto) | - |
+| [GetOverallBoundingBox](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Get the full extent of a data type  | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/uuid_datatype_pair.proto)     | [Boundingbox](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/boundingbox.proto) | - |
+| [GetAllCategories](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Get all categories of a data type   | [UuidDatatypePair](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/uuid_datatype_pair.proto)     | [StringVector](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/string_vector.proto) | - |
+| [GetAllLabels](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/meta_operations.proto)    | Get all labels in a category of a data type   | [UuidDatatypeWithCategory](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/uuid_datatype_with_category.proto)     | [StringVector](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/string_vector.proto) | - |
 
 ### ImageService
 
@@ -93,7 +92,7 @@ server can send `1 ... N` messages during the service call.
 | Service                | Description              | Request Message                                                                                          | Response Message | Streaming |
 |------------------------|--------------------------------|----------------------------------------------------------------------------------------------------------|------------------|-----------|
 | [GetCameraIntrinsics](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/camera_intrinsics_service.proto)    | Get a specific camera instrinic    | [CameraIntrinsicsQuery](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/camera_intrinsics_query.proto) | [CameraIntrinsics](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/camera_intrinsics.proto) | - |
-| [TransferCameraIntrinsics](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/camera_intrinsics_service.protos)    | Transfer camera intrinsics to SEEREP   |  [CameraIntrinsics](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/camera_intrinsics.protos) | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/server_response.proto) | - |
+| [TransferCameraIntrinsics](https://github.com/agri-gaia/seerep/blob/main/seerep_com/protos/camera_intrinsics_service.proto)    | Transfer camera intrinsics to SEEREP   |  [CameraIntrinsics](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/camera_intrinsics.proto) | [ServerResponse](https://github.com/agri-gaia/seerep/blob/main/seerep_msgs/protos/server_response.proto) | - |
 
 ### PointCloudService
 

--- a/seerep_com/fbs/README.md
+++ b/seerep_com/fbs/README.md
@@ -1,3 +1,0 @@
-# README
-
-Check this stackoverflow question for the gRPC flatbuffer syntax: <https://stackoverflow.com/questions/65526157/flatbuffer-grpc-streaming-definitions-bidi-server-client>


### PR DESCRIPTION
Adds documentation about what services are available in FlatBuffers and Protocol Buffers and what messages they use. 

Preview: 
![Bildschirmfoto 2024-07-29 um 14 31 08](https://github.com/user-attachments/assets/df9b4e9a-d126-4b73-8d04-3e9babab3c1b)
