### PR TITLE
Refactor seerep_hdf5_ros

### DIFF
--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_tf.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_tf.h
@@ -1,18 +1,11 @@
 #ifndef SEEREP_HDF5_CORE_HDF5_CORE_TF_H_
 #define SEEREP_HDF5_CORE_HDF5_CORE_TF_H_
 
-// highfive
-#include <highfive/H5File.hpp>
-
-// seerep_hdf5_core
-#include "hdf5_core_general.h"
-
-// ros-msgs (tf)
 #include <geometry_msgs/TransformStamped.h>
 
-// std
-#include <boost/geometry.hpp>
 #include <optional>
+
+#include "hdf5_core_general.h"
 
 namespace seerep_hdf5_core
 {
@@ -23,31 +16,45 @@ public:
              std::shared_ptr<std::mutex>& write_mtx);
 
   std::optional<std::vector<geometry_msgs::TransformStamped>>
-  readTransformStamped(const std::string& id, const bool isStatic);
+  readTransformStamped(const std::string& id, bool isStatic);
   std::optional<std::vector<std::string>>
-  readTransformStampedFrames(const std::string& id, const bool isStatic);
+  readTransformStampedFrames(const std::string& id, bool isStatic);
+
+  std::string
+  readFrame(const std::string& frameName,
+            const std::shared_ptr<const HighFive::Group>& group_ptr) const;
+
+  void writeTimestamp(const std::string& datasetPath,
+                      std::array<int64_t, 2> timestamp);
+  std::vector<std::vector<int64_t>>
+  readTimestamps(const std::string& timeDatasetPath) const;
+
+  void writeTranslation(const std::string& translationDatasetPath,
+                        std::array<double, 3> translation);
+  std::vector<std::vector<double>>
+  readTranslations(const std::string& translationDatasetPath) const;
+
+  void writeRotation(const std::string& rotationsDatasetPath,
+                     std::array<double, 4> rotation);
+  std::vector<std::vector<double>>
+  readRotations(const std::string& rotationDatasetPath) const;
 
 private:
-  std::vector<std::vector<int64_t>>
-  readTime(const std::string& hdf5DatasetTimePath) const;
-  std::vector<std::vector<double>>
-  readTranslation(const std::string& hdf5DatasetTransPath) const;
-  std::vector<std::vector<double>>
-  readRotation(const std::string& hdf5DatasetRotPath) const;
-
   std::optional<std::vector<geometry_msgs::TransformStamped>>
   convertToTfs(const long unsigned int& size, const std::string& parentframe,
                const std::string& childframe,
-               const std::vector<std::vector<int64_t>>& time,
-               const std::vector<std::vector<double>>& trans,
-               const std::vector<std::vector<double>>& rot);
+               const std::vector<std::vector<int64_t>>& timestamps,
+               const std::vector<std::vector<double>>& translations,
+               const std::vector<std::vector<double>>& rotations);
 
 public:
-  // datatype group names in hdf5
   inline static const std::string HDF5_GROUP_TF = "tf";
   inline static const std::string HDF5_GROUP_TF_STATIC = "tf_static";
-
   inline static const std::string SIZE = "size";
+
+  inline static const std::string HDF5_DATASET_TIMESTAMPS = "/time";
+  inline static const std::string HDF5_DATASET_TRANSLATION = "/translation";
+  inline static const std::string HDF5_DATASET_ROTATION = "/rotation";
 
   inline static const std::string PARENT_FRAME = "PARENT_FRAME";
   inline static const std::string CHILD_FRAME = "CHILD_FRAME";

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_tf.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_tf.cpp
@@ -1,7 +1,5 @@
 #include "seerep_hdf5_core/hdf5_core_tf.h"
 
-#include <highfive/H5DataSet.hpp>
-
 namespace seerep_hdf5_core
 {
 Hdf5CoreTf::Hdf5CoreTf(std::shared_ptr<HighFive::File>& file,
@@ -15,20 +13,11 @@ Hdf5CoreTf::readTransformStamped(const std::string& id, const bool isStatic)
 {
   const std::scoped_lock lock(*m_write_mtx);
 
-  std::string hdf5_group_tf;
-  if (isStatic)
-  {
-    hdf5_group_tf = HDF5_GROUP_TF_STATIC;
-  }
-  else
-  {
-    hdf5_group_tf = HDF5_GROUP_TF;
-  }
-
-  std::string hdf5GroupPath = hdf5_group_tf + "/" + id;
-  std::string hdf5DatasetTimePath = hdf5GroupPath + "/" + "time";
-  std::string hdf5DatasetTransPath = hdf5GroupPath + "/" + "translation";
-  std::string hdf5DatasetRotPath = hdf5GroupPath + "/" + "rotation";
+  const std::string tfGroup = isStatic ? HDF5_GROUP_TF_STATIC : HDF5_GROUP_TF;
+  const std::string hdf5GroupPath = tfGroup + "/" + id;
+  const std::string hdf5DatasetTimePath = hdf5GroupPath + "/" + "time";
+  const std::string hdf5DatasetTransPath = hdf5GroupPath + "/" + "translation";
+  const std::string hdf5DatasetRotPath = hdf5GroupPath + "/" + "rotation";
 
   if (!m_file->exist(hdf5GroupPath) || !m_file->exist(hdf5DatasetTimePath) ||
       !m_file->exist(hdf5DatasetTransPath) ||
@@ -37,13 +26,9 @@ Hdf5CoreTf::readTransformStamped(const std::string& id, const bool isStatic)
     return std::nullopt;
   }
 
-  BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::info)
-      << "loading " << hdf5GroupPath;
-
-  // read size
   std::shared_ptr<HighFive::Group> group_ptr =
       std::make_shared<HighFive::Group>(m_file->getGroup(hdf5GroupPath));
-  long unsigned int size;
+  size_t size;
   group_ptr->getAttribute(SIZE).read(size);
   if (size == 0)
   {
@@ -53,33 +38,23 @@ Hdf5CoreTf::readTransformStamped(const std::string& id, const bool isStatic)
   }
 
   // read frames
-  std::string parentframe = readFrameId(*group_ptr, PARENT_FRAME, id);
-  std::string childframe = readFrameId(*group_ptr, CHILD_FRAME, id);
-  std::vector<std::vector<int64_t>> time = readTime(hdf5DatasetTimePath);
+  std::string parentframe = readFrame("PARENT_FRAME", group_ptr);
+  std::string childframe = readFrame("CHILD_FRAME", group_ptr);
+  std::vector<std::vector<int64_t>> time = readTimestamps(hdf5DatasetTimePath);
   std::vector<std::vector<double>> trans =
-      readTranslation(hdf5DatasetTransPath);
-  std::vector<std::vector<double>> rot = readRotation(hdf5DatasetRotPath);
+      readTranslations(hdf5DatasetTransPath);
+  std::vector<std::vector<double>> rot = readRotations(hdf5DatasetRotPath);
 
   return convertToTfs(size, parentframe, childframe, time, trans, rot);
 }
 
 std::optional<std::vector<std::string>>
-Hdf5CoreTf::readTransformStampedFrames(const std::string& id,
-                                       const bool isStatic)
+Hdf5CoreTf::readTransformStampedFrames(const std::string& id, bool isStatic)
 {
   const std::scoped_lock lock(*m_write_mtx);
 
-  std::string hdf5_group_tf;
-  if (isStatic)
-  {
-    hdf5_group_tf = HDF5_GROUP_TF_STATIC;
-  }
-  else
-  {
-    hdf5_group_tf = HDF5_GROUP_TF;
-  }
-
-  std::string hdf5GroupPath = hdf5_group_tf + "/" + id;
+  const std::string tfGroup = isStatic ? HDF5_GROUP_TF_STATIC : HDF5_GROUP_TF;
+  const std::string hdf5GroupPath = tfGroup + "/" + id;
 
   if (!m_file->exist(hdf5GroupPath))
   {
@@ -89,29 +64,123 @@ Hdf5CoreTf::readTransformStampedFrames(const std::string& id,
   std::shared_ptr<HighFive::Group> group_ptr =
       std::make_shared<HighFive::Group>(m_file->getGroup(hdf5GroupPath));
 
-  BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::info)
-      << "loading parent frame of " << hdf5GroupPath;
-
-  // read frames
-  std::string parentframe = readFrameId(*group_ptr, PARENT_FRAME, id);
-  std::string childframe = readFrameId(*group_ptr, CHILD_FRAME, id);
+  const std::string parentframe =
+      readFrame(seerep_hdf5_core::Hdf5CoreTf::CHILD_FRAME, group_ptr);
+  const std::string childframe =
+      readFrame(seerep_hdf5_core::Hdf5CoreTf::PARENT_FRAME, group_ptr);
 
   return std::vector<std::string>{ parentframe, childframe };
 }
 
+std::string Hdf5CoreTf::readFrame(
+    const std::string& frameName,
+    const std::shared_ptr<const HighFive::Group>& group_ptr) const
+{
+  std::string frame;
+  group_ptr->getAttribute(frameName).read(frame);
+  return frame;
+}
+
+void Hdf5CoreTf::writeTimestamp(const std::string& datagroupPath,
+                                std::array<int64_t, 2> timestamp)
+{
+  std::shared_ptr<HighFive::DataSet> dataset;
+
+  uint64_t size = 0;
+  const std::string timestampDatasetPath = datagroupPath + "/time";
+
+  if (!m_file->exist(timestampDatasetPath))
+  {
+    HighFive::DataSpace dataspace({ 1, 2 },
+                                  { HighFive::DataSpace::UNLIMITED, 2 });
+    HighFive::DataSetCreateProps createProperties;
+    createProperties.add(HighFive::Chunking(std::vector<hsize_t>{ 1, 2 }));
+    dataset =
+        std::make_shared<HighFive::DataSet>(m_file->createDataSet<int64_t>(
+            timestampDatasetPath, dataspace, createProperties));
+  }
+  else
+  {
+    dataset = std::make_shared<HighFive::DataSet>(
+        m_file->getDataSet(timestampDatasetPath));
+    HighFive::Group group = m_file->getGroup(datagroupPath);
+    group.getAttribute(seerep_hdf5_core::Hdf5CoreTf::SIZE).read(size);
+    dataset->resize({ size + 1, 2 });
+  }
+  dataset->select({ size, 0 }, { 1, 2 }).write(timestamp);
+  m_file->flush();
+}
+
+void Hdf5CoreTf::writeTranslation(const std::string& datagroupPath,
+                                  std::array<double, 3> translation)
+{
+  std::shared_ptr<HighFive::DataSet> dataset;
+  uint64_t size = 0;
+  const std::string translationDatasetPath =
+      datagroupPath + seerep_hdf5_core::Hdf5CoreTf::HDF5_DATASET_TRANSLATION;
+
+  if (!m_file->exist(translationDatasetPath))
+  {
+    HighFive::DataSpace dataspace({ 1, 3 },
+                                  { HighFive::DataSpace::UNLIMITED, 3 });
+    HighFive::DataSetCreateProps createProperties;
+    createProperties.add(HighFive::Chunking(std::vector<hsize_t>{ 1, 3 }));
+    dataset = std::make_shared<HighFive::DataSet>(m_file->createDataSet<double>(
+        translationDatasetPath, dataspace, createProperties));
+  }
+  else
+  {
+    dataset = std::make_shared<HighFive::DataSet>(
+        m_file->getDataSet(translationDatasetPath));
+    HighFive::Group group = m_file->getGroup(datagroupPath);
+    group.getAttribute(seerep_hdf5_core::Hdf5CoreTf::SIZE).read(size);
+    dataset->resize({ size + 1, 3 });
+  }
+  dataset->select({ size, 0 }, { 1, 3 }).write(translation);
+  m_file->flush();
+}
+
+void Hdf5CoreTf::writeRotation(const std::string& datagroupPath,
+                               std::array<double, 4> rotation)
+{
+  std::shared_ptr<HighFive::DataSet> dataset;
+  uint64_t size = 0;
+  const std::string rotationDatasetPath =
+      datagroupPath + seerep_hdf5_core::Hdf5CoreTf::HDF5_DATASET_ROTATION;
+
+  if (!m_file->exist(rotationDatasetPath))
+  {
+    HighFive::DataSpace dataspace({ 1, 4 },
+                                  { HighFive::DataSpace::UNLIMITED, 4 });
+    HighFive::DataSetCreateProps createProperties;
+    createProperties.add(HighFive::Chunking(std::vector<hsize_t>{ 1, 4 }));
+    dataset = std::make_shared<HighFive::DataSet>(m_file->createDataSet<double>(
+        rotationDatasetPath, dataspace, createProperties));
+  }
+  else
+  {
+    dataset = std::make_shared<HighFive::DataSet>(
+        m_file->getDataSet(rotationDatasetPath));
+    HighFive::Group group = m_file->getGroup(datagroupPath);
+    group.getAttribute(seerep_hdf5_core::Hdf5CoreTf::SIZE).read(size);
+    dataset->resize({ size + 1, 4 });
+  }
+  dataset->select({ size, 0 }, { 1, 4 }).write(rotation);
+  m_file->flush();
+}
+
 std::vector<std::vector<int64_t>>
-Hdf5CoreTf::readTime(const std::string& hdf5DatasetTimePath) const
+Hdf5CoreTf::readTimestamps(const std::string& hdf5DatasetPath) const
 {
   std::shared_ptr<HighFive::DataSet> data_set_time_ptr =
-      std::make_shared<HighFive::DataSet>(
-          m_file->getDataSet(hdf5DatasetTimePath));
+      std::make_shared<HighFive::DataSet>(m_file->getDataSet(hdf5DatasetPath));
   std::vector<std::vector<int64_t>> time;
   data_set_time_ptr->read(time);
 
   return time;
 }
 std::vector<std::vector<double>>
-Hdf5CoreTf::readTranslation(const std::string& hdf5DatasetTransPath) const
+Hdf5CoreTf::readTranslations(const std::string& hdf5DatasetTransPath) const
 {
   std::shared_ptr<HighFive::DataSet> data_set_trans_ptr =
       std::make_shared<HighFive::DataSet>(
@@ -122,7 +191,7 @@ Hdf5CoreTf::readTranslation(const std::string& hdf5DatasetTransPath) const
   return trans;
 }
 std::vector<std::vector<double>>
-Hdf5CoreTf::readRotation(const std::string& hdf5DatasetRotPath) const
+Hdf5CoreTf::readRotations(const std::string& hdf5DatasetRotPath) const
 {
   std::shared_ptr<HighFive::DataSet> data_set_rot_ptr =
       std::make_shared<HighFive::DataSet>(
@@ -137,16 +206,17 @@ std::optional<std::vector<geometry_msgs::TransformStamped>>
 Hdf5CoreTf::convertToTfs(const long unsigned int& size,
                          const std::string& parentframe,
                          const std::string& childframe,
-                         const std::vector<std::vector<int64_t>>& time,
-                         const std::vector<std::vector<double>>& trans,
-                         const std::vector<std::vector<double>>& rot)
+                         const std::vector<std::vector<int64_t>>& timestamps,
+                         const std::vector<std::vector<double>>& translations,
+                         const std::vector<std::vector<double>>& rotations)
 {
   // check if all have the right size
-  if (time.size() != size || trans.size() != size || rot.size() != size)
+  if (timestamps.size() != size || translations.size() != size ||
+      rotations.size() != size)
   {
     BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::warning)
-        << "sizes of time (" << time.size() << "), translation ("
-        << trans.size() << ") and rotation (" << rot.size()
+        << "sizes of time (" << timestamps.size() << "), translation ("
+        << translations.size() << ") and rotation (" << rotations.size()
         << ") not matching. Size expected by value in metadata (" << size
         << ")";
     return std::nullopt;
@@ -159,17 +229,17 @@ Hdf5CoreTf::convertToTfs(const long unsigned int& size,
     tf.header.frame_id = parentframe;
     tf.child_frame_id = childframe;
 
-    tf.header.stamp.sec = time.at(i).at(0);
-    tf.header.stamp.nsec = time.at(i).at(1);
+    tf.header.stamp.sec = timestamps.at(i).at(0);
+    tf.header.stamp.nsec = timestamps.at(i).at(1);
 
-    tf.transform.translation.x = trans.at(i).at(0);
-    tf.transform.translation.y = trans.at(i).at(1);
-    tf.transform.translation.z = trans.at(i).at(2);
+    tf.transform.translation.x = translations.at(i).at(0);
+    tf.transform.translation.y = translations.at(i).at(1);
+    tf.transform.translation.z = translations.at(i).at(2);
 
-    tf.transform.rotation.x = rot.at(i).at(0);
-    tf.transform.rotation.y = rot.at(i).at(1);
-    tf.transform.rotation.z = rot.at(i).at(2);
-    tf.transform.rotation.w = rot.at(i).at(3);
+    tf.transform.rotation.x = rotations.at(i).at(0);
+    tf.transform.rotation.y = rotations.at(i).at(1);
+    tf.transform.rotation.z = rotations.at(i).at(2);
+    tf.transform.rotation.w = rotations.at(i).at(3);
 
     tfs.push_back(tf);
   }

--- a/seerep_hdf5/seerep_hdf5_ros/CMakeLists.txt
+++ b/seerep_hdf5/seerep_hdf5_ros/CMakeLists.txt
@@ -7,7 +7,13 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -fPIC")
 
-find_package(catkin REQUIRED COMPONENTS std_msgs geometry_msgs sensor_msgs)
+find_package(
+  catkin REQUIRED
+  COMPONENTS std_msgs
+             geometry_msgs
+             sensor_msgs
+             tf2_msgs
+)
 
 find_package(SeerepHdf5Core REQUIRED)
 
@@ -27,6 +33,7 @@ catkin_package(
   CATKIN_DEPENDS
   std_msgs
   geometry_msgs
+  tf2_msgs
   sensor_msgs
   DEPENDS
   HighFive

--- a/seerep_hdf5/seerep_hdf5_ros/include/seerep_hdf5_ros/hdf5_ros.h
+++ b/seerep_hdf5/seerep_hdf5_ros/include/seerep_hdf5_ros/hdf5_ros.h
@@ -1,44 +1,117 @@
 #ifndef SEEREP_HDF5_ROS_H_
 #define SEEREP_HDF5_ROS_H_
 
-// Std
-#include <mutex>
-#include <string>
-
-// HighFive
-#include <highfive/H5Easy.hpp>
-#include <highfive/H5File.hpp>
-
-// Boost
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <highfive/H5File.hpp>
+#include <mutex>
+#include <string>
 
-// ROS
-#include <sensor_msgs/Image.h>
-#include <std_msgs/Header.h>
-
-// Seerep
-#include <seerep_hdf5_core/hdf5_core_general.h>
+#include "geometry_msgs/TransformStamped.h"
+#include "seerep_hdf5_core/hdf5_core_general.h"
+#include "seerep_hdf5_core/hdf5_core_tf.h"
+#include "sensor_msgs/CameraInfo.h"
+#include "sensor_msgs/CompressedImage.h"
+#include "sensor_msgs/Image.h"
+#include "sensor_msgs/PointCloud2.h"
+#include "sensor_msgs/RegionOfInterest.h"
+#include "std_msgs/Header.h"
+#include "tf2_msgs/TFMessage.h"
 
 namespace seerep_hdf5_ros
 {
+
 class Hdf5Ros
 {
 public:
   Hdf5Ros() = delete;
-  Hdf5Ros(const std::string& path, const std::string& filename,
-          const std::string& projectFrameId, const std::string& projectName);
 
-  bool dumpImage(const sensor_msgs::Image& image) const;
-  bool dumpHeader(const std_msgs::Header& header,
-                  const std::string& datasetPath) const;
+  /**
+   * @brief Intialize the hdf5 file with the minimal required information.
+   *
+   * TODO: Add geo-refercing and versioning information.
+   *
+   * @param fileName Full path for the hdf5 file.
+   * @param projectName Name of the seerep project.
+   * @param projectFrameId Root frame of the project.
+   */
+  Hdf5Ros(const std::string& fileName, const std::string& projectName,
+          const std::string& projectFrameId);
+
+  /**
+   * @brief Destructor to flush the file.
+   */
+  ~Hdf5Ros();
+
+  /**
+   * @brief Store an image message to hdf5.
+   *
+   * @param image Image message to dump.
+   * @param uuid UUID of the corresponding camera info message.
+   */
+  void dump(const sensor_msgs::Image& image, const std::string& uuid);
+
+  /**
+   * @brief Store a compressed image message to hdf5.
+   *
+   * Note: Currently only used for benchmarking. Seerep currently does
+   * not support compressed images.
+   *
+   * @param image Compressed image message to store.
+   */
+  void dump(const sensor_msgs::CompressedImage& image);
+  std::string dump(const sensor_msgs::CameraInfo& cameraInfo,
+                   float maxViewingDistance = 0.0);
+
+  /**
+   * @briefStore a point cloud message to hdf5.
+   *
+   * @param pcl Point cloud message to store.
+   */
+  void dump(const sensor_msgs::PointCloud2& pcl);
+
+  /**
+   * @brief Store a tf message to hdf5.
+   *
+   * @param tfMessage TF message to store.
+   */
+  void dump(const tf2_msgs::TFMessage& tfMessage);
+
+  /**
+   * @brief Store a transform message to hdf5.
+   *
+   * @param tf Transform message to store.
+   */
+  void dump(const geometry_msgs::TransformStamped& tf);
 
 private:
-  std::string path_;
-  std::string filename_;
+  std::shared_ptr<std::mutex> mutex_;
+  std::shared_ptr<HighFive::File> file_;
 
-  std::shared_ptr<HighFive::File> hdf5File_;
+  /* composition to the hdf5 core to re-use data type independent implementations */
+  std::shared_ptr<seerep_hdf5_core::Hdf5CoreGeneral> hdf5Core_;
+
+  std::shared_ptr<seerep_hdf5_core::Hdf5CoreTf> hdf5CoreTf_;
+
+  /**
+   * @brief Store a message header to hdf5.
+   *
+   * @param groupPath Path to the hdf5 group, to which the header should be added.
+   * @param header Header message to store.
+   */
+  void dump(const std::string& groupPath, const std_msgs::Header& header);
+
+  /**
+   * @brief Store a region of interest message to hdf5.
+   *
+   * @param cameraInfoPath Path to the camerainfo the roi message should be added.
+   * @param roi Region of interest message to store.
+   */
+  void dump(const std::string& cameraInfoPath,
+            const sensor_msgs::RegionOfInterest& roi);
 };
+
 }  // namespace seerep_hdf5_ros
+
 #endif /* SEEREP_HDF5_ROS_H_ */

--- a/seerep_hdf5/seerep_hdf5_ros/package.xml
+++ b/seerep_hdf5/seerep_hdf5_ros/package.xml
@@ -2,19 +2,18 @@
 <package format="2">
   <name>seerep_hdf5_ros</name>
   <version>0.0.1</version>
-  <description>
-    Interface for writing ROS messages into SEEREP complaint HDF5 files
-  </description>
+  <description>Package to write ROS messages directly into hdf5</description>
 
   <maintainer email="mark.niemeyer@dfki.de">Mark Niemeyer</maintainer>
-  <maintainer email="julian.arkenau@dfki.de"> Julian Arkenau </maintainer>
-
-  <license>BSD-3-Clause</license>
-
   <author email="julian.arkenau@dfki.de"> Julian Arkenau </author>
+
+  <license>BSD-3</license>
+
+  <url type="website">TODO</url>
 
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>tf2_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>seerep_hdf5_core</depend>
 

--- a/seerep_hdf5/seerep_hdf5_ros/src/hdf5_ros.cpp
+++ b/seerep_hdf5/seerep_hdf5_ros/src/hdf5_ros.cpp
@@ -2,51 +2,216 @@
 
 namespace seerep_hdf5_ros
 {
-Hdf5Ros::Hdf5Ros(const std::string& path, const std::string& filename,
-                 const std::string& projectFrameId,
-                 const std::string& projectName)
-  : path_{ path }, filename_{ filename }
+
+Hdf5Ros::Hdf5Ros(const std::string& fileName, const std::string& projectName,
+                 const std::string& projectFrameId)
+
+  : mutex_(std::make_shared<std::mutex>())
+  , file_(std::make_shared<HighFive::File>(
+        fileName, HighFive::File::ReadWrite | HighFive::File::Create))
+  , hdf5Core_(std::make_shared<seerep_hdf5_core::Hdf5CoreGeneral>(file_, mutex_))
+  , hdf5CoreTf_(std::make_shared<seerep_hdf5_core::Hdf5CoreTf>(file_, mutex_))
 {
-  auto write_mtx = std::make_shared<std::mutex>();
-  hdf5File_ = std::make_shared<HighFive::File>(path_ + filename_ + ".h5",
-                                               HighFive::File::ReadWrite |
-                                                   HighFive::File::Create);
-  auto ioGeneral = seerep_hdf5_core::Hdf5CoreGeneral(hdf5File_, write_mtx);
-  ioGeneral.writeProjectFrameId(projectFrameId);
-  ioGeneral.writeProjectname(projectName);
+  hdf5Core_->writeProjectname(projectName);
+  hdf5Core_->writeProjectFrameId(projectFrameId);
 }
 
-bool Hdf5Ros::dumpImage(const sensor_msgs::Image& image) const
+Hdf5Ros::~Hdf5Ros()
 {
-  const std::string datasetPath =
-      "images/" +
+  file_->flush();
+}
+
+void Hdf5Ros::dump(const sensor_msgs::Image& image, const std::string& uuid)
+{
+  const std::string path = "images/" + boost::lexical_cast<std::string>(
+                                           boost::uuids::random_generator()());
+  HighFive::DataSpace dataspace =
+      HighFive::DataSpace(image.height * image.step);
+
+  HighFive::Group group = *hdf5Core_->getHdf5Group(path);
+
+  dump(path, image.header);
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(group, "height", image.height);
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(group, "width", image.width);
+  hdf5Core_->writeAttributeToHdf5<std::string>(group, "encoding",
+                                               image.encoding);
+  hdf5Core_->writeAttributeToHdf5<bool>(group, "is_bigendian",
+                                        image.is_bigendian);
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(group, "step", image.step);
+  hdf5Core_->getHdf5DataSet<uint8_t>(path + "/rawdata", dataspace)
+      ->write(std::move(image.data.data()));
+
+  if (!uuid.empty())
+  {
+    hdf5Core_->writeAttributeToHdf5<std::string>(
+        group, "camera_intrinsics_uuid", uuid);
+  }
+}
+
+void Hdf5Ros::dump(const sensor_msgs::CompressedImage& image)
+{
+  const std::string path = "images/" + boost::lexical_cast<std::string>(
+                                           boost::uuids::random_generator()());
+  HighFive::DataSpace dataspace = HighFive::DataSpace(image.data.size());
+  HighFive::Group group = *hdf5Core_->getHdf5Group(path);
+
+  dump(path, image.header);
+  hdf5Core_->writeAttributeToHdf5<std::string>(group, "format", image.format);
+  hdf5Core_->getHdf5DataSet<uint8_t>(path + "/rawdata", dataspace)
+      ->write(std::move(image.data.data()));
+}
+
+std::string Hdf5Ros::dump(const sensor_msgs::CameraInfo& cameraInfo,
+                          float maxViewingDistance)
+{
+  const std::string uuid =
       boost::lexical_cast<std::string>(boost::uuids::random_generator()());
 
-  H5Easy::dump(*hdf5File_, datasetPath, std::move(image.data));
+  const std::string path = "cameraintrinsics/" + uuid;
 
-  this->dumpHeader(image.header, datasetPath);
+  HighFive::Group group = *hdf5Core_->getHdf5Group(path);
 
-  H5Easy::dumpAttribute(*hdf5File_, datasetPath, "encoding", image.encoding);
-  H5Easy::dumpAttribute(*hdf5File_, datasetPath, "height", image.height);
-  H5Easy::dumpAttribute(*hdf5File_, datasetPath, "width", image.width);
-  H5Easy::dumpAttribute(*hdf5File_, datasetPath, "is_bigendian",
-                        image.is_bigendian);
-  H5Easy::dumpAttribute(*hdf5File_, datasetPath, "step", image.step);
+  dump(path, cameraInfo.header);
 
-  return true;
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(group, "height", cameraInfo.height);
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(group, "width", cameraInfo.width);
+  hdf5Core_->writeAttributeToHdf5<std::string>(group, "distortion_model",
+                                               cameraInfo.distortion_model);
+
+  std::vector<double> D(cameraInfo.D.data(),
+                        cameraInfo.D.data() + cameraInfo.D.size());
+  std::vector<double> K(cameraInfo.K.data(),
+                        cameraInfo.K.data() + cameraInfo.K.size());
+  std::vector<double> R(cameraInfo.R.data(),
+                        cameraInfo.R.data() + cameraInfo.R.size());
+  std::vector<double> P(cameraInfo.P.data(),
+                        cameraInfo.P.data() + cameraInfo.P.size());
+
+  hdf5Core_->writeAttributeToHdf5<std::vector<double>>(group, "distortion", D);
+  hdf5Core_->writeAttributeToHdf5<std::vector<double>>(group,
+                                                       "intrinsic_matrix", K);
+  hdf5Core_->writeAttributeToHdf5<std::vector<double>>(
+      group, "rectification_matrix", R);
+  hdf5Core_->writeAttributeToHdf5<std::vector<double>>(group,
+                                                       "projection_matrix", P);
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(group, "binning_x",
+                                            cameraInfo.binning_x);
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(group, "binning_y",
+                                            cameraInfo.binning_y);
+  dump(path, cameraInfo.roi);
+
+  hdf5Core_->writeAttributeToHdf5<float>(group, "max_viewing_distance",
+                                         maxViewingDistance);
+
+  return uuid;
 }
 
-bool Hdf5Ros::dumpHeader(const std_msgs::Header& header,
-                         const std::string& datasetPath) const
+void Hdf5Ros::dump(const std::string& groupPath,
+                   const sensor_msgs::RegionOfInterest& roi)
 {
-  H5Easy::dumpAttribute(*hdf5File_, datasetPath, "seq", header.seq);
-  H5Easy::dumpAttribute(*hdf5File_, datasetPath, "stamp_seconds",
-                        header.stamp.sec);
-  H5Easy::dumpAttribute(*hdf5File_, datasetPath, "stamp_nanoseconds",
-                        header.stamp.nsec);
-  H5Easy::dumpAttribute(*hdf5File_, datasetPath, "frame_id", header.frame_id);
+  HighFive::Group group = *hdf5Core_->getHdf5Group(groupPath);
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(
+      group, "region_of_interest/x_offset", roi.x_offset);
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(
+      group, "region_of_interest/y_offset", roi.y_offset);
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(group, "region_of_interest/height",
+                                            roi.height);
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(group, "region_of_interest/width",
+                                            roi.width);
+  hdf5Core_->writeAttributeToHdf5<bool>(group, "region_of_interest/do_rectify",
+                                        roi.do_rectify);
+}
 
-  return true;
+void Hdf5Ros::dump(const std::string& groupPath, const std_msgs::Header& header)
+{
+  HighFive::Group group = *hdf5Core_->getHdf5Group(groupPath);
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(group, "header_seq", header.seq);
+  hdf5Core_->writeAttributeToHdf5<uint64_t>(group, "stamp_seconds",
+                                            header.stamp.sec);
+  hdf5Core_->writeAttributeToHdf5<uint64_t>(group, "stamp_nanos",
+                                            header.stamp.nsec);
+  hdf5Core_->writeAttributeToHdf5<std::string>(group, "frame_id",
+                                               header.frame_id);
+}
+
+void Hdf5Ros::dump(const sensor_msgs::PointCloud2& pcl)
+{
+  const std::string path =
+      "pointclouds/" +
+      boost::lexical_cast<std::string>(boost::uuids::random_generator()());
+  HighFive::DataSpace dataspace = HighFive::DataSpace(pcl.data.size());
+  HighFive::Group group = *hdf5Core_->getHdf5Group(path);
+
+  std::vector<std::string> names;
+  std::vector<uint32_t> offsets, counts;
+  std::vector<uint8_t> types;
+  for (const sensor_msgs::PointField& field : pcl.fields)
+  {
+    names.push_back(field.name);
+    offsets.push_back(field.offset);
+    counts.push_back(field.count);
+    types.push_back(field.datatype);
+  }
+
+  dump(path, pcl.header);
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(group, "height", pcl.height);
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(group, "width", pcl.width);
+  hdf5Core_->writeAttributeToHdf5<bool>(group, "is_bigendian", pcl.is_bigendian);
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(group, "point_step", pcl.point_step);
+  hdf5Core_->writeAttributeToHdf5<uint32_t>(group, "row_step", pcl.row_step);
+  hdf5Core_->writeAttributeToHdf5<bool>(group, "is_dense", pcl.is_dense);
+  hdf5Core_->writeAttributeToHdf5<std::vector<std::string>>(group, "fields",
+                                                            names);
+  hdf5Core_->writeAttributeToHdf5<std::vector<uint32_t>>(group, "offsets",
+                                                         offsets);
+  hdf5Core_->writeAttributeToHdf5<std::vector<uint32_t>>(group, "counts",
+                                                         counts);
+  hdf5Core_->writeAttributeToHdf5<std::vector<uint8_t>>(group, "types", types);
+  hdf5Core_->getHdf5DataSet<uint8_t>(path + "/rawdata", dataspace)
+      ->write(std::move(pcl.data.data()));
+}
+
+void Hdf5Ros::dump(const tf2_msgs::TFMessage& tf2_msg)
+{
+  for (const auto& transform : tf2_msg.transforms)
+  {
+    const std::string datagroupPath =
+        seerep_hdf5_core::Hdf5CoreTf::HDF5_GROUP_TF + "/" +
+        transform.header.frame_id + "_" + transform.child_frame_id;
+
+    std::unique_ptr<HighFive::Group> group;
+
+    if (!file_->exist(datagroupPath))
+    {
+      group =
+          std::make_unique<HighFive::Group>(file_->createGroup(datagroupPath));
+      group->createAttribute<uint64_t>(seerep_hdf5_core::Hdf5CoreTf::SIZE, 0);
+      hdf5Core_->writeAttributeToHdf5<std::string>(*group, "PARENT_FRAME",
+                                                   transform.header.frame_id);
+      hdf5Core_->writeAttributeToHdf5<std::string>(*group, "CHILD_FRAME",
+                                                   transform.child_frame_id);
+    }
+    else
+    {
+      group = std::make_unique<HighFive::Group>(file_->getGroup(datagroupPath));
+    }
+    hdf5CoreTf_->writeTimestamp(datagroupPath, { transform.header.stamp.sec,
+                                                 transform.header.stamp.nsec });
+    hdf5CoreTf_->writeTranslation(datagroupPath,
+                                  { transform.transform.translation.x,
+                                    transform.transform.translation.y,
+                                    transform.transform.translation.z });
+    hdf5CoreTf_->writeRotation(
+        datagroupPath,
+        { transform.transform.rotation.x, transform.transform.rotation.y,
+          transform.transform.rotation.z, transform.transform.rotation.w });
+
+    uint64_t size = hdf5Core_->readAttributeFromHdf5<uint64_t>(
+        *group, seerep_hdf5_core::Hdf5CoreTf::SIZE, "");
+
+    hdf5Core_->writeAttributeToHdf5<uint64_t>(
+        *group, seerep_hdf5_core::Hdf5CoreTf::SIZE, size + 1);
+  }
 }
 
 }  // namespace seerep_hdf5_ros

--- a/seerep_ros/seerep_ros_comm/CMakeLists.txt
+++ b/seerep_ros/seerep_ros_comm/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(SeerepCom REQUIRED)
 
 find_package(SeerepHdf5Pb REQUIRED)
 find_package(SeerepHdf5Fb REQUIRED)
+find_package(seerep_hdf5_ros REQUIRED)
 find_package(SeerepHdf5Core REQUIRED)
 find_package(SeerepCoreFb REQUIRED)
 find_package(SeerepCore REQUIRED)
@@ -58,6 +59,7 @@ catkin_package(
   roscpp
   seerep_ros_conversions_pb
   seerep_ros_conversions_fb
+  seerep_hdf5_ros
   roscpp
   topic_tools
   tf
@@ -71,6 +73,7 @@ include_directories(
   ${SeerepCom_INCLUDE_DIRS}
   ${SeerepHdf5Pb_INCLUDE_DIRS}
   ${SeerepHdf5Fb_INCLUDE_DIRS}
+  ${seerep_hdf5_ros_INCLUDE_DIRS}
   ${SeerepHdf5Core_INCLUDE_DIRS}
   ${SeerepCoreFb_INCLUDE_DIRS}
   ${seerep_ros_conversions_pb_INCLUDE_DIRS}
@@ -102,6 +105,7 @@ target_link_libraries(
   ${SeerepCom_LIBRARIES}
   ${seerep_ros_conversions_pb_LIBRARIES}
   ${SeerepHdf5Pb_LIBRARIES}
+  ${seerep_hdf5_ros_LIBRARIES}
   ${SeerepHdf5Core_LIBRARIES}
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}

--- a/seerep_ros/seerep_ros_comm/include/seerep_ros_comm/rostopic_dumper.h
+++ b/seerep_ros/seerep_ros_comm/include/seerep_ros_comm/rostopic_dumper.h
@@ -1,59 +1,83 @@
-#ifndef SEEREP_ROS_ROSTOPIC_DUMPER_H_
-#define SEEREP_ROS_ROSTOPIC_DUMPER_H_
+#ifndef HDF5_NODE_H
+#define HDF5_NODE_H
 
 #include <ros/master.h>
 #include <ros/ros.h>
-#include <seerep_hdf5_core/hdf5_core_general.h>
-#include <seerep_hdf5_core/hdf5_core_image.h>
-#include <seerep_hdf5_pb/hdf5_pb_image.h>
-#include <seerep_hdf5_pb/hdf5_pb_pointcloud.h>
-#include <seerep_hdf5_pb/hdf5_pb_tf.h>
-#include <seerep_ros_conversions_pb/conversions.h>
-#include <tf2_msgs/TFMessage.h>
+#include <seerep_hdf5_ros/hdf5_ros.h>
 
-#include <boost/functional/hash.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-#include <functional>
+#include <chrono>
 #include <optional>
+#include <thread>
 
-#include "types.h"
-
-namespace seerep_ros_comm
+namespace seerep_ros_examples
 {
-class DumpSensorMsgs
+
+std::string getCameraInfoTopic(const std::string& imageTopic);
+bool topicAvailable(const std::string& topic, ros::master::TopicInfo& info);
+
+class Hdf5Node
 {
 public:
-  DumpSensorMsgs(std::string hdf5FilePath, std::string project_frame_id,
-                 std::string project_name);
+  Hdf5Node() = delete;
 
-  std::optional<ros::Subscriber> getSubscriber(const std::string& message_type,
-                                               const std::string& topic);
+  Hdf5Node(const ros::NodeHandle& nh, const ros::NodeHandle& pnh);
 
-  void dump(const std_msgs::Header::ConstPtr& msg) const;
-
-  void dump(const sensor_msgs::PointCloud2::ConstPtr& msg) const;
-
-  void dump(const sensor_msgs::Image::ConstPtr& msg) const;
-
-  void dump(const geometry_msgs::Point::ConstPtr& msg) const;
-
-  void dump(const geometry_msgs::Quaternion::ConstPtr& msg) const;
-
-  void dump(const tf2_msgs::TFMessage::ConstPtr& msg) const;
+  void subscribe();
 
 private:
-  std::vector<seerep_core_msgs::LabelCategory> m_labelsCategory;
+  ros::NodeHandle nh_;
+  ros::NodeHandle pnh_;
 
-  std::shared_ptr<seerep_hdf5_pb::Hdf5PbTf> m_ioTf;
-  std::shared_ptr<seerep_hdf5_pb::Hdf5PbPointCloud> m_ioPointCloud;
-  std::shared_ptr<seerep_hdf5_pb::Hdf5PbImage> m_ioImage;
-  std::shared_ptr<seerep_hdf5_core::Hdf5CoreImage> m_ioImageCore;
-  ros::NodeHandle nh;
+  /* store the topics to dump */
+  std::vector<std::string> topics_;
+
+  /* keeps the subsribers alive outside of their initial function scope */
+  std::map<std::string, ros::Subscriber> subscribers_;
+
+  /*
+   * Current workaround is to store the first camera info message and use it
+   * for all following images. If the camera info is  subject to change, the
+   * camera and camera info topic should be time synchronized.
+   * This could be achieved by using message filters.
+   * http://wiki.ros.org/message_filters
+   */
+  std::string cameraInfoUuid_;
+
+  /* composition to the seerep_hdf5_ros interface */
+  std::unique_ptr<seerep_hdf5_ros::Hdf5Ros> hdf5Ros_;
+
+  /* @brief Get a parameter from the parameter server.
+   *
+   * @tparam T Type of the parameter.
+   * @param name Nname of the parameter.
+   * @return Vvalue of the parameter.
+   * @throws std::runtime_error if the parameter is missing.
+   */
+  template <typename T>
+  T getParameter(const std::string& name);
+
+  /*
+    Callbacks for the subscribers, some require additional logic, thus it is
+    not possible to unify them with a template.
+  */
+  void callback(const sensor_msgs::Image::ConstPtr& msg);
+  void callback(const sensor_msgs::PointCloud2::ConstPtr& msg);
+  void callback(const tf2_msgs::TFMessage::ConstPtr& msg);
 };
 
-}  // namespace seerep_ros_comm
+template <typename T>
+T Hdf5Node::getParameter(const std::string& name)
+{
+  T value;
+  if (!pnh_.getParam(name, value))
+  {
+    throw std::runtime_error("Paramter '" + name + "' is missing");
+  }
+  return value;
+}
 
-#endif  // SEEREP_ROS_ROSTOPIC_DUMPER_H_
+} /* Namespace seerep_ros_examples */
+
+#endif /* HDF5_NODE_H_ */

--- a/seerep_ros/seerep_ros_comm/launch/rostopic_dumper.launch
+++ b/seerep_ros/seerep_ros_comm/launch/rostopic_dumper.launch
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <launch>
-    <arg name="topics" default="['/image', '/tf', '/point_cloud2']"/>
-    <arg name="hdf5FolderPath" default="/seerep/seerep-data/"/>
-    <arg name="project_frame_id" default="map"/>
+    <arg name="topics" default="['/camera_r/depth/image_rect_raw', '/tf']"/>
+    <arg name="path" default="/seerep/seerep-data/"/>
+    <arg name="project_root_frame" default="map"/>
     <arg name="project_name" default="testproject"/>
-    <node name="seerep_ros_communication_rostopic_dumper" pkg="seerep_ros_comm" type="rostopic_dumper" output="screen">
+    <arg name="max_viewing_distance" default="1.0"/>
+    <node name="seerep_ros_examples_hdf5_node" pkg="seerep_ros_examples" type="seerep_ros_examples_hdf5_node" output="screen">
         <rosparam param="topics" subst_value="True">$(arg topics)</rosparam>
-        <rosparam param="hdf5FolderPath" subst_value="True">$(arg hdf5FolderPath)</rosparam>
-        <rosparam param="project_frame_id" subst_value="True">$(arg project_frame_id)</rosparam>
+        <rosparam param="path" subst_value="True">$(arg path)</rosparam>
+        <rosparam param="project_root_frame" subst_value="True">$(arg project_root_frame)</rosparam>
         <rosparam param="project_name" subst_value="True">$(arg project_name)</rosparam>
+        <rosparam param="max_viewing_distance" subst_value="True">$(arg max_viewing_distance)</rosparam>
     </node>
 </launch>

--- a/seerep_ros/seerep_ros_comm/package.xml
+++ b/seerep_ros/seerep_ros_comm/package.xml
@@ -18,6 +18,7 @@
   <depend>seerep_core_fb</depend>
   <depend>seerep_hdf5_pb</depend>
   <depend>seerep_hdf5_fb</depend>
+  <depend>seerep_hdf5_ros</depend>
   <depend>seerep_hdf5_core</depend>
   <depend>seerep_ros_conversions_fb</depend>
   <depend>seerep_ros_conversions_pb</depend>

--- a/seerep_ros/seerep_ros_comm/src/rostopic_dumper.cpp
+++ b/seerep_ros/seerep_ros_comm/src/rostopic_dumper.cpp
@@ -1,255 +1,130 @@
 #include "seerep_ros_comm/rostopic_dumper.h"
 
-namespace seerep_ros_comm
+namespace seerep_ros_examples
 {
-DumpSensorMsgs::DumpSensorMsgs(std::string hdf5FilePath,
-                               std::string project_frame_id,
-                               std::string project_name)
+
+bool topicAvailable(const std::string& topic, ros::master::TopicInfo& info)
 {
-  ROS_INFO_STREAM("creating a new project with name: \""
-                  << project_name << "\" and frame id: \"" << project_frame_id
-                  << "\" in  file: \"" << hdf5FilePath << "\"");
-  std::vector<std::string> labelsAsStdVector, instancesAsStdVector;
-  std::vector<int> labelIdDaturmaro, instanceIdDatumaro;
-  labelsAsStdVector.push_back("testlabel_0");
-  labelIdDaturmaro.push_back(42);
-  labelsAsStdVector.push_back("testlabel_1");
-  labelIdDaturmaro.push_back(43);
-
-  // no instances, just labels -> no uuids
-  instancesAsStdVector.push_back("");
-  instanceIdDatumaro.push_back(-1);
-  instancesAsStdVector.push_back("");
-  instanceIdDatumaro.push_back(-1);
-
-  seerep_core_msgs::LabelCategory labelCategory;
-  labelCategory.category = "testcategory";
-  labelCategory.instances = instancesAsStdVector;
-  labelCategory.instancesIdDatumaro = instanceIdDatumaro;
-  labelCategory.labels = labelsAsStdVector;
-  labelCategory.labelsIdDatumaro = labelIdDaturmaro;
-
-  m_labelsCategory.push_back(labelCategory);
-
-  auto write_mtx = std::make_shared<std::mutex>();
-  std::shared_ptr<HighFive::File> hdf5_file = std::make_shared<HighFive::File>(
-      hdf5FilePath, HighFive::File::OpenOrCreate);
-  auto ioGeneral = seerep_hdf5_core::Hdf5CoreGeneral(hdf5_file, write_mtx);
-  ioGeneral.writeProjectFrameId(project_frame_id);
-  ioGeneral.writeProjectname(project_name);
-
-  m_ioTf = std::make_shared<seerep_hdf5_pb::Hdf5PbTf>(hdf5_file, write_mtx);
-  m_ioPointCloud =
-      std::make_shared<seerep_hdf5_pb::Hdf5PbPointCloud>(hdf5_file, write_mtx);
-  m_ioImage =
-      std::make_shared<seerep_hdf5_pb::Hdf5PbImage>(hdf5_file, write_mtx);
-  m_ioImageCore =
-      std::make_shared<seerep_hdf5_core::Hdf5CoreImage>(hdf5_file, write_mtx);
-}
-
-void DumpSensorMsgs::dump(const std_msgs::Header::ConstPtr& msg) const
-{
-  (void)msg;  // ignore that variable without causing warnings
-  ROS_INFO_STREAM("Datatype not implemented.");
-}
-
-void DumpSensorMsgs::dump(const sensor_msgs::PointCloud2::ConstPtr& msg) const
-{
-  std::string uuid =
-      boost::lexical_cast<std::string>(boost::uuids::random_generator()());
-  ROS_INFO_STREAM("Dump point cloud 2 with uuid: " << uuid);
-  try
+  ros::master::V_TopicInfo topicInfo;
+  ros::master::getTopics(topicInfo);
+  auto findIter = std::find_if(topicInfo.begin(), topicInfo.end(),
+                               [&topic](const ros::master::TopicInfo& info) {
+                                 return info.name == topic;
+                               });
+  if (findIter != topicInfo.end())
   {
-    m_ioPointCloud->writePointCloud2(uuid,
-                                     seerep_ros_conversions_pb::toProto(*msg));
+    info.name = findIter->name;
+    info.datatype = findIter->datatype;
+    return true;
   }
-  catch (const std::exception& e)
+  return false;
+}
+
+std::string getCameraInfoTopic(const std::string& imageTopic)
+{
+  std::string cameraInfoTopic;
+  size_t pos = imageTopic.rfind("/");
+  if (pos != std::string::npos)
   {
-    ROS_ERROR_STREAM("Exception while saving point cloud: " << e.what());
+    cameraInfoTopic = imageTopic.substr(0, pos) + "/camera_info";
   }
+  return cameraInfoTopic;
 }
 
-void DumpSensorMsgs::dump(const sensor_msgs::Image::ConstPtr& msg) const
+Hdf5Node::Hdf5Node(const ros::NodeHandle& nh, const ros::NodeHandle& pnh)
+  : nh_{ nh }, pnh_{ pnh }
 {
-  boost::uuids::uuid uuid = boost::uuids::random_generator()();
-  std::string uuidString = boost::lexical_cast<std::string>(uuid);
-  try
+  const std::string path = getParameter<std::string>("path");
+  const std::string projectName = getParameter<std::string>("project_name");
+  const std::string rootFrameId =
+      getParameter<std::string>("project_root_frame");
+  topics_ = getParameter<std::vector<std::string>>("topics");
+  const std::string filename =
+      boost::lexical_cast<std::string>(boost::uuids::random_generator()()) +
+      ".h5";
+  hdf5Ros_ = std::make_unique<seerep_hdf5_ros::Hdf5Ros>(
+      path + "/" + filename, rootFrameId, projectName);
+}
+
+void Hdf5Node::subscribe()
+{
+  for (const std::string& topic : topics_)
   {
-    m_ioImage->writeImage(uuidString, seerep_ros_conversions_pb::toProto(*msg));
-
-    // also write the labels; filled with dummy data right now
-    m_ioImageCore->writeLabels(uuidString, m_labelsCategory);
-  }
-  catch (const std::exception& e)
-  {
-    ROS_ERROR_STREAM("Exception while saving image: " << e.what());
-  }
-}
-
-void DumpSensorMsgs::dump(const geometry_msgs::Point::ConstPtr& msg) const
-{
-  (void)msg;  // ignore that variable without causing warnings
-  ROS_INFO_STREAM("Datatype not implemented.");
-}
-
-void DumpSensorMsgs::dump(const geometry_msgs::Quaternion::ConstPtr& msg) const
-{
-  (void)msg;  // ignore that variable without causing warnings
-  ROS_INFO_STREAM("Datatype not implemented.");
-}
-
-void DumpSensorMsgs::dump(const tf2_msgs::TFMessage::ConstPtr& msg) const
-{
-  for (geometry_msgs::TransformStamped transform : msg->transforms)
-  {
-    try
+    ros::master::TopicInfo info;
+    if (!topicAvailable(topic, info))
     {
-      m_ioTf->writeTransformStamped(
-          seerep_ros_conversions_pb::toProto(transform, false));
+      ROS_WARN_STREAM("Topic " << topic << " not available");
     }
-    catch (const std::exception& e)
+
+    ROS_INFO_STREAM("Subscribing to topic " << topic);
+    ROS_INFO_STREAM("Topic datatype: " << info.datatype);
+
+    if (info.datatype == "sensor_msgs/Image")
     {
-      ROS_ERROR_STREAM("Exception while saving transformation: " << e.what());
+      /*
+       * Current workaround is to store the first camera info message and use it
+       * for all following images. If the camera info is  subject to change, the
+       * camera and camera info topic should be time synchronized.
+       * This could be achieved by using message filters.
+       * http://wiki.ros.org/message_filters
+       */
+      auto firstCameraInfo =
+          ros::topic::waitForMessage<sensor_msgs::CameraInfo>(
+              getCameraInfoTopic(topic), nh_, ros::Duration(3.0));
+
+      cameraInfoUuid_ = hdf5Ros_->dump(
+          *firstCameraInfo, getParameter<float>("max_viewing_distance"));
+
+      ros::Subscriber subImage = nh_.subscribe<sensor_msgs::Image>(
+          topic, 0, &Hdf5Node::callback, this);
+      subscribers_[topic] = subImage;
     }
-  }
-}
-
-std::optional<ros::Subscriber>
-DumpSensorMsgs::getSubscriber(const std::string& message_type,
-                              const std::string& topic)
-{
-  switch (type(message_type))
-  {
-    case std_msgs_Header:
-      return nh.subscribe<std_msgs::Header>(topic, 0, &DumpSensorMsgs::dump,
-                                            this);
-    case sensor_msgs_Image:
-      return nh.subscribe<sensor_msgs::Image>(topic, 0, &DumpSensorMsgs::dump,
-                                              this);
-    case sensor_msgs_PointCloud2:
-      return nh.subscribe<sensor_msgs::PointCloud2>(
-          topic, 0, &DumpSensorMsgs::dump, this);
-    case geometry_msgs_Point:
-      return nh.subscribe<geometry_msgs::Point>(topic, 0, &DumpSensorMsgs::dump,
-                                                this);
-    case geometry_msgs_Quaternion:
-      return nh.subscribe<geometry_msgs::Quaternion>(
-          topic, 0, &DumpSensorMsgs::dump, this);
-    case tf2_msgs_TFMessage:
-      return nh.subscribe<tf2_msgs::TFMessage>(topic, 0, &DumpSensorMsgs::dump,
-                                               this);
-    default:
-      ROS_ERROR_STREAM("Type \"" << message_type << "\" not supported");
-      return std::nullopt;
-  }
-}
-}  // namespace seerep_ros_comm
-
-int main(int argc, char** argv)
-{
-  ros::init(argc, argv, "seerep_ros_communication_hdf5_dump");
-  ros::NodeHandle nh;
-  ros::NodeHandle private_nh("~");
-
-  std::map<std::string, ros::Subscriber> subscribers;
-  std::vector<std::string> topics;
-
-  std::string hdf5FolderPath;
-  if (!private_nh.getParam("hdf5FolderPath", hdf5FolderPath))
-  {
-    ROS_WARN_STREAM(
-        "Use the \"hdf5FolderPath\" parameter to specify the HDF5 file!");
-    return EXIT_FAILURE;
-  }
-
-  std::string projectUuid;
-  if (private_nh.getParam("projectUuid", projectUuid))
-  {
-    try
+    else if (info.datatype == "sensor_msgs/PointCloud2")
     {
-      boost::uuids::string_generator gen;
-      // if this throws no exception, the UUID is valid
-      gen(projectUuid);
+      ros::Subscriber sub = nh_.subscribe<sensor_msgs::PointCloud2>(
+          topic, 0, &Hdf5Node::callback, this);
+      subscribers_[topic] = sub;
     }
-    catch (std::runtime_error const& e)
+    else if (info.datatype == "tf2_msgs/TFMessage")
     {
-      // mainly catching "invalid uuid string"
-      std::cout << e.what() << std::endl;
-      projectUuid =
-          boost::lexical_cast<std::string>(boost::uuids::random_generator()());
-      ROS_WARN_STREAM(
-          "The provided UUID is invalid! Generating a a new one. (" +
-          projectUuid + ".h5)");
-    }
-  }
-  else
-  {
-    projectUuid =
-        boost::lexical_cast<std::string>(boost::uuids::random_generator()());
-    ROS_WARN_STREAM("Use the \"projectUuid\" parameter to specify the HDF5 "
-                    "file! Generating a a new one. (" +
-                    projectUuid + ".h5)");
-  }
-
-  std::string hdf5FilePath = hdf5FolderPath + "/" + projectUuid + ".h5";
-
-  std::string project_frame_id, project_name;
-  if (!private_nh.getParam("project_frame_id", project_frame_id))
-  {
-    ROS_WARN_STREAM("Use the \"project_frame_id\" parameter to specify the "
-                    "base frame id of the Seerep project! The "
-                    "\"project_frame_id\" parameter should be a string.");
-  }
-  if (!private_nh.getParam("project_name", project_name))
-  {
-    ROS_WARN_STREAM("Use the \"project_name\" parameter to specify the name of "
-                    "the Seerep project! The "
-                    "\"project_name\" parameter should be a string.");
-  }
-
-  seerep_ros_comm::DumpSensorMsgs dumpSensorMsgs =
-      seerep_ros_comm::DumpSensorMsgs(hdf5FilePath, project_frame_id,
-                                      project_name);
-
-  ros::master::V_TopicInfo topic_info;
-  ros::master::getTopics(topic_info);
-
-  if (!private_nh.getParam("topics", topics))
-  {
-    ROS_WARN_STREAM("Use the \"topics\" parameter to specify the ROS topics "
-                    "which should be transferred! The "
-                    "\"topics\" parameter should be a list of strings.");
-  }
-
-  ROS_INFO_STREAM("Type names: " << seerep_ros_comm::names());
-
-  for (auto topic : topics)
-  {
-    ROS_INFO_STREAM("Trying to subscribe to topic \"" << topic << "\".");
-  }
-
-  for (auto info : topic_info)
-  {
-    auto find_iter = std::find(topics.begin(), topics.end(), info.name);
-
-    if (find_iter != topics.end())
-    {
-      auto sub_opt = dumpSensorMsgs.getSubscriber(info.datatype, info.name);
-      if (sub_opt)
-      {
-        ROS_INFO_STREAM("Subscribe to topic: \"" << info.name << "\" of type:\""
-                                                 << info.datatype << "\".");
-        subscribers[info.name] = *sub_opt;
-      }
-      topics.erase(find_iter);
+      ros::Subscriber sub = nh_.subscribe<tf2_msgs::TFMessage>(
+          topic, 0, &Hdf5Node::callback, this);
+      subscribers_[topic] = sub;
     }
     else
     {
-      ROS_INFO_STREAM("Available Topics: \"" << info.name << "\"");
+      ROS_WARN_STREAM("Type " << info.datatype << " not supported");
     }
   }
+}
+
+void Hdf5Node::callback(const sensor_msgs::ImageConstPtr& image)
+{
+  hdf5Ros_->dump(*image, cameraInfoUuid_);
+}
+
+void Hdf5Node::callback(const sensor_msgs::PointCloud2ConstPtr& pointCloud)
+{
+  hdf5Ros_->dump(*pointCloud);
+}
+
+void Hdf5Node::callback(const tf2_msgs::TFMessageConstPtr& tfMessage)
+{
+  hdf5Ros_->dump(*tfMessage);
+}
+
+} /* Namespace seerep_ros_examples */
+
+int main(int argc, char** argv)
+{
+  const std::string& node_name = "hdf5-node";
+  ros::init(argc, argv, node_name);
+
+  ros::NodeHandle nh;
+  ros::NodeHandle pnh("~");
+
+  seerep_ros_examples::Hdf5Node node(nh, pnh);
+  node.subscribe();
 
   ros::spin();
-
-  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
- Refactor `seerep_hdf5_ros` package
  - It now supports the storage of Images, CompressedImages, PointClouds and Transformations
  - Stores transformations via common implementation in hdf5_core

Merge after #408 