### PR TITLE
Add more precise spatial check for the query

### DIFF
--- a/examples/python/gRPC/images/gRPC_fb_sendImages.py
+++ b/examples/python/gRPC/images/gRPC_fb_sendImages.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import random
 import time
 import uuid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,16 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[tool.setuptools_scm]
-version_scheme = "no-guess-dev"
-local_scheme = "no-local-version"
-
 [project.urls]
 Repository = "https://github.com/DFKI-NI/seerep"
 Documentation = "https://dfki-ni.github.io/seerep/mkdocs/home/index.html"
+
+[tool.basedpyright]
+typeCheckingMode="standard"
+
+[tool.setuptools_scm]
+version_scheme = "no-guess-dev"
+local_scheme = "no-local-version"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/seerep_hdf5/seerep_hdf5_core/CMakeLists.txt
+++ b/seerep_hdf5/seerep_hdf5_core/CMakeLists.txt
@@ -21,6 +21,9 @@ find_package(
   REQUIRED
 )
 
+find_package(CGAL REQUIRED)
+set(CGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE TRUE)
+
 enable_testing()
 find_package(GTest 1.12.0 REQUIRED)
 
@@ -59,6 +62,7 @@ target_link_libraries(
   ${Boost_LOG_LIBRARY}
   ${Boost_LOG_SETUP_LIBRARY}
   ${catkin_LIBRARIES}
+  CGAL::CGAL
 )
 
 # create executable with tests

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_datatype_interface.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_datatype_interface.h
@@ -10,6 +10,9 @@
 
 namespace seerep_hdf5_core
 {
+typedef std::optional<std::pair<std::string, std::vector<seerep_core_msgs::Point>>>
+    frame_to_points_mapping;
+
 class Hdf5CoreDatatypeInterface
 {
 public:
@@ -19,6 +22,16 @@ public:
   readDataset(const std::string& uuid) = 0;
 
   virtual std::vector<std::string> getDatasetUuids() = 0;
+
+  /**
+   * @brief a option to pass points down to check for spatially, the first
+   * return value are the points which should get checked, the second in which
+   * frame they should be checked
+   *
+   * @return the points which should get checked (if empty this should be a
+   * noop) and the frame_id in which they need to get transformed from
+   */
+  virtual frame_to_points_mapping getPolygonConstraintPoints() = 0;
 };
 
 }  // namespace seerep_hdf5_core

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_datatype_interface.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_datatype_interface.h
@@ -3,7 +3,7 @@
 
 // seerep-msgs
 #include <seerep_msgs/dataset_indexable.h>
-#include <seerep_msgs/timestamp_frame_points.h>
+#include <seerep_msgs/timestamp_frame_mesh.h>
 
 // std
 #include <boost/uuid/uuid.hpp>
@@ -33,8 +33,8 @@ public:
    * @return the points which should get checked (if empty this should be a
    * noop) and the frame_id in which they need to get transformed from
    */
-  virtual std::optional<seerep_core_msgs::TimestampFramePoints>
-  getPolygonConstraintPoints(const boost::uuids::uuid& uuid_entry) = 0;
+  virtual std::optional<seerep_core_msgs::TimestampFrameMesh>
+  getPolygonConstraintMesh(const boost::uuids::uuid& uuid_entry) = 0;
 };
 
 }  // namespace seerep_hdf5_core

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_datatype_interface.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_datatype_interface.h
@@ -3,6 +3,7 @@
 
 // seerep-msgs
 #include <seerep_msgs/dataset_indexable.h>
+#include <seerep_msgs/timestamp_frame_points.h>
 
 // std
 #include <boost/uuid/uuid.hpp>
@@ -10,8 +11,6 @@
 
 namespace seerep_hdf5_core
 {
-typedef std::optional<std::pair<std::string, std::vector<seerep_core_msgs::Point>>>
-    frame_to_points_mapping;
 
 class Hdf5CoreDatatypeInterface
 {
@@ -28,10 +27,14 @@ public:
    * return value are the points which should get checked, the second in which
    * frame they should be checked
    *
+   * @param uuid_entry optionally specify the uuid of a specific data entry to
+   * perform additional operations
+   *
    * @return the points which should get checked (if empty this should be a
    * noop) and the frame_id in which they need to get transformed from
    */
-  virtual frame_to_points_mapping getPolygonConstraintPoints() = 0;
+  virtual std::optional<seerep_core_msgs::TimestampFramePoints>
+  getPolygonConstraintPoints(std::optional<boost::uuids::uuid> uuid_entry) = 0;
 };
 
 }  // namespace seerep_hdf5_core

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_datatype_interface.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_datatype_interface.h
@@ -34,7 +34,7 @@ public:
    * noop) and the frame_id in which they need to get transformed from
    */
   virtual std::optional<seerep_core_msgs::TimestampFramePoints>
-  getPolygonConstraintPoints(std::optional<boost::uuids::uuid> uuid_entry) = 0;
+  getPolygonConstraintPoints(const boost::uuids::uuid& uuid_entry) = 0;
 };
 
 }  // namespace seerep_hdf5_core

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_image.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_image.h
@@ -4,6 +4,10 @@
 // highfive
 #include <highfive/H5File.hpp>
 
+// CGAL
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Surface_mesh.h>
+
 // seerep_hdf5_core
 #include "hdf5_core_cameraintrinsics.h"
 #include "hdf5_core_datatype_interface.h"
@@ -12,7 +16,7 @@
 // seerep_msgs
 #include <seerep_msgs/dataset_indexable.h>
 #include <seerep_msgs/label_category.h>
-#include <seerep_msgs/timestamp_frame_points.h>
+#include <seerep_msgs/timestamp_frame_mesh.h>
 
 // std
 #include <boost/geometry.hpp>
@@ -97,16 +101,17 @@ public:
   std::vector<std::string> getDatasetUuids();
 
   /**
-   * @brief Get points which should get constraint by the query polygon,
-   *  otherwise the data is not fullyEncapsulated by the polygon
+   * @brief Get a timestamp-frameid-mesh struct which will be subject to
+   *  encapsulation checks of a query polygon
    *
-   * @param uuid_entry provide a uuid to be used for retrieving the camera uuid
+   * The mesh is created from the camera frustum.
    *
-   * @return the points which should get checked and the frame as a string in
-   *  which they should be checked
+   * @param uuid_entry of the image datatype entry to fetch the data from
+   *
+   * @return a struct containing the timestamp, frame_id of the data and the mesh itself
    */
-  std::optional<seerep_core_msgs::TimestampFramePoints>
-  getPolygonConstraintPoints(const boost::uuids::uuid& uuid_entry);
+  std::optional<seerep_core_msgs::TimestampFrameMesh>
+  getPolygonConstraintMesh(const boost::uuids::uuid& uuid_entry);
 
   /**
    * @brief Write generals labels based on C++ data structures to HdF5
@@ -154,7 +159,8 @@ public:
   /**
    * @brief Compute the frustum corner points from the camera_intrinsics uuid
    *
-   * @param cameraintrinsics_uuid
+   * @param cameraintrinsics_uuid to fetch the cameraintrinsics,
+   * from which the frustum should be based on
    *
    * @return the frustum corner points ordered as follows:
    *  1. near plane camera origin point (0,0,0)
@@ -166,6 +172,18 @@ public:
   std::array<seerep_core_msgs::Point, 5>
   computeFrustumPoints(const std::string& camintrinsics_uuid);
 
+  /**
+   * @brief create a surface mesh from given frustum points
+   *
+   * @param points frustum corner points ordered as follows:
+   *  1. near plane camera origin point (0,0,0)
+   *  2. far plane top left
+   *  3. far plane top right
+   *  4. far plane bottom left
+   *  5. far plane bottom right
+   *
+   * @return the created SurfaceMesh
+   */
   CGSurfaceMesh
   computeFrustumMesh(std::array<seerep_core_msgs::Point, 5>& points);
 

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_image.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_image.h
@@ -27,6 +27,11 @@
 
 namespace seerep_hdf5_core
 {
+
+using ExactKernel = CGAL::Exact_predicates_exact_constructions_kernel;
+using CGPoint_3 = ExactKernel::Point_3;
+using SurfaceMesh = CGAL::Surface_mesh<CGPoint_3>;
+
 /**
  * @brief Helper struct to summarize the general attributes of an image
  *
@@ -156,10 +161,12 @@ public:
    *  2. far plane top left
    *  3. far plane top right
    *  4. far plane bottom left
-   *  5. far plane bottom rigth
+   *  5. far plane bottom right
    */
   std::array<seerep_core_msgs::Point, 5>
   computeFrustumPoints(const std::string& camintrinsics_uuid);
+
+  SurfaceMesh computeFrustumMesh(std::array<seerep_core_msgs::Point, 5>& points);
 
   /**
    * @brief Computes the frustum for given camera intrinsic parameters and stores

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_image.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_image.h
@@ -30,7 +30,7 @@ namespace seerep_hdf5_core
 
 using ExactKernel = CGAL::Exact_predicates_exact_constructions_kernel;
 using CGPoint_3 = ExactKernel::Point_3;
-using SurfaceMesh = CGAL::Surface_mesh<CGPoint_3>;
+using CGSurfaceMesh = CGAL::Surface_mesh<CGPoint_3>;
 
 /**
  * @brief Helper struct to summarize the general attributes of an image
@@ -166,7 +166,8 @@ public:
   std::array<seerep_core_msgs::Point, 5>
   computeFrustumPoints(const std::string& camintrinsics_uuid);
 
-  SurfaceMesh computeFrustumMesh(std::array<seerep_core_msgs::Point, 5>& points);
+  CGSurfaceMesh
+  computeFrustumMesh(std::array<seerep_core_msgs::Point, 5>& points);
 
   /**
    * @brief Computes the frustum for given camera intrinsic parameters and stores

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_image.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_image.h
@@ -106,7 +106,7 @@ public:
    *  which they should be checked
    */
   std::optional<seerep_core_msgs::TimestampFramePoints>
-  getPolygonConstraintPoints(std::optional<boost::uuids::uuid> uuid_entry);
+  getPolygonConstraintPoints(const boost::uuids::uuid& uuid_entry);
 
   /**
    * @brief Write generals labels based on C++ data structures to HdF5

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_image.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_image.h
@@ -91,6 +91,15 @@ public:
   std::vector<std::string> getDatasetUuids();
 
   /**
+   * @brief Get points which should get constraint by the query polygon,
+   *  otherwise the data is not fullyEncapsulated by the polygon
+   *
+   * @return the points which should get checked and the frame as a string in
+   *  which they should be checked
+   */
+  frame_to_points_mapping getPolygonConstraintPoints();
+
+  /**
    * @brief Write generals labels based on C++ data structures to HdF5
    *
    * @param uuid uuid of the image data group

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_image.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_image.h
@@ -12,6 +12,7 @@
 // seerep_msgs
 #include <seerep_msgs/dataset_indexable.h>
 #include <seerep_msgs/label_category.h>
+#include <seerep_msgs/timestamp_frame_points.h>
 
 // std
 #include <boost/geometry.hpp>
@@ -94,10 +95,13 @@ public:
    * @brief Get points which should get constraint by the query polygon,
    *  otherwise the data is not fullyEncapsulated by the polygon
    *
+   * @param uuid_entry provide a uuid to be used for retrieving the camera uuid
+   *
    * @return the points which should get checked and the frame as a string in
    *  which they should be checked
    */
-  frame_to_points_mapping getPolygonConstraintPoints();
+  std::optional<seerep_core_msgs::TimestampFramePoints>
+  getPolygonConstraintPoints(std::optional<boost::uuids::uuid> uuid_entry);
 
   /**
    * @brief Write generals labels based on C++ data structures to HdF5
@@ -141,6 +145,21 @@ public:
    * @return const std::string path to the image dataset
    */
   const std::string getHdf5DataSetPath(const std::string& id) const;
+
+  /**
+   * @brief Compute the frustum corner points from the camera_intrinsics uuid
+   *
+   * @param cameraintrinsics_uuid
+   *
+   * @return the frustum corner points ordered as follows:
+   *  1. near plane camera origin point (0,0,0)
+   *  2. far plane top left
+   *  3. far plane top right
+   *  4. far plane bottom left
+   *  5. far plane bottom rigth
+   */
+  std::array<seerep_core_msgs::Point, 5>
+  computeFrustumPoints(const std::string& camintrinsics_uuid);
 
   /**
    * @brief Computes the frustum for given camera intrinsic parameters and stores

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point.h
@@ -10,6 +10,7 @@
 
 // seerep_msgs
 #include <seerep_msgs/dataset_indexable.h>
+#include <seerep_msgs/timestamp_frame_points.h>
 
 // std
 #include <boost/geometry.hpp>
@@ -42,7 +43,8 @@ public:
    *
    * @return a empty vector and string
    */
-  frame_to_points_mapping getPolygonConstraintPoints();
+  std::optional<seerep_core_msgs::TimestampFramePoints>
+  getPolygonConstraintPoints(std::optional<boost::uuids::uuid> uuid_entry);
 
 public:
   inline static const std::string RAWDATA = "rawdata";

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point.h
@@ -10,7 +10,7 @@
 
 // seerep_msgs
 #include <seerep_msgs/dataset_indexable.h>
-#include <seerep_msgs/timestamp_frame_points.h>
+#include <seerep_msgs/timestamp_frame_mesh.h>
 
 // std
 #include <boost/geometry.hpp>
@@ -41,10 +41,10 @@ public:
   /**
    * @brief THIS IS CURRENTLY A NOOP
    *
-   * @return a empty vector and string
+   * @return nullopt
    */
-  std::optional<seerep_core_msgs::TimestampFramePoints>
-  getPolygonConstraintPoints(const boost::uuids::uuid& uuid_entry);
+  std::optional<seerep_core_msgs::TimestampFrameMesh>
+  getPolygonConstraintMesh(const boost::uuids::uuid& uuid_entry);
 
 public:
   inline static const std::string RAWDATA = "rawdata";

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point.h
@@ -44,7 +44,7 @@ public:
    * @return a empty vector and string
    */
   std::optional<seerep_core_msgs::TimestampFramePoints>
-  getPolygonConstraintPoints(std::optional<boost::uuids::uuid> uuid_entry);
+  getPolygonConstraintPoints(const boost::uuids::uuid& uuid_entry);
 
 public:
   inline static const std::string RAWDATA = "rawdata";

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point.h
@@ -37,6 +37,13 @@ public:
 
   std::vector<std::string> getDatasetUuids();
 
+  /**
+   * @brief THIS IS CURRENTLY A NOOP
+   *
+   * @return a empty vector and string
+   */
+  frame_to_points_mapping getPolygonConstraintPoints();
+
 public:
   inline static const std::string RAWDATA = "rawdata";
 

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point_cloud.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point_cloud.h
@@ -25,6 +25,12 @@
 
 namespace seerep_hdf5_core
 {
+
+using ExactKernel = CGAL::Exact_predicates_exact_constructions_kernel;
+using CGPoint_3 = ExactKernel::Point_3;
+using CGSurfaceMesh = CGAL::Surface_mesh<CGPoint_3>;
+using CGVertexIndex = CGSurfaceMesh::Vertex_index;
+
 class Hdf5CorePointCloud : public Hdf5CoreGeneral,
                            public Hdf5CoreDatatypeInterface
 {
@@ -45,7 +51,21 @@ public:
    * @return a empty vector and string
    */
   std::optional<seerep_core_msgs::TimestampFramePoints>
-  getPolygonConstraintPoints(std::optional<boost::uuids::uuid> uuid_entry);
+  getPolygonConstraintPoints(const boost::uuids::uuid& uuid_entry);
+
+  /**
+   * @brief create mesh given a AABB
+   *
+   * @param bb_coords the coordinates of the AABB in the following order:
+   *        0: min_corner_x
+   *        1: min_corner_y
+   *        2: min_corner_z
+   *        3: max_corner_x
+   *        4: max_corner_y
+   *        5: max_corner_z
+   *  @return the surface mesh based on these coordinates
+   */
+  CGSurfaceMesh createMeshFromAABB(const std::vector<float>& bb_coords);
 
 public:
   // image / pointcloud attribute keys

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point_cloud.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point_cloud.h
@@ -38,6 +38,13 @@ public:
 
   std::vector<std::string> getDatasetUuids();
 
+  /**
+   * @brief THIS IS CURRENTLY A NOOP
+   *
+   * @return a empty vector and string
+   */
+  frame_to_points_mapping getPolygonConstraintPoints();
+
 public:
   // image / pointcloud attribute keys
   inline static const std::string HEIGHT = "height";

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point_cloud.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point_cloud.h
@@ -4,13 +4,17 @@
 // highfive
 #include <highfive/H5File.hpp>
 
+// CGAL
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Surface_mesh.h>
+
 // seerep_hdf5_core
 #include "hdf5_core_datatype_interface.h"
 #include "hdf5_core_general.h"
 
 // seerep-msgs
 #include <seerep_msgs/dataset_indexable.h>
-#include <seerep_msgs/timestamp_frame_points.h>
+#include <seerep_msgs/timestamp_frame_mesh.h>
 
 // std
 #include <boost/geometry.hpp>
@@ -46,23 +50,28 @@ public:
   std::vector<std::string> getDatasetUuids();
 
   /**
-   * @brief THIS IS CURRENTLY A NOOP
+   * @brief Get a timestamp-frameid-mesh struct which will be subject to
+   *  encapsulation checks of a query polygon
    *
-   * @return a empty vector and string
+   * The mesh is created from the AABB bounding a pointcloud datatype entry
+   *
+   * @param uuid_entry of the pointcloud datatype entry to fetch the data from
+   *
+   * @return a struct containing the timestamp, frame_id of the data and the mesh itself
    */
-  std::optional<seerep_core_msgs::TimestampFramePoints>
-  getPolygonConstraintPoints(const boost::uuids::uuid& uuid_entry);
+  std::optional<seerep_core_msgs::TimestampFrameMesh>
+  getPolygonConstraintMesh(const boost::uuids::uuid& uuid_entry);
 
   /**
-   * @brief create mesh given a AABB
+   * @brief create mesh from a given AABB
    *
    * @param bb_coords the coordinates of the AABB in the following order:
-   *        0: min_corner_x
-   *        1: min_corner_y
-   *        2: min_corner_z
-   *        3: max_corner_x
-   *        4: max_corner_y
-   *        5: max_corner_z
+   *       0. min_corner_x
+   *       1. min_corner_y
+   *       2. min_corner_z
+   *       3. max_corner_x
+   *       4. max_corner_y
+   *       5. max_corner_z
    *  @return the surface mesh based on these coordinates
    */
   CGSurfaceMesh createMeshFromAABB(const std::vector<float>& bb_coords);

--- a/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point_cloud.h
+++ b/seerep_hdf5/seerep_hdf5_core/include/seerep_hdf5_core/hdf5_core_point_cloud.h
@@ -10,6 +10,7 @@
 
 // seerep-msgs
 #include <seerep_msgs/dataset_indexable.h>
+#include <seerep_msgs/timestamp_frame_points.h>
 
 // std
 #include <boost/geometry.hpp>
@@ -43,7 +44,8 @@ public:
    *
    * @return a empty vector and string
    */
-  frame_to_points_mapping getPolygonConstraintPoints();
+  std::optional<seerep_core_msgs::TimestampFramePoints>
+  getPolygonConstraintPoints(std::optional<boost::uuids::uuid> uuid_entry);
 
 public:
   // image / pointcloud attribute keys

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_image.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_image.cpp
@@ -105,7 +105,7 @@ Hdf5CoreImage::getPolygonConstraintPoints(
   auto points = this->computeFrustumPoints(camintrinsics_uuid);
   auto mesh = this->computeFrustumMesh(points);
 
-  return seerep_core_msgs::TimestampFramePoints{ ts, SurfaceMesh{}, frame_id };
+  return seerep_core_msgs::TimestampFramePoints{ ts, frame_id, mesh };
 }
 
 void Hdf5CoreImage::writeLabels(
@@ -197,10 +197,10 @@ Hdf5CoreImage::computeFrustumPoints(const std::string& camintrinsics_uuid)
                                                  far_bottomright };
 }
 
-SurfaceMesh
+CGSurfaceMesh
 Hdf5CoreImage::computeFrustumMesh(std::array<seerep_core_msgs::Point, 5>& points)
 {
-  SurfaceMesh mesh;
+  CGSurfaceMesh mesh;
   auto o = mesh.add_vertex(
       CGPoint_3{ points[0].get<0>(), points[0].get<1>(), points[0].get<2>() });
 

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_image.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_image.cpp
@@ -68,16 +68,10 @@ std::vector<std::string> Hdf5CoreImage::getDatasetUuids()
 }
 
 std::optional<seerep_core_msgs::TimestampFramePoints>
-Hdf5CoreImage::getPolygonConstraintPoints(
-    std::optional<boost::uuids::uuid> uuid_entry)
+Hdf5CoreImage::getPolygonConstraintPoints(const boost::uuids::uuid& uuid_entry)
 {
-  if (!uuid_entry.has_value())
-  {
-    // TODO throw exception
-    return std::nullopt;
-  }
   std::string hdf5DataGroupPath =
-      getHdf5GroupPath(boost::uuids::to_string(uuid_entry.value()));
+      getHdf5GroupPath(boost::uuids::to_string(uuid_entry));
 
   auto dataGroupPtr = getHdf5Group(hdf5DataGroupPath);
 

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_image.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_image.cpp
@@ -67,6 +67,11 @@ std::vector<std::string> Hdf5CoreImage::getDatasetUuids()
   return getGroupDatasets(HDF5_GROUP_IMAGE);
 }
 
+frame_to_points_mapping Hdf5CoreImage::getPolygonConstraintPoints()
+{
+  return std::nullopt;
+}
+
 void Hdf5CoreImage::writeLabels(
     const std::string& uuid,
     const std::vector<seerep_core_msgs::LabelCategory>& labelCategory)

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point.cpp
@@ -64,7 +64,9 @@ std::vector<std::string> Hdf5CorePoint::getDatasetUuids()
   return getGroupDatasets(HDF5_GROUP_POINT);
 }
 
-frame_to_points_mapping Hdf5CorePoint::getPolygonConstraintPoints()
+std::optional<seerep_core_msgs::TimestampFramePoints>
+Hdf5CorePoint::getPolygonConstraintPoints(
+    std::optional<boost::uuids::uuid> uuid_entry)
 {
   return std::nullopt;
 }

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point.cpp
@@ -64,4 +64,9 @@ std::vector<std::string> Hdf5CorePoint::getDatasetUuids()
   return getGroupDatasets(HDF5_GROUP_POINT);
 }
 
+frame_to_points_mapping Hdf5CorePoint::getPolygonConstraintPoints()
+{
+  return std::nullopt;
+}
+
 }  // namespace seerep_hdf5_core

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point.cpp
@@ -65,9 +65,9 @@ std::vector<std::string> Hdf5CorePoint::getDatasetUuids()
 }
 
 std::optional<seerep_core_msgs::TimestampFramePoints>
-Hdf5CorePoint::getPolygonConstraintPoints(
-    std::optional<boost::uuids::uuid> uuid_entry)
+Hdf5CorePoint::getPolygonConstraintPoints(const boost::uuids::uuid& uuid_entry)
 {
+  (void)uuid_entry;
   return std::nullopt;
 }
 

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point.cpp
@@ -64,8 +64,8 @@ std::vector<std::string> Hdf5CorePoint::getDatasetUuids()
   return getGroupDatasets(HDF5_GROUP_POINT);
 }
 
-std::optional<seerep_core_msgs::TimestampFramePoints>
-Hdf5CorePoint::getPolygonConstraintPoints(const boost::uuids::uuid& uuid_entry)
+std::optional<seerep_core_msgs::TimestampFrameMesh>
+Hdf5CorePoint::getPolygonConstraintMesh(const boost::uuids::uuid& uuid_entry)
 {
   (void)uuid_entry;
   return std::nullopt;

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point_cloud.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point_cloud.cpp
@@ -61,7 +61,9 @@ std::vector<std::string> Hdf5CorePointCloud::getDatasetUuids()
   return getGroupDatasets(HDF5_GROUP_POINTCLOUD);
 }
 
-frame_to_points_mapping Hdf5CorePointCloud::getPolygonConstraintPoints()
+std::optional<seerep_core_msgs::TimestampFramePoints>
+Hdf5CorePointCloud::getPolygonConstraintPoints(
+    std::optional<boost::uuids::uuid> uuid_entry)
 {
   return std::nullopt;
 }

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point_cloud.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point_cloud.cpp
@@ -61,4 +61,9 @@ std::vector<std::string> Hdf5CorePointCloud::getDatasetUuids()
   return getGroupDatasets(HDF5_GROUP_POINTCLOUD);
 }
 
+frame_to_points_mapping Hdf5CorePointCloud::getPolygonConstraintPoints()
+{
+  return std::nullopt;
+}
+
 }  // namespace seerep_hdf5_core

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point_cloud.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point_cloud.cpp
@@ -130,15 +130,19 @@ Hdf5CorePointCloud::createMeshFromAABB(const std::vector<float>& bb_coords)
   // right plane
   descriptors.push_back(mesh.add_face(verts[2], verts[3], verts[7], verts[6]));
   // top plane
-  descriptors.push_back(mesh.add_face(verts[1], verts[5], verts[7], verts[3]));
+  // for whatever the reason the vertices have to be reversed...
+  descriptors.push_back(mesh.add_face(verts[3], verts[7], verts[5], verts[1]));
 
+  std::vector<CGSurfaceMesh::Face_index>::iterator idx;
   // check if any of the faces was not constructed properly
-  if (std::find_if(descriptors.begin(), descriptors.end(), [](auto elem) {
-        return elem == CGSurfaceMesh::null_face();
-      }) != descriptors.end())
+  if ((idx = std::find_if(descriptors.begin(), descriptors.end(), [](auto elem) {
+         return elem == CGSurfaceMesh::null_face();
+       })) != descriptors.end())
   {
     throw std::invalid_argument("Could not create the faces for the "
-                                "SurfaceMesh from the pointcloud AABB!");
+                                "SurfaceMesh from the pointcloud AABB! "
+                                "First null_face index: " +
+                                boost::lexical_cast<std::string>(idx->idx()));
   }
 
   return mesh;

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point_cloud.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point_cloud.cpp
@@ -28,7 +28,7 @@ Hdf5CorePointCloud::readDataset(const std::string& uuid)
     return std::nullopt;
   }
 
-  std::shared_ptr<HighFive::Group> group_ptr =
+  const std::shared_ptr<HighFive::Group> group_ptr =
       std::make_shared<HighFive::Group>(m_file->getGroup(hdf5DatasetPath));
 
   seerep_core_msgs::DatasetIndexable data;
@@ -63,9 +63,101 @@ std::vector<std::string> Hdf5CorePointCloud::getDatasetUuids()
 
 std::optional<seerep_core_msgs::TimestampFramePoints>
 Hdf5CorePointCloud::getPolygonConstraintPoints(
-    std::optional<boost::uuids::uuid> uuid_entry)
+    const boost::uuids::uuid& uuid_entry)
 {
-  return std::nullopt;
+  const std::scoped_lock lock(*m_write_mtx);
+
+  std::string uuid_str = boost::lexical_cast<std::string>(uuid_entry);
+
+  std::string hdf5DatasetPath = HDF5_GROUP_POINTCLOUD + "/" + uuid_str;
+
+  if (!m_file->exist(hdf5DatasetPath))
+  {
+    // TODO throw exception
+    return std::nullopt;
+  }
+
+  const std::shared_ptr<HighFive::Group> group_ptr =
+      std::make_shared<HighFive::Group>(m_file->getGroup(hdf5DatasetPath));
+
+  std::vector<float> bb;
+  group_ptr->getAttribute(seerep_hdf5_core::Hdf5CorePointCloud::BOUNDINGBOX)
+      .read(bb);
+
+  seerep_core_msgs::Header head;
+
+  readHeader(uuid_str, *group_ptr, head);
+
+  return seerep_core_msgs::TimestampFramePoints{ head.timestamp, head.frameId,
+                                                 this->createMeshFromAABB(bb) };
+}
+
+CGSurfaceMesh
+Hdf5CorePointCloud::createMeshFromAABB(const std::vector<float>& bb_coords)
+{
+  CGSurfaceMesh mesh;
+
+  // define base indices
+  int x_base = 0;
+  int y_base = 1;
+  int z_base = 2;
+
+  std::vector<CGVertexIndex> verts;
+
+  // create vertices with 3bit cube coords
+  for (uint idx = 0; idx < 0b1000; idx++)
+  {
+    int x_i = x_base + 3 * (idx & 0b001);
+    int y_i = y_base + 3 * ((idx & 0b010) >> 1);
+    int z_i = z_base + 3 * ((idx & 0b100) >> 2);
+
+    CGPoint_3 p{ bb_coords.at(x_i), bb_coords.at(y_i), bb_coords.at(z_i) };
+
+    verts.push_back(mesh.add_vertex(p));
+  }
+
+  // bottom plane
+  auto desc = mesh.add_face(verts[0], verts[4], verts[6], verts[2]);
+  if (desc == CGSurfaceMesh::null_face())
+  {
+    throw std::invalid_argument(
+        "Could not add bottom face from AABB to SurfaceMesh correctly!");
+  }
+  // front plane
+  mesh.add_face(verts[0], verts[1], verts[3], verts[2]);
+  if (desc == CGSurfaceMesh::null_face())
+  {
+    throw std::invalid_argument(
+        "Could not add front face from AABB to SurfaceMesh correctly!");
+  }
+  // left plane
+  mesh.add_face(verts[4], verts[5], verts[1], verts[0]);
+  if (desc == CGSurfaceMesh::null_face())
+  {
+    throw std::invalid_argument(
+        "Could not add left face from AABB to SurfaceMesh correctly!");
+  }
+  // back plane
+  mesh.add_face(verts[4], verts[5], verts[7], verts[6]);
+  if (desc == CGSurfaceMesh::null_face())
+  {
+    throw std::invalid_argument(
+        "Could not add back face from AABB to SurfaceMesh correctly!");
+  }
+  // right plane
+  mesh.add_face(verts[2], verts[3], verts[7], verts[6]);
+  if (desc == CGSurfaceMesh::null_face())
+  {
+    throw std::invalid_argument(
+        "Could not add right face from AABB to SurfaceMesh correctly!");
+  }
+  // top plane
+  mesh.add_face(verts[1], verts[5], verts[7], verts[3]);
+  if (desc == CGSurfaceMesh::null_face())
+  {
+    throw std::invalid_argument(
+        "Could not add top face from AABB to SurfaceMesh correctly!");
+  }
 }
 
 }  // namespace seerep_hdf5_core

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point_cloud.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point_cloud.cpp
@@ -61,9 +61,8 @@ std::vector<std::string> Hdf5CorePointCloud::getDatasetUuids()
   return getGroupDatasets(HDF5_GROUP_POINTCLOUD);
 }
 
-std::optional<seerep_core_msgs::TimestampFramePoints>
-Hdf5CorePointCloud::getPolygonConstraintPoints(
-    const boost::uuids::uuid& uuid_entry)
+std::optional<seerep_core_msgs::TimestampFrameMesh>
+Hdf5CorePointCloud::getPolygonConstraintMesh(const boost::uuids::uuid& uuid_entry)
 {
   const std::scoped_lock lock(*m_write_mtx);
 
@@ -73,7 +72,9 @@ Hdf5CorePointCloud::getPolygonConstraintPoints(
 
   if (!m_file->exist(hdf5DatasetPath))
   {
-    // TODO throw exception
+    throw std::invalid_argument("Hdf5DatasetPath not present for uuid " +
+                                uuid_str + "! Skipping precise check...");
+    BOOST_LOG_SEV(this->m_logger, boost::log::trivial::severity_level::info);
     return std::nullopt;
   }
 
@@ -88,8 +89,8 @@ Hdf5CorePointCloud::getPolygonConstraintPoints(
 
   readHeader(uuid_str, *group_ptr, head);
 
-  return seerep_core_msgs::TimestampFramePoints{ head.timestamp, head.frameId,
-                                                 this->createMeshFromAABB(bb) };
+  return seerep_core_msgs::TimestampFrameMesh{ head.timestamp, head.frameId,
+                                               this->createMeshFromAABB(bb) };
 }
 
 CGSurfaceMesh
@@ -158,6 +159,7 @@ Hdf5CorePointCloud::createMeshFromAABB(const std::vector<float>& bb_coords)
     throw std::invalid_argument(
         "Could not add top face from AABB to SurfaceMesh correctly!");
   }
+  return mesh;
 }
 
 }  // namespace seerep_hdf5_core

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point_cloud.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point_cloud.cpp
@@ -117,48 +117,30 @@ Hdf5CorePointCloud::createMeshFromAABB(const std::vector<float>& bb_coords)
     verts.push_back(mesh.add_vertex(p));
   }
 
+  std::vector<CGSurfaceMesh::Face_index> descriptors;
+
   // bottom plane
-  auto desc = mesh.add_face(verts[0], verts[4], verts[6], verts[2]);
-  if (desc == CGSurfaceMesh::null_face())
-  {
-    throw std::invalid_argument(
-        "Could not add bottom face from AABB to SurfaceMesh correctly!");
-  }
+  descriptors.push_back(mesh.add_face(verts[0], verts[4], verts[6], verts[2]));
   // front plane
-  mesh.add_face(verts[0], verts[1], verts[3], verts[2]);
-  if (desc == CGSurfaceMesh::null_face())
-  {
-    throw std::invalid_argument(
-        "Could not add front face from AABB to SurfaceMesh correctly!");
-  }
+  descriptors.push_back(mesh.add_face(verts[0], verts[1], verts[3], verts[2]));
   // left plane
-  mesh.add_face(verts[4], verts[5], verts[1], verts[0]);
-  if (desc == CGSurfaceMesh::null_face())
-  {
-    throw std::invalid_argument(
-        "Could not add left face from AABB to SurfaceMesh correctly!");
-  }
+  descriptors.push_back(mesh.add_face(verts[4], verts[5], verts[1], verts[0]));
   // back plane
-  mesh.add_face(verts[4], verts[5], verts[7], verts[6]);
-  if (desc == CGSurfaceMesh::null_face())
-  {
-    throw std::invalid_argument(
-        "Could not add back face from AABB to SurfaceMesh correctly!");
-  }
+  descriptors.push_back(mesh.add_face(verts[4], verts[5], verts[7], verts[6]));
   // right plane
-  mesh.add_face(verts[2], verts[3], verts[7], verts[6]);
-  if (desc == CGSurfaceMesh::null_face())
-  {
-    throw std::invalid_argument(
-        "Could not add right face from AABB to SurfaceMesh correctly!");
-  }
+  descriptors.push_back(mesh.add_face(verts[2], verts[3], verts[7], verts[6]));
   // top plane
-  mesh.add_face(verts[1], verts[5], verts[7], verts[3]);
-  if (desc == CGSurfaceMesh::null_face())
+  descriptors.push_back(mesh.add_face(verts[1], verts[5], verts[7], verts[3]));
+
+  // check if any of the faces was not constructed properly
+  if (std::find_if(descriptors.begin(), descriptors.end(), [](auto elem) {
+        return elem == CGSurfaceMesh::null_face();
+      }) != descriptors.end())
   {
-    throw std::invalid_argument(
-        "Could not add top face from AABB to SurfaceMesh correctly!");
+    throw std::invalid_argument("Could not create the faces for the "
+                                "SurfaceMesh from the pointcloud AABB!");
   }
+
   return mesh;
 }
 

--- a/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point_cloud.cpp
+++ b/seerep_hdf5/seerep_hdf5_core/src/hdf5_core_point_cloud.cpp
@@ -120,18 +120,17 @@ Hdf5CorePointCloud::createMeshFromAABB(const std::vector<float>& bb_coords)
   std::vector<CGSurfaceMesh::Face_index> descriptors;
 
   // bottom plane
-  descriptors.push_back(mesh.add_face(verts[0], verts[4], verts[6], verts[2]));
-  // front plane
   descriptors.push_back(mesh.add_face(verts[0], verts[1], verts[3], verts[2]));
+  // front plane
+  descriptors.push_back(mesh.add_face(verts[2], verts[6], verts[4], verts[0]));
   // left plane
-  descriptors.push_back(mesh.add_face(verts[4], verts[5], verts[1], verts[0]));
+  descriptors.push_back(mesh.add_face(verts[3], verts[7], verts[6], verts[2]));
   // back plane
-  descriptors.push_back(mesh.add_face(verts[4], verts[5], verts[7], verts[6]));
+  descriptors.push_back(mesh.add_face(verts[1], verts[5], verts[7], verts[3]));
   // right plane
-  descriptors.push_back(mesh.add_face(verts[2], verts[3], verts[7], verts[6]));
+  descriptors.push_back(mesh.add_face(verts[4], verts[5], verts[1], verts[0]));
   // top plane
-  // for whatever the reason the vertices have to be reversed...
-  descriptors.push_back(mesh.add_face(verts[3], verts[7], verts[5], verts[1]));
+  descriptors.push_back(mesh.add_face(verts[6], verts[7], verts[5], verts[4]));
 
   std::vector<CGSurfaceMesh::Face_index>::iterator idx;
   // check if any of the faces was not constructed properly
@@ -139,10 +138,11 @@ Hdf5CorePointCloud::createMeshFromAABB(const std::vector<float>& bb_coords)
          return elem == CGSurfaceMesh::null_face();
        })) != descriptors.end())
   {
-    throw std::invalid_argument("Could not create the faces for the "
-                                "SurfaceMesh from the pointcloud AABB! "
-                                "First null_face index: " +
-                                boost::lexical_cast<std::string>(idx->idx()));
+    throw std::invalid_argument(
+        "Could not create the faces for the "
+        "SurfaceMesh from the pointcloud AABB! "
+        "First null_face index: " +
+        std::to_string(std::distance(descriptors.begin(), idx)));
   }
 
   return mesh;

--- a/seerep_hdf5/seerep_hdf5_pb/src/hdf5_pb_pointcloud.cpp
+++ b/seerep_hdf5/seerep_hdf5_pb/src/hdf5_pb_pointcloud.cpp
@@ -138,7 +138,7 @@ void Hdf5PbPointCloud::writePoints(HighFive::Group& object,
 
   std::array<float, 3> min, max;
   min[0] = min[1] = min[2] = std::numeric_limits<float>::max();
-  max[0] = max[1] = max[2] = std::numeric_limits<float>::min();
+  max[0] = max[1] = max[2] = std::numeric_limits<float>::lowest();
 
   for (unsigned int i = 0; i < cloud.height(); i++)
   {

--- a/seerep_hdf5/seerep_hdf5_py/include/seerep_hdf5_py/impl/hdf5_py_pointcloud.hpp
+++ b/seerep_hdf5/seerep_hdf5_py/include/seerep_hdf5_py/impl/hdf5_py_pointcloud.hpp
@@ -80,6 +80,7 @@ void Hdf5PyPointCloud::getMinMax(
 {
   for (std::size_t i = 0; i < Nfields; i++)
   {
+    // TODO check if min needs to be replaced by lowest for, due to floating point types
     min[i] = std::numeric_limits<T>::max();
     max[i] = std::numeric_limits<T>::min();
 

--- a/seerep_msgs/CMakeLists.txt
+++ b/seerep_msgs/CMakeLists.txt
@@ -116,7 +116,7 @@ set(MY_CORE_MSGS
     ${CMAKE_CURRENT_SOURCE_DIR}/core/sparql_query.h
     ${CMAKE_CURRENT_SOURCE_DIR}/core/timeinterval.h
     ${CMAKE_CURRENT_SOURCE_DIR}/core/timestamp.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/core/timestamp_frame_points.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/timestamp_frame_mesh.h
 )
 
 add_library(SeerepCoreMsgsTarget INTERFACE)

--- a/seerep_msgs/CMakeLists.txt
+++ b/seerep_msgs/CMakeLists.txt
@@ -113,6 +113,7 @@ set(MY_CORE_MSGS
     ${CMAKE_CURRENT_SOURCE_DIR}/core/sparql_query.h
     ${CMAKE_CURRENT_SOURCE_DIR}/core/timeinterval.h
     ${CMAKE_CURRENT_SOURCE_DIR}/core/timestamp.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/core/timestamp_frame_points.h
 )
 
 add_library(SeerepCoreMsgsTarget INTERFACE)

--- a/seerep_msgs/CMakeLists.txt
+++ b/seerep_msgs/CMakeLists.txt
@@ -14,6 +14,9 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
 find_package(Boost REQUIRED)
 
+find_package(CGAL REQUIRED)
+set(CGAL_DO_NOT_WARN_ABOUT_CMAKE_BUILD_TYPE TRUE)
+
 set(MY_PROTO_FILES
     protos/boundingbox.proto
     protos/camera_intrinsics.proto

--- a/seerep_msgs/core/timestamp_frame_mesh.h
+++ b/seerep_msgs/core/timestamp_frame_mesh.h
@@ -1,5 +1,5 @@
-#ifndef SEEREP_CORE_MSGS_TIMESTAMP_FRAME_POINTS_H_
-#define SEEREP_CORE_MSGS_TIMESTAMP_FRAME_POINTS_H_
+#ifndef SEEREP_CORE_MSGS_TIMESTAMP_FRAME_MESH_H_
+#define SEEREP_CORE_MSGS_TIMESTAMP_FRAME_MESH_H_
 
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
@@ -13,7 +13,7 @@ using ExactKernel = CGAL::Exact_predicates_exact_constructions_kernel;
 using CGPoint_3 = CGAL::Point_3<ExactKernel>;
 using SurfaceMesh = CGAL::Surface_mesh<ExactKernel::Point_3>;
 
-struct TimestampFramePoints
+struct TimestampFrameMesh
 {
   seerep_core_msgs::Timestamp timestamp;
   std::string frame_id;

--- a/seerep_msgs/core/timestamp_frame_points.h
+++ b/seerep_msgs/core/timestamp_frame_points.h
@@ -1,0 +1,17 @@
+#ifndef SEEREP_CORE_MSGS_TIMESTAMP_FRAME_POINTS_H_
+#define SEEREP_CORE_MSGS_TIMESTAMP_FRAME_POINTS_H_
+
+#include "aabb.h"
+#include "timestamp.h"
+
+namespace seerep_core_msgs
+{
+struct TimestampFramePoints
+{
+  seerep_core_msgs::Timestamp timestamp;
+  std::array<seerep_core_msgs::Point, 5> points;
+  std::string frame_id;
+};
+}  // namespace seerep_core_msgs
+
+#endif

--- a/seerep_msgs/core/timestamp_frame_points.h
+++ b/seerep_msgs/core/timestamp_frame_points.h
@@ -16,8 +16,8 @@ using SurfaceMesh = CGAL::Surface_mesh<ExactKernel::Point_3>;
 struct TimestampFramePoints
 {
   seerep_core_msgs::Timestamp timestamp;
-  SurfaceMesh mesh;
   std::string frame_id;
+  SurfaceMesh mesh;
 };
 }  // namespace seerep_core_msgs
 

--- a/seerep_msgs/core/timestamp_frame_points.h
+++ b/seerep_msgs/core/timestamp_frame_points.h
@@ -1,15 +1,22 @@
 #ifndef SEEREP_CORE_MSGS_TIMESTAMP_FRAME_POINTS_H_
 #define SEEREP_CORE_MSGS_TIMESTAMP_FRAME_POINTS_H_
 
-#include "aabb.h"
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Surface_mesh.h>
+
 #include "timestamp.h"
 
 namespace seerep_core_msgs
 {
+
+using ExactKernel = CGAL::Exact_predicates_exact_constructions_kernel;
+using CGPoint_3 = CGAL::Point_3<ExactKernel>;
+using SurfaceMesh = CGAL::Surface_mesh<ExactKernel::Point_3>;
+
 struct TimestampFramePoints
 {
   seerep_core_msgs::Timestamp timestamp;
-  std::array<seerep_core_msgs::Point, 5> points;
+  SurfaceMesh mesh;
   std::string frame_id;
 };
 }  // namespace seerep_core_msgs

--- a/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
@@ -352,10 +352,11 @@ private:
    * @param queryFullyEncapsulated
    * @return std::optional<std::vector<seerep_core_msgs::AabbIdPair>>
    */
-  std::optional<std::vector<seerep_core_msgs::AabbIdPair>>
-  queryRtree(const seerep_core_msgs::rtree& rt,
-             const seerep_core_msgs::Polygon2D& polygon,
-             const bool queryFullyEncapsulated);
+  std::optional<std::vector<seerep_core_msgs::AabbIdPair>> queryRtree(
+      const seerep_core_msgs::rtree& rt,
+      const seerep_core_msgs::Polygon2D& polygon,
+      // const seerep_hdf5_core::frame_to_points_mapping frame_and_points,
+      const bool queryFullyEncapsulated);
 
   /**
    * @brief queries the temporal index and returns a vector of temporal bounding

--- a/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
@@ -3,6 +3,8 @@
 
 #include <CGAL/Boolean_set_operations_2.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/polygon_mesh_processing.h>
 
 #include <algorithm>
 #include <cstdint>
@@ -29,7 +31,11 @@
 #include <boost/uuid/uuid_generators.hpp>  // generators
 #include <boost/uuid/uuid_io.hpp>          // streaming operators etc.
 
-typedef CGAL::Exact_predicates_exact_constructions_kernel Kernel;
+typedef CGAL::Exact_predicates_exact_constructions_kernel ExactKernel;
+typedef CGAL::Point_3<ExactKernel> CGPoint_3;
+typedef CGAL::Surface_mesh<CGPoint_3> SurfaceMesh;
+typedef CGAL::Polygon_2<ExactKernel> CGPolygon_2;
+typedef CGAL::Point_2<ExactKernel> CGPoint_2;
 
 namespace seerep_core
 {
@@ -250,7 +256,7 @@ private:
    * @return true The polygon abides by CGAL requirements
    * @return false The polygon does not abide by CGAL requirements
    */
-  bool verifyPolygonIntegrity(CGAL::Polygon_2<Kernel>& polygon_cgal);
+  bool verifyPolygonIntegrity(CGAL::Polygon_2<ExactKernel>& polygon_cgal);
 
   /**
    * @brief transforms the bounding box to the datasets frameId (mostly the map
@@ -268,7 +274,7 @@ private:
    * @param polygon core msg polygon
    * @return CGAL::Polygon_2<Kernel> cgal polygon
    */
-  CGAL::Polygon_2<Kernel>
+  CGAL::Polygon_2<ExactKernel>
   toCGALPolygon(const seerep_core_msgs::Polygon2D& polygon);
 
   /**
@@ -277,7 +283,7 @@ private:
    * @param polygon core msg aabb
    * @return CGAL::Polygon_2<Kernel> cgal aabb
    */
-  CGAL::Polygon_2<Kernel> toCGALPolygon(const seerep_core_msgs::AABB& aabb);
+  CGAL::Polygon_2<ExactKernel> toCGALPolygon(const seerep_core_msgs::AABB& aabb);
 
   /**
    * @brief determine if the axis aligned bounding box is fully or paritally
@@ -294,18 +300,27 @@ private:
                           const seerep_core_msgs::Polygon2D& polygon,
                           bool& fullEncapsulation, bool& partialEncapsulation);
 
-  void intersectionDegreeCgalPolygons(CGAL::Polygon_2<Kernel> cgal1,
-                                      CGAL::Polygon_2<Kernel> cgal2,
+  void intersectionDegreeCgalPolygons(CGAL::Polygon_2<ExactKernel> cgal1,
+                                      CGAL::Polygon_2<ExactKernel> cgal2,
                                       bool z_partially,
                                       bool checkIfFullyEncapsulated,
                                       bool& fullEncapsulation,
                                       bool& partialEncapsulation);
 
-  void intersectionDegreeAABBinPolygon(
-      const seerep_core_msgs::AABB& aabb,
-      const seerep_core_msgs::Polygon2D& polygon,
-      CGAL::Polygon_2<Kernel> aabb_cgal, CGAL::Polygon_2<Kernel> polygon_cgal,
+  void
+  intersectionDegreeAABBinPolygon(const seerep_core_msgs::AABB& aabb,
+                                  const seerep_core_msgs::Polygon2D& polygon,
+                                  CGAL::Polygon_2<ExactKernel> aabb_cgal,
+                                  CGAL::Polygon_2<ExactKernel> polygon_cgal,
+                                  bool& fullEncapsulation,
+                                  bool& partialEncapsulation);
+
+  void checkIntersectionWithZExtrudedPolygon(
+      const SurfaceMesh& enclosedMesh,
+      const seerep_core_msgs::Polygon2D& enclosingPolygon,
       bool& fullEncapsulation, bool& partialEncapsulation);
+
+  CGPolygon_2 reduceZDimension(const SurfaceMesh& mesh);
 
   void getUuidsFromMap(
       std::unordered_map<boost::uuids::uuid, std::vector<boost::uuids::uuid>,

--- a/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
@@ -338,22 +338,20 @@ private:
                                   bool& partialEncapsulation);
 
   /**
-   * @brief checks whether the enclosedMesh is really enclosed by the
+   * @brief checks whether the enclosedMesh is really partially enclosed by the
    * enclosingPolygon
    *
    * Both the enclosedMesh and enclosingPolygon have to be convex objects
    *
    * @param enclosedMesh mesh to check whether it is enclosed by the polygon
    * @param enclosingPolygon polygon which is enclosing object
-   * @param fullEncapsulation flag which is set when enclosedMesh is fully
-   * encapsulated by the enclosingPolygon
    * @param partialEncapsulation flag which is set when enclosedMesh is
-   * partially encapsulated by the enclosingPolygon
+   *   partially encapsulated by the enclosingPolygon
    */
-  void checkIntersectionWithZExtrudedPolygon(
+  void checkPartialIntersectionWithZExtrudedPolygon(
       CGSurfaceMesh enclosedMesh,
       const seerep_core_msgs::Polygon2D& enclosingPolygon,
-      bool& fullEncapsulation, bool& partialEncapsulation);
+      bool& partialEncapsulation);
 
   /**
    * @brief Creates a 2DPolygon by removing the 3rd dimension from the points of the Mesh

--- a/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
@@ -345,18 +345,19 @@ private:
                         const seerep_core_msgs::Query& query);
 
   /**
-   * @brief queries the
+   * @brief queries the rtree
    *
    * @param rt
    * @param polygon
+   * @param coreDatatype
    * @param queryFullyEncapsulated
    * @return std::optional<std::vector<seerep_core_msgs::AabbIdPair>>
    */
-  std::optional<std::vector<seerep_core_msgs::AabbIdPair>> queryRtree(
-      const seerep_core_msgs::rtree& rt,
-      const seerep_core_msgs::Polygon2D& polygon,
-      // const seerep_hdf5_core::frame_to_points_mapping frame_and_points,
-      const bool queryFullyEncapsulated);
+  std::optional<std::vector<seerep_core_msgs::AabbIdPair>>
+  queryRtree(const seerep_core_msgs::rtree& rt,
+             seerep_hdf5_core::Hdf5CoreDatatypeInterface& coreDatatype,
+             const seerep_core_msgs::Polygon2D& polygon,
+             const bool queryFullyEncapsulated);
 
   /**
    * @brief queries the temporal index and returns a vector of temporal bounding

--- a/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
@@ -7,9 +7,6 @@
 #include <CGAL/Polygon_mesh_processing/triangulate_faces.h>
 #include <CGAL/Surface_mesh.h>
 
-#include <algorithm>
-#include <cstdint>
-#include <functional>
 #include <optional>
 #include <unordered_set>
 
@@ -302,6 +299,18 @@ private:
                           const seerep_core_msgs::Polygon2D& polygon,
                           bool& fullEncapsulation, bool& partialEncapsulation);
 
+  /**
+   * @brief check whether cgal1 is encapsulated by cgal2
+   *
+   * @param cgal1 the (possibly) encapsulated polygon
+   * @param cgal2 the (possibly) encapsulating polygon
+   * @param z_partially a flag to indicate partial height encapsulation by cgal2
+   * @param checkIfFullyEncapsulated whether to check fully encapsulation
+   * @param fullEncapsulation is set to false when fullEncapsulation is not
+   * valid. This flag is only set, when checkIfFullyEncapsulated is true
+   * @param partialEncapsulation is set to true, when cgal1 is partially
+   * encapsulated by cgal2
+   */
   void intersectionDegreeCgalPolygons(CGAL::Polygon_2<ExactKernel> cgal1,
                                       CGAL::Polygon_2<ExactKernel> cgal2,
                                       bool z_partially,
@@ -309,6 +318,17 @@ private:
                                       bool& fullEncapsulation,
                                       bool& partialEncapsulation);
 
+  /**
+   * @brief check if and to what degree AABB is encapsulated by polygon
+   *
+   * @param aabb the aabb to perform the check on
+   * @param polygon the query polygon
+   * @param aabb_cgal the core msgs aabb converted to a CGAL polygon
+   * @param polygon_cgal the core msgs polygon converted to a CGAL polygon
+   * @param fullEncapsulation whether aabb is fully encapsulated by the polygon
+   * @param partialEncapsulation whether the aabb and polygon intersect on a
+   *    subset of them in some way
+   */
   void
   intersectionDegreeAABBinPolygon(const seerep_core_msgs::AABB& aabb,
                                   const seerep_core_msgs::Polygon2D& polygon,
@@ -318,16 +338,39 @@ private:
                                   bool& partialEncapsulation);
 
   /**
+   * @brief checks whether the enclosedMesh is really enclosed by the
+   * enclosingPolygon
    *
+   * Both the enclosedMesh and enclosingPolygon have to be convex objects
    *
+   * @param enclosedMesh mesh to check whether it is enclosed by the polygon
+   * @param enclosingPolygon polygon which is enclosing object
+   * @param fullEncapsulation flag which is set when enclosedMesh is fully
+   * encapsulated by the enclosingPolygon
+   * @param partialEncapsulation flag which is set when enclosedMesh is
+   * partially encapsulated by the enclosingPolygon
    */
   void checkIntersectionWithZExtrudedPolygon(
       CGSurfaceMesh enclosedMesh,
       const seerep_core_msgs::Polygon2D& enclosingPolygon,
       bool& fullEncapsulation, bool& partialEncapsulation);
 
+  /**
+   * @brief Creates a 2DPolygon by removing the 3rd dimension from the points of the Mesh
+   *
+   * @param mesh the input mesh
+   *
+   * @return the reduced mesh as a CGAL 2D polygon
+   */
   CGPolygon_2 reduceZDimension(const CGSurfaceMesh& mesh);
 
+  /**
+   * @brief creates a SurfaceMesh from a seerep polygon 2D
+   *
+   * @param seerep_polygon the polygon to create the mesh from
+   *
+   * @return the resulting SurfaceMesh
+   */
   CGSurfaceMesh toSurfaceMesh(const seerep_core_msgs::Polygon2D& seerep_polygon);
 
   void getUuidsFromMap(

--- a/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_dataset.h
@@ -3,8 +3,9 @@
 
 #include <CGAL/Boolean_set_operations_2.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/intersection.h>
+#include <CGAL/Polygon_mesh_processing/triangulate_faces.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/polygon_mesh_processing.h>
 
 #include <algorithm>
 #include <cstdint>
@@ -33,9 +34,10 @@
 
 typedef CGAL::Exact_predicates_exact_constructions_kernel ExactKernel;
 typedef CGAL::Point_3<ExactKernel> CGPoint_3;
-typedef CGAL::Surface_mesh<CGPoint_3> SurfaceMesh;
+typedef CGAL::Surface_mesh<CGPoint_3> CGSurfaceMesh;
 typedef CGAL::Polygon_2<ExactKernel> CGPolygon_2;
 typedef CGAL::Point_2<ExactKernel> CGPoint_2;
+typedef CGSurfaceMesh::Face_index CGFaceIdx;
 
 namespace seerep_core
 {
@@ -315,12 +317,18 @@ private:
                                   bool& fullEncapsulation,
                                   bool& partialEncapsulation);
 
+  /**
+   *
+   *
+   */
   void checkIntersectionWithZExtrudedPolygon(
-      const SurfaceMesh& enclosedMesh,
+      CGSurfaceMesh enclosedMesh,
       const seerep_core_msgs::Polygon2D& enclosingPolygon,
       bool& fullEncapsulation, bool& partialEncapsulation);
 
-  CGPolygon_2 reduceZDimension(const SurfaceMesh& mesh);
+  CGPolygon_2 reduceZDimension(const CGSurfaceMesh& mesh);
+
+  CGSurfaceMesh toSurfaceMesh(const seerep_core_msgs::Polygon2D& seerep_polygon);
 
   void getUuidsFromMap(
       std::unordered_map<boost::uuids::uuid, std::vector<boost::uuids::uuid>,

--- a/seerep_srv/seerep_core/include/seerep_core/core_tf.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_tf.h
@@ -22,12 +22,19 @@
 #include <tf2/buffer_core.h>
 #include <tf2/transform_datatypes.h>
 
+// CGAL
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+
 // logging
 #include <boost/log/sources/severity_logger.hpp>
 #include <boost/log/trivial.hpp>
 
 namespace seerep_core
 {
+
+using ExactKernel = CGAL::Exact_predicates_exact_constructions_kernel;
+using CGPoint_3 = CGAL::Point_3<ExactKernel>;
+
 /**
  * @brief This is the class handling the TF buffer
  *
@@ -100,10 +107,10 @@ public:
    *
    * @return the transformed points
    */
-  std::vector<seerep_core_msgs::Point>
+  std::vector<CGPoint_3>
   transform(const std::string& sourceFrame, const std::string& targetFrame,
             const int64_t& timeSecs, const int64_t& timeNanos,
-            const std::vector<seerep_core_msgs::Point>& points);
+            const std::vector<std::reference_wrapper<CGPoint_3>>& points);
 
   /**
    * @brief Returns a vector of all frames stored in the TF tree by the TF buffer

--- a/seerep_srv/seerep_core/include/seerep_core/core_tf.h
+++ b/seerep_srv/seerep_core/include/seerep_core/core_tf.h
@@ -92,6 +92,20 @@ public:
                     const int64_t& timeNanos);
 
   /**
+   * @brief transform points into another frame
+   *
+   * @param sourceFrame the frame the points are in
+   * @param targetFrame the frame to transform the points to
+   * @param points the points to transform
+   *
+   * @return the transformed points
+   */
+  std::vector<seerep_core_msgs::Point>
+  transform(const std::string& sourceFrame, const std::string& targetFrame,
+            const int64_t& timeSecs, const int64_t& timeNanos,
+            const std::vector<seerep_core_msgs::Point>& points);
+
+  /**
    * @brief Returns a vector of all frames stored in the TF tree by the TF buffer
    * @return vector of frame names
    */

--- a/seerep_srv/seerep_core/src/core_dataset.cpp
+++ b/seerep_srv/seerep_core/src/core_dataset.cpp
@@ -312,7 +312,7 @@ std::optional<std::vector<seerep_core_msgs::AabbIdPair>> CoreDataset::queryRtree
     auto ts_frame_points = coreDatatype.getPolygonConstraintPoints(it->second);
     if (ts_frame_points.has_value())
     {
-      SurfaceMesh& mesh = ts_frame_points->mesh;
+      CGSurfaceMesh& mesh = ts_frame_points->mesh;
       std::vector<std::reference_wrapper<CGPoint_3>> ref_points;
 
       for (auto& idx : mesh.vertices())
@@ -1023,21 +1023,26 @@ void CoreDataset::intersectionDegreeAABBinPolygon(
                                  fullEncapsulation, partialEncapsulation);
 }
 
-SurfaceMesh toSurfaceMesh(const seerep_core_msgs::Polygon2D& seerep_polygon)
+CGSurfaceMesh
+CoreDataset::toSurfaceMesh(const seerep_core_msgs::Polygon2D& seerep_polygon)
 {
-  using VertexIndex = SurfaceMesh::Vertex_index;
+  using CGVertexIndex = CGSurfaceMesh::Vertex_index;
 
   if (seerep_polygon.vertices.size() <= 2)
   {
     // TODO: throw error
+    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::debug)
+        << "seerep_core_msgs::Polygon2D has not enough vertices to be expanded "
+           "to a full 3D SurfaceMesh";
   }
 
-  SurfaceMesh surface_mesh;
+  CGSurfaceMesh surface_mesh;
 
-  std::vector<VertexIndex> lower_surface, upper_surface;
+  std::vector<CGVertexIndex> lower_surface, upper_surface;
+  CGVertexIndex topInitial, bottomInitial;
+  CGVertexIndex topFirst, bottomFirst, topSecond, bottomSecond;
 
-  VertexIndex topInitial, bottomInitial;
-  VertexIndex topFirst, bottomFirst, topSecond, bottomSecond;
+  CGFaceIdx face_desc;
 
   auto z_top = seerep_polygon.z + seerep_polygon.height;
   auto& z_bottom = seerep_polygon.z;
@@ -1049,8 +1054,8 @@ SurfaceMesh toSurfaceMesh(const seerep_core_msgs::Polygon2D& seerep_polygon)
   bottomInitial = bottomFirst =
       surface_mesh.add_vertex(CGPoint_3{ x, y, z_bottom });
 
-  // the vertices are connected in order; It is assumed that the last point of
-  // the polygon connects to the first
+  // the vertices are connected in order; The assumption is that the last point
+  // of the polygon connects to the first
   for (size_t j = 1; j < verts.size(); ++j)
   {
     x = verts[j].get<0>();
@@ -1059,26 +1064,61 @@ SurfaceMesh toSurfaceMesh(const seerep_core_msgs::Polygon2D& seerep_polygon)
     bottomSecond = surface_mesh.add_vertex(CGPoint_3{ x, y, z_bottom });
 
     upper_surface.push_back(topFirst);
-    upper_surface.push_back(topSecond);
     lower_surface.push_back(bottomFirst);
-    lower_surface.push_back(bottomSecond);
-    surface_mesh.add_face(topFirst, topSecond, bottomFirst, bottomSecond);
+    face_desc =
+        surface_mesh.add_face(topFirst, topSecond, bottomSecond, bottomFirst);
+
+    if (face_desc == CGSurfaceMesh::null_face())
+    {
+      throw std::invalid_argument(
+          "Could not add side face from Polygon2d to SurfaceMesh correctly!");
+    }
 
     topFirst = topSecond;
     bottomFirst = bottomSecond;
   }
-  surface_mesh.add_face(topFirst, topInitial, bottomFirst, bottomInitial);
-  surface_mesh.add_face(lower_surface);
-  surface_mesh.add_face(upper_surface);
+  upper_surface.push_back(topFirst);
+  lower_surface.push_back(bottomFirst);
+
+  face_desc =
+      surface_mesh.add_face(topFirst, topInitial, bottomInitial, bottomFirst);
+  if (face_desc == CGSurfaceMesh::null_face())
+  {
+    throw std::invalid_argument("Could not add last side face from Polygon2d "
+                                "to SurfaceMesh correctly!");
+  }
+  face_desc = surface_mesh.add_face(lower_surface);
+  if (face_desc == CGSurfaceMesh::null_face())
+  {
+    throw std::invalid_argument("Could not add lower surface face from "
+                                "Polygon2d to SurfaceMesh correctly!");
+  }
+
+  std::reverse(upper_surface.begin(), upper_surface.end());
+
+  face_desc = surface_mesh.add_face(upper_surface);
+  if (face_desc == CGSurfaceMesh::null_face())
+  {
+    throw std::invalid_argument("Could not add upper surface face from "
+                                "Polygon2d to SurfaceMesh correctly!");
+  }
   return surface_mesh;
 }
 
 void CoreDataset::checkIntersectionWithZExtrudedPolygon(
-    const SurfaceMesh& enclosedMesh,
+    CGSurfaceMesh enclosedMesh,
     const seerep_core_msgs::Polygon2D& enclosingPolygon,
     bool& fullEncapsulation, bool& partialEncapsulation)
 {
   using CGAL::Polygon_mesh_processing::triangulate_faces;
+
+  if (!enclosedMesh.is_valid() || enclosedMesh.is_empty())
+  {
+    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::debug)
+        << "enclosedMesh passed to checkIntersectionWithZExtrudedPolygon "
+           "is either not valid or empty";
+    return;
+  }
 
   fullEncapsulation = false;
   partialEncapsulation = false;
@@ -1087,15 +1127,15 @@ void CoreDataset::checkIntersectionWithZExtrudedPolygon(
   // get highest and lowest point of innerPoints
   auto highestPoint = std::max_element(
       enclosedMesh.vertices_begin(), enclosedMesh.vertices_end(),
-      [&enclosedMesh](const SurfaceMesh::Vertex_index& p1,
-                      const SurfaceMesh::Vertex_index& p2) {
+      [&enclosedMesh](const CGSurfaceMesh::Vertex_index& p1,
+                      const CGSurfaceMesh::Vertex_index& p2) {
         return enclosedMesh.point(p1).z() < enclosedMesh.point(p2).z();
       });
 
   auto lowestPoint = std::min_element(
       enclosedMesh.vertices_begin(), enclosedMesh.vertices_end(),
-      [&enclosedMesh](const SurfaceMesh::Vertex_index& p1,
-                      const SurfaceMesh::Vertex_index& p2) {
+      [&enclosedMesh](const CGSurfaceMesh::Vertex_index& p1,
+                      const CGSurfaceMesh::Vertex_index& p2) {
         return enclosedMesh.point(p1).z() > enclosedMesh.point(p2).z();
       });
 
@@ -1133,15 +1173,27 @@ void CoreDataset::checkIntersectionWithZExtrudedPolygon(
 
   auto enclosingMesh = toSurfaceMesh(enclosingPolygon);
 
+  if (!enclosingMesh.is_valid() || enclosingMesh.is_empty())
+  {
+    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::debug)
+        << "enclosingMesh derived from enclosingPolygon"
+           "passed to checkIntersectionWithZExtrudedPolygon "
+           "is either not valid or empty";
+    return;
+  }
+
+  triangulate_faces(enclosedMesh);
+  triangulate_faces(enclosingMesh);
+
   partialEncapsulation =
       CGAL::Polygon_mesh_processing::do_intersect(enclosedMesh, enclosingMesh);
 }
 
-CGPolygon_2 CoreDataset::reduceZDimension(const SurfaceMesh& mesh)
+CGPolygon_2 CoreDataset::reduceZDimension(const CGSurfaceMesh& mesh)
 {
   CGPolygon_2 poly2;
 
-  for (SurfaceMesh::Vertex_index idx : mesh.vertices())
+  for (CGSurfaceMesh::Vertex_index idx : mesh.vertices())
   {
     CGPoint_2 p{ mesh.point(idx).x(), mesh.point(idx).y() };
     poly2.push_back(p);

--- a/seerep_srv/seerep_core/src/core_dataset.cpp
+++ b/seerep_srv/seerep_core/src/core_dataset.cpp
@@ -312,15 +312,28 @@ std::optional<std::vector<seerep_core_msgs::AabbIdPair>> CoreDataset::queryRtree
     auto ts_frame_points = coreDatatype.getPolygonConstraintPoints(it->second);
     if (ts_frame_points.has_value())
     {
-      auto points_vec = std::vector<seerep_core_msgs::Point>(
-          ts_frame_points->points.begin(), ts_frame_points->points.end());
-      // transform frame from the camera coordinate system to the map frame
-      points_vec =
+      SurfaceMesh& mesh = ts_frame_points->mesh;
+      std::vector<std::reference_wrapper<CGPoint_3>> ref_points;
+
+      for (auto& idx : mesh.vertices())
+      {
+        ref_points.push_back(mesh.point(idx));
+      }
+
+      // transform points from another coordinate system to the map frame of the project
+      auto points_vec =
           m_tfOverview->transform(ts_frame_points->frame_id, m_frameId,
                                   ts_frame_points->timestamp.seconds,
-                                  ts_frame_points->timestamp.nanos, points_vec);
+                                  ts_frame_points->timestamp.nanos, ref_points);
+
+      for (auto& idx : mesh.vertices())
+      {
+        mesh.point(idx) = ref_points[idx.idx()];
+      }
 
       // check if these point are enclosed by the query polygon
+      checkIntersectionWithZExtrudedPolygon(mesh, polygon, fullyEncapsulated,
+                                            partiallyEncapsulated);
     }
 
     // if there is no intersection between the result and the user's
@@ -837,7 +850,8 @@ void CoreDataset::addLabels(
   datatypeSpecifics->datasetInstancesMap.emplace(msgUuid, instanceUuids);
 }
 
-bool CoreDataset::verifyPolygonIntegrity(CGAL::Polygon_2<Kernel>& polygon_cgal)
+bool CoreDataset::verifyPolygonIntegrity(
+    CGAL::Polygon_2<ExactKernel>& polygon_cgal)
 {
   if (!polygon_cgal.is_simple())
   {
@@ -861,44 +875,43 @@ bool CoreDataset::verifyPolygonIntegrity(CGAL::Polygon_2<Kernel>& polygon_cgal)
   return true;
 }
 
-CGAL::Polygon_2<Kernel>
+CGAL::Polygon_2<ExactKernel>
 CoreDataset::toCGALPolygon(const seerep_core_msgs::Polygon2D& polygon)
 {
-  CGAL::Polygon_2<Kernel> polygon_cgal;
+  CGAL::Polygon_2<ExactKernel> polygon_cgal;
   for (auto point : polygon.vertices)
   {
     polygon_cgal.push_back(
-        Kernel::Point_2(bg::get<0>(point), bg::get<1>(point)));
+        ExactKernel::Point_2(bg::get<0>(point), bg::get<1>(point)));
   }
-
   return polygon_cgal;
 }
 
-CGAL::Polygon_2<Kernel>
+CGAL::Polygon_2<ExactKernel>
 CoreDataset::toCGALPolygon(const seerep_core_msgs::AABB& aabb)
 {
   /* Check if the bounding box has no spatial extent -> Only add one point to the polygon */
   if (bg::get<bg::min_corner, 0>(aabb) == bg::get<bg::max_corner, 0>(aabb) &&
       bg::get<bg::min_corner, 1>(aabb) == bg::get<bg::max_corner, 1>(aabb))
   {
-    Kernel::Point_2 points_aabb[] = { Kernel::Point_2(
+    ExactKernel::Point_2 points_aabb[] = { ExactKernel::Point_2(
         bg::get<bg::min_corner, 0>(aabb), bg::get<bg::min_corner, 1>(aabb)) };
-    CGAL::Polygon_2<Kernel> aabb_cgal(points_aabb, points_aabb + 1);
+    CGAL::Polygon_2<ExactKernel> aabb_cgal(points_aabb, points_aabb + 1);
     return aabb_cgal;
   }
   else
   {
-    Kernel::Point_2 points_aabb[] = {
-      Kernel::Point_2(bg::get<bg::min_corner, 0>(aabb),
-                      bg::get<bg::min_corner, 1>(aabb)),
-      Kernel::Point_2(bg::get<bg::max_corner, 0>(aabb),
-                      bg::get<bg::min_corner, 1>(aabb)),
-      Kernel::Point_2(bg::get<bg::max_corner, 0>(aabb),
-                      bg::get<bg::max_corner, 1>(aabb)),
-      Kernel::Point_2(bg::get<bg::min_corner, 0>(aabb),
-                      bg::get<bg::max_corner, 1>(aabb)),
+    ExactKernel::Point_2 points_aabb[] = {
+      ExactKernel::Point_2(bg::get<bg::min_corner, 0>(aabb),
+                           bg::get<bg::min_corner, 1>(aabb)),
+      ExactKernel::Point_2(bg::get<bg::max_corner, 0>(aabb),
+                           bg::get<bg::min_corner, 1>(aabb)),
+      ExactKernel::Point_2(bg::get<bg::max_corner, 0>(aabb),
+                           bg::get<bg::max_corner, 1>(aabb)),
+      ExactKernel::Point_2(bg::get<bg::min_corner, 0>(aabb),
+                           bg::get<bg::max_corner, 1>(aabb)),
     };
-    CGAL::Polygon_2<Kernel> aabb_cgal(points_aabb, points_aabb + 4);
+    CGAL::Polygon_2<ExactKernel> aabb_cgal(points_aabb, points_aabb + 4);
 
     return aabb_cgal;
   }
@@ -910,10 +923,10 @@ void CoreDataset::intersectionDegree(const seerep_core_msgs::AABB& aabb,
                                      bool& partialEncapsulation)
 {
   // convert seerep core aabb to cgal polygon
-  CGAL::Polygon_2<Kernel> aabb_cgal = toCGALPolygon(aabb);
+  CGAL::Polygon_2<ExactKernel> aabb_cgal = toCGALPolygon(aabb);
 
   // convert seerep core polygon to cgal polygon
-  CGAL::Polygon_2<Kernel> polygon_cgal = toCGALPolygon(polygon);
+  CGAL::Polygon_2<ExactKernel> polygon_cgal = toCGALPolygon(polygon);
 
   // a cgal polyon needs to be simple, convex and the points should be added
   // in a counter clockwise order
@@ -927,14 +940,12 @@ void CoreDataset::intersectionDegree(const seerep_core_msgs::AABB& aabb,
                                   fullEncapsulation, partialEncapsulation);
 }
 
-void CoreDataset::intersectionDegreeCgalPolygons(CGAL::Polygon_2<Kernel> cgal1,
-                                                 CGAL::Polygon_2<Kernel> cgal2,
-                                                 bool z_partially,
-                                                 bool checkIfFullyEncapsulated,
-                                                 bool& fullEncapsulation,
-                                                 bool& partialEncapsulation)
+void CoreDataset::intersectionDegreeCgalPolygons(
+    CGAL::Polygon_2<ExactKernel> cgal1, CGAL::Polygon_2<ExactKernel> cgal2,
+    bool z_partially, bool checkIfFullyEncapsulated, bool& fullEncapsulation,
+    bool& partialEncapsulation)
 {
-  for (CGAL::Polygon_2<Kernel>::Vertex_iterator vi = cgal1.vertices_begin();
+  for (CGAL::Polygon_2<ExactKernel>::Vertex_iterator vi = cgal1.vertices_begin();
        vi != cgal1.vertices_end(); ++vi)
   {
     // is the vertex of the aabb inside or on the boundary (not outside) the
@@ -956,8 +967,9 @@ void CoreDataset::intersectionDegreeCgalPolygons(CGAL::Polygon_2<Kernel> cgal1,
 void CoreDataset::intersectionDegreeAABBinPolygon(
     const seerep_core_msgs::AABB& aabb,
     const seerep_core_msgs::Polygon2D& polygon,
-    CGAL::Polygon_2<Kernel> aabb_cgal, CGAL::Polygon_2<Kernel> polygon_cgal,
-    bool& fullEncapsulation, bool& partialEncapsulation)
+    CGAL::Polygon_2<ExactKernel> aabb_cgal,
+    CGAL::Polygon_2<ExactKernel> polygon_cgal, bool& fullEncapsulation,
+    bool& partialEncapsulation)
 {
   fullEncapsulation = true;
   partialEncapsulation = false;
@@ -1009,6 +1021,132 @@ void CoreDataset::intersectionDegreeAABBinPolygon(
   // AABB are inside the polygon
   intersectionDegreeCgalPolygons(polygon_cgal, aabb_cgal, z_partially, false,
                                  fullEncapsulation, partialEncapsulation);
+}
+
+SurfaceMesh toSurfaceMesh(const seerep_core_msgs::Polygon2D& seerep_polygon)
+{
+  using VertexIndex = SurfaceMesh::Vertex_index;
+
+  if (seerep_polygon.vertices.size() <= 2)
+  {
+    // TODO: throw error
+  }
+
+  SurfaceMesh surface_mesh;
+
+  std::vector<VertexIndex> lower_surface, upper_surface;
+
+  VertexIndex topInitial, bottomInitial;
+  VertexIndex topFirst, bottomFirst, topSecond, bottomSecond;
+
+  auto z_top = seerep_polygon.z + seerep_polygon.height;
+  auto& z_bottom = seerep_polygon.z;
+  auto& verts = seerep_polygon.vertices;
+
+  auto x = verts[0].get<0>();
+  auto y = verts[0].get<1>();
+  topInitial = topFirst = surface_mesh.add_vertex(CGPoint_3{ x, y, z_top });
+  bottomInitial = bottomFirst =
+      surface_mesh.add_vertex(CGPoint_3{ x, y, z_bottom });
+
+  // the vertices are connected in order; It is assumed that the last point of
+  // the polygon connects to the first
+  for (size_t j = 1; j < verts.size(); ++j)
+  {
+    x = verts[j].get<0>();
+    y = verts[j].get<1>();
+    topSecond = surface_mesh.add_vertex(CGPoint_3{ x, y, z_top });
+    bottomSecond = surface_mesh.add_vertex(CGPoint_3{ x, y, z_bottom });
+
+    upper_surface.push_back(topFirst);
+    upper_surface.push_back(topSecond);
+    lower_surface.push_back(bottomFirst);
+    lower_surface.push_back(bottomSecond);
+    surface_mesh.add_face(topFirst, topSecond, bottomFirst, bottomSecond);
+
+    topFirst = topSecond;
+    bottomFirst = bottomSecond;
+  }
+  surface_mesh.add_face(topFirst, topInitial, bottomFirst, bottomInitial);
+  surface_mesh.add_face(lower_surface);
+  surface_mesh.add_face(upper_surface);
+  return surface_mesh;
+}
+
+void CoreDataset::checkIntersectionWithZExtrudedPolygon(
+    const SurfaceMesh& enclosedMesh,
+    const seerep_core_msgs::Polygon2D& enclosingPolygon,
+    bool& fullEncapsulation, bool& partialEncapsulation)
+{
+  using CGAL::Polygon_mesh_processing::triangulate_faces;
+
+  fullEncapsulation = false;
+  partialEncapsulation = false;
+
+  // check if the enclosing polygon encloses every point
+  // get highest and lowest point of innerPoints
+  auto highestPoint = std::max_element(
+      enclosedMesh.vertices_begin(), enclosedMesh.vertices_end(),
+      [&enclosedMesh](const SurfaceMesh::Vertex_index& p1,
+                      const SurfaceMesh::Vertex_index& p2) {
+        return enclosedMesh.point(p1).z() < enclosedMesh.point(p2).z();
+      });
+
+  auto lowestPoint = std::min_element(
+      enclosedMesh.vertices_begin(), enclosedMesh.vertices_end(),
+      [&enclosedMesh](const SurfaceMesh::Vertex_index& p1,
+                      const SurfaceMesh::Vertex_index& p2) {
+        return enclosedMesh.point(p1).z() > enclosedMesh.point(p2).z();
+      });
+
+  const double& z_low = enclosingPolygon.z;
+  double z_high = z_low + enclosingPolygon.height;
+
+  double p_low =
+      enclosedMesh.point(*lowestPoint).z().exact().convert_to<double>();
+  double p_high =
+      enclosedMesh.point(*highestPoint).z().exact().convert_to<double>();
+
+  // fully enclosed if all points of the enclosedMesh are contained in the enclosing Polygon
+  if ((z_low <= p_low && z_low <= p_high && z_high >= p_low && z_high >= p_high))
+  {
+    auto enclosedPolygon2CG = reduceZDimension(enclosedMesh);
+    auto enclosingPolygon2CG = toCGALPolygon(enclosingPolygon);
+
+    bool xy_bounded = true;
+    for (CGPolygon_2::Vertex_iterator vi = enclosedPolygon2CG.vertices_begin();
+         vi != enclosedPolygon2CG.vertices_end(); ++vi)
+    {
+      if (enclosingPolygon2CG.bounded_side(*vi) == CGAL::ON_UNBOUNDED_SIDE)
+      {
+        xy_bounded = false;
+        break;
+      }
+    }
+    if (xy_bounded)
+    {
+      fullEncapsulation = true;
+      partialEncapsulation = true;
+      return;
+    }
+  }
+
+  auto enclosingMesh = toSurfaceMesh(enclosingPolygon);
+
+  partialEncapsulation =
+      CGAL::Polygon_mesh_processing::do_intersect(enclosedMesh, enclosingMesh);
+}
+
+CGPolygon_2 CoreDataset::reduceZDimension(const SurfaceMesh& mesh)
+{
+  CGPolygon_2 poly2;
+
+  for (SurfaceMesh::Vertex_index idx : mesh.vertices())
+  {
+    CGPoint_2 p{ mesh.point(idx).x(), mesh.point(idx).y() };
+    poly2.push_back(p);
+  }
+  return poly2;
 }
 
 seerep_core_msgs::AabbTime

--- a/seerep_srv/seerep_core/src/core_dataset.cpp
+++ b/seerep_srv/seerep_core/src/core_dataset.cpp
@@ -208,10 +208,10 @@ CoreDataset::polygonToAABB(const seerep_core_msgs::Polygon2D& polygon)
   seerep_core_msgs::Point min, max;
 
   bg::set<0>(min, std::numeric_limits<float>::max());
-  bg::set<0>(max, std::numeric_limits<float>::min());
+  bg::set<0>(max, std::numeric_limits<float>::lowest());
 
   bg::set<1>(min, std::numeric_limits<float>::max());
-  bg::set<1>(max, std::numeric_limits<float>::min());
+  bg::set<1>(max, std::numeric_limits<float>::lowest());
 
   bg::set<2>(min, polygon.z);
   bg::set<2>(max, polygon.height + polygon.z);
@@ -1235,9 +1235,9 @@ CoreDataset::getSpatialBounds(std::vector<seerep_core_msgs::Datatype> datatypes)
   seerep_core_msgs::AABB overallbb;
 
   // set the minimum to minimum possible for the datatype
-  overallbb.max_corner().set<0>(std::numeric_limits<float>::min());
-  overallbb.max_corner().set<1>(std::numeric_limits<float>::min());
-  overallbb.max_corner().set<2>(std::numeric_limits<float>::min());
+  overallbb.max_corner().set<0>(std::numeric_limits<float>::lowest());
+  overallbb.max_corner().set<1>(std::numeric_limits<float>::lowest());
+  overallbb.max_corner().set<2>(std::numeric_limits<float>::lowest());
 
   // set the maximum for the maximum possible for the datatype
   overallbb.min_corner().set<0>(std::numeric_limits<float>::max());

--- a/seerep_srv/seerep_core/src/core_dataset.cpp
+++ b/seerep_srv/seerep_core/src/core_dataset.cpp
@@ -309,7 +309,7 @@ std::optional<std::vector<seerep_core_msgs::AabbIdPair>> CoreDataset::queryRtree
     intersectionDegree(it->first, polygon, fullyEncapsulated,
                        partiallyEncapsulated);
 
-    auto ts_frame_points = coreDatatype.getPolygonConstraintPoints(it->second);
+    auto ts_frame_points = coreDatatype.getPolygonConstraintMesh(it->second);
     if (ts_frame_points.has_value())
     {
       CGSurfaceMesh& mesh = ts_frame_points->mesh;
@@ -1030,10 +1030,9 @@ CoreDataset::toSurfaceMesh(const seerep_core_msgs::Polygon2D& seerep_polygon)
 
   if (seerep_polygon.vertices.size() <= 2)
   {
-    // TODO: throw error
-    BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::debug)
-        << "seerep_core_msgs::Polygon2D has not enough vertices to be expanded "
-           "to a full 3D SurfaceMesh";
+    throw std::invalid_argument(
+        "seerep_core_msgs::Polygon2D has not enough vertices to be expanded"
+        " to a full 3D SurfaceMesh");
   }
 
   CGSurfaceMesh surface_mesh;

--- a/seerep_srv/seerep_core/src/core_dataset.cpp
+++ b/seerep_srv/seerep_core/src/core_dataset.cpp
@@ -283,6 +283,7 @@ CoreDataset::querySpatialSensorPos(
 std::optional<std::vector<seerep_core_msgs::AabbIdPair>>
 CoreDataset::queryRtree(const seerep_core_msgs::rtree& rt,
                         const seerep_core_msgs::Polygon2D& polygon,
+                        // const seerep_hdf5_core::frame_to_points_mapping,
                         const bool queryFullyEncapsulated)
 {
   // generate rtree result container
@@ -306,6 +307,19 @@ CoreDataset::queryRtree(const seerep_core_msgs::rtree& rt,
     // provided in the query
     intersectionDegree(it->first, polygon, fullyEncapsulated,
                        partiallyEncapsulated);
+
+    // check thoroughly if a image has been passed and check whether the
+    // corresponding Frustum is in the polygon
+    // partial encapsulation is pre-condition for the case
+    // if the aabb of the data, which is a upper bound for the check, is
+    // already encapsulated we can skip the check
+    // if (partialEncapsulation && !fullEncapsulation)
+    // {
+    //   if (isPreciselyFullEncapsulated())
+    //   {
+    //     fullEncapsulation = true;
+    //   }
+    // }
 
     // if there is no intersection between the result and the user's
     // request, remove it from the iterator

--- a/seerep_srv/seerep_core/src/core_dataset.cpp
+++ b/seerep_srv/seerep_core/src/core_dataset.cpp
@@ -328,7 +328,7 @@ std::optional<std::vector<seerep_core_msgs::AabbIdPair>> CoreDataset::queryRtree
 
       for (auto& idx : mesh.vertices())
       {
-        mesh.point(idx) = ref_points[idx.idx()];
+        mesh.point(idx) = points_vec[idx.idx()];
       }
 
       // check if these point are enclosed by the query polygon

--- a/seerep_srv/seerep_core/src/core_dataset.cpp
+++ b/seerep_srv/seerep_core/src/core_dataset.cpp
@@ -1079,28 +1079,28 @@ CoreDataset::toSurfaceMesh(const seerep_core_msgs::Polygon2D& seerep_polygon)
   upper_surface.push_back(topFirst);
   lower_surface.push_back(bottomFirst);
 
-  face_desc =
-      surface_mesh.add_face(topFirst, topInitial, bottomInitial, bottomFirst);
-  if (face_desc == CGSurfaceMesh::null_face())
-  {
-    throw std::invalid_argument("Could not add last side face from Polygon2d "
-                                "to SurfaceMesh correctly!");
-  }
-  face_desc = surface_mesh.add_face(lower_surface);
-  if (face_desc == CGSurfaceMesh::null_face())
-  {
-    throw std::invalid_argument("Could not add lower surface face from "
-                                "Polygon2d to SurfaceMesh correctly!");
-  }
+  std::vector<CGSurfaceMesh::Face_index> descriptors;
 
+  descriptors.push_back(
+      surface_mesh.add_face(topFirst, topInitial, bottomInitial, bottomFirst));
+  descriptors.push_back(surface_mesh.add_face(lower_surface));
+
+  // for whatever reason the vertices need to be reversed for the latest face to
+  // construct the mesh correctly.
+  // If the construction of the latest face does not work ALWAYS try
+  // reversing the vertex order
   std::reverse(upper_surface.begin(), upper_surface.end());
+  descriptors.push_back(surface_mesh.add_face(upper_surface));
 
-  face_desc = surface_mesh.add_face(upper_surface);
-  if (face_desc == CGSurfaceMesh::null_face())
+  // check if any of the faces was not constructed properly
+  if (std::find_if(descriptors.begin(), descriptors.end(), [](auto elem) {
+        return elem == CGSurfaceMesh::null_face();
+      }) != descriptors.end())
   {
-    throw std::invalid_argument("Could not add upper surface face from "
-                                "Polygon2d to SurfaceMesh correctly!");
+    throw std::invalid_argument("Could not upper/lower or latest side face from"
+                                " Polygon2d to SurfaceMesh correctly!");
   }
+
   return surface_mesh;
 }
 

--- a/seerep_srv/seerep_core/src/core_dataset.cpp
+++ b/seerep_srv/seerep_core/src/core_dataset.cpp
@@ -309,31 +309,45 @@ std::optional<std::vector<seerep_core_msgs::AabbIdPair>> CoreDataset::queryRtree
     intersectionDegree(it->first, polygon, fullyEncapsulated,
                        partiallyEncapsulated);
 
-    auto ts_frame_points = coreDatatype.getPolygonConstraintMesh(it->second);
-    if (ts_frame_points.has_value())
+    // precise check
+    // This is only needed when fullyEncapsulated = false and
+    // partiallyEncapsulated = true as the aabb approximation through
+    // intersectionDegree is a upper bound for the real 3D object
+    // If fullyEncapsulated = true => the real object is inside the approx and thus
+    // inside the query
+    // If both are false using the approx for the real object
+    // the values must be false aswell
+    // True for partialEncapsulation and false for fullyEncapsulated must
+    // be verified, as this could be indeed false with the real object
+    if (partiallyEncapsulated == true && fullyEncapsulated == false)
     {
-      CGSurfaceMesh& mesh = ts_frame_points->mesh;
-      std::vector<std::reference_wrapper<CGPoint_3>> ref_points;
-
-      for (auto& idx : mesh.vertices())
+      auto ts_frame_points = coreDatatype.getPolygonConstraintMesh(it->second);
+      if (ts_frame_points.has_value())
       {
-        ref_points.push_back(mesh.point(idx));
+        CGSurfaceMesh& mesh = ts_frame_points->mesh;
+        std::vector<std::reference_wrapper<CGPoint_3>> ref_points;
+
+        for (auto& idx : mesh.vertices())
+        {
+          ref_points.push_back(mesh.point(idx));
+        }
+
+        // transform points from another coordinate system to the map frame of the project
+        auto points_vec =
+            m_tfOverview->transform(ts_frame_points->frame_id, m_frameId,
+                                    ts_frame_points->timestamp.seconds,
+                                    ts_frame_points->timestamp.nanos,
+                                    ref_points);
+
+        for (auto& idx : mesh.vertices())
+        {
+          mesh.point(idx) = points_vec[idx.idx()];
+        }
+
+        // check if these point are enclosed by the query polygon
+        checkPartialIntersectionWithZExtrudedPolygon(mesh, polygon,
+                                                     partiallyEncapsulated);
       }
-
-      // transform points from another coordinate system to the map frame of the project
-      auto points_vec =
-          m_tfOverview->transform(ts_frame_points->frame_id, m_frameId,
-                                  ts_frame_points->timestamp.seconds,
-                                  ts_frame_points->timestamp.nanos, ref_points);
-
-      for (auto& idx : mesh.vertices())
-      {
-        mesh.point(idx) = points_vec[idx.idx()];
-      }
-
-      // check if these point are enclosed by the query polygon
-      checkIntersectionWithZExtrudedPolygon(mesh, polygon, fullyEncapsulated,
-                                            partiallyEncapsulated);
     }
 
     // if there is no intersection between the result and the user's
@@ -1104,10 +1118,10 @@ CoreDataset::toSurfaceMesh(const seerep_core_msgs::Polygon2D& seerep_polygon)
   return surface_mesh;
 }
 
-void CoreDataset::checkIntersectionWithZExtrudedPolygon(
+void CoreDataset::checkPartialIntersectionWithZExtrudedPolygon(
     CGSurfaceMesh enclosedMesh,
     const seerep_core_msgs::Polygon2D& enclosingPolygon,
-    bool& fullEncapsulation, bool& partialEncapsulation)
+    bool& partialEncapsulation)
 {
   using CGAL::Polygon_mesh_processing::triangulate_faces;
 
@@ -1115,59 +1129,8 @@ void CoreDataset::checkIntersectionWithZExtrudedPolygon(
   {
     BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::debug)
         << "enclosedMesh passed to checkIntersectionWithZExtrudedPolygon "
-           "is either not valid or empty";
+           "is either not valid or empty. Skipping precise check...";
     return;
-  }
-
-  fullEncapsulation = false;
-  partialEncapsulation = false;
-
-  // check if the enclosing polygon encloses every point
-  // get highest and lowest point of innerPoints
-  auto highestPoint = std::max_element(
-      enclosedMesh.vertices_begin(), enclosedMesh.vertices_end(),
-      [&enclosedMesh](const CGSurfaceMesh::Vertex_index& p1,
-                      const CGSurfaceMesh::Vertex_index& p2) {
-        return enclosedMesh.point(p1).z() < enclosedMesh.point(p2).z();
-      });
-
-  auto lowestPoint = std::min_element(
-      enclosedMesh.vertices_begin(), enclosedMesh.vertices_end(),
-      [&enclosedMesh](const CGSurfaceMesh::Vertex_index& p1,
-                      const CGSurfaceMesh::Vertex_index& p2) {
-        return enclosedMesh.point(p1).z() > enclosedMesh.point(p2).z();
-      });
-
-  const double& z_low = enclosingPolygon.z;
-  double z_high = z_low + enclosingPolygon.height;
-
-  double p_low =
-      enclosedMesh.point(*lowestPoint).z().exact().convert_to<double>();
-  double p_high =
-      enclosedMesh.point(*highestPoint).z().exact().convert_to<double>();
-
-  // fully enclosed if all points of the enclosedMesh are contained in the enclosing Polygon
-  if ((z_low <= p_low && z_low <= p_high && z_high >= p_low && z_high >= p_high))
-  {
-    auto enclosedPolygon2CG = reduceZDimension(enclosedMesh);
-    auto enclosingPolygon2CG = toCGALPolygon(enclosingPolygon);
-
-    bool xy_bounded = true;
-    for (CGPolygon_2::Vertex_iterator vi = enclosedPolygon2CG.vertices_begin();
-         vi != enclosedPolygon2CG.vertices_end(); ++vi)
-    {
-      if (enclosingPolygon2CG.bounded_side(*vi) == CGAL::ON_UNBOUNDED_SIDE)
-      {
-        xy_bounded = false;
-        break;
-      }
-    }
-    if (xy_bounded)
-    {
-      fullEncapsulation = true;
-      partialEncapsulation = true;
-      return;
-    }
   }
 
   auto enclosingMesh = toSurfaceMesh(enclosingPolygon);
@@ -1177,7 +1140,7 @@ void CoreDataset::checkIntersectionWithZExtrudedPolygon(
     BOOST_LOG_SEV(m_logger, boost::log::trivial::severity_level::debug)
         << "enclosingMesh derived from enclosingPolygon"
            "passed to checkIntersectionWithZExtrudedPolygon "
-           "is either not valid or empty";
+           "is either not valid or empty. Skipping precise check...";
     return;
   }
 

--- a/seerep_srv/seerep_core/src/core_tf.cpp
+++ b/seerep_srv/seerep_core/src/core_tf.cpp
@@ -130,13 +130,13 @@ bool CoreTf::canTransform(const std::string& sourceFrame,
                                  ros::Time(timeSecs, timeNanos));
 }
 
-std::vector<seerep_core_msgs::Point>
+std::vector<CGPoint_3>
 CoreTf::transform(const std::string& sourceFrame,
                   const std::string& targetFrame, const int64_t& timeSecs,
                   const int64_t& timeNanos,
-                  const std::vector<seerep_core_msgs::Point>& points)
+                  const std::vector<std::reference_wrapper<CGPoint_3>>& points)
 {
-  std::vector<seerep_core_msgs::Point> transformed_points;
+  std::vector<CGPoint_3> transformed_points;
   if (this->canTransform(sourceFrame, targetFrame, timeSecs, timeNanos))
   {
     auto tf =
@@ -151,12 +151,14 @@ CoreTf::transform(const std::string& sourceFrame,
 
     for (auto&& p : points)
     {
-      tf2::Vector3 vec{ p.get<0>(), p.get<1>(), p.get<2>() };
+      tf2::Vector3 vec{ p.get().x().exact().convert_to<double>(),
+                        p.get().y().exact().convert_to<double>(),
+                        p.get().z().exact().convert_to<double>() };
+
       tf2::Vector3 vec_target = tf2_tf * vec;
 
-      seerep_core_msgs::Point p_target{ static_cast<float>(vec_target.getX()),
-                                        static_cast<float>(vec_target.getY()),
-                                        static_cast<float>(vec_target.getZ()) };
+      CGPoint_3 p_target{ vec_target.getX(), vec_target.getY(),
+                          vec_target.getZ() };
 
       transformed_points.push_back(p_target);
     }

--- a/seerep_srv/seerep_core/src/core_tf.cpp
+++ b/seerep_srv/seerep_core/src/core_tf.cpp
@@ -136,6 +136,11 @@ CoreTf::transform(const std::string& sourceFrame,
                   const int64_t& timeNanos,
                   const std::vector<std::reference_wrapper<CGPoint_3>>& points)
 {
+  if (sourceFrame == targetFrame)
+  {
+    return std::vector<CGPoint_3>{ points.begin(), points.end() };
+  }
+
   std::vector<CGPoint_3> transformed_points;
   if (this->canTransform(sourceFrame, targetFrame, timeSecs, timeNanos))
   {

--- a/tests/python/gRPC/images/test_gRPC_fb_queryImagePrecise.py
+++ b/tests/python/gRPC/images/test_gRPC_fb_queryImagePrecise.py
@@ -113,13 +113,7 @@ def send_tf(
 
     header = createHeader(builder, ts, frame_id, project_uuid, str(uuid4()))
 
-    # make sure the frustum is above the query cube
     trans = createVector3(builder, translation)
-
-    # this is equivalent to a Euler XYZ rotation with:
-    #   X = 225°
-    #   Y = 0°
-    #   Z = -45°
     quat = createQuaternion(builder, create_quat(*quaternion))
 
     tf = createTransform(builder, trans, quat)
@@ -133,7 +127,7 @@ def send_tf(
     return serialized_tf
 
 
-def test_gRPC_fb_queryImagePrecise(grpc_channel, project_setup):
+def test_gRPC_fb_queryImagePreciseIntersect(grpc_channel, project_setup):
     _, proj_uuid = project_setup
 
     timestamp_secs = 1661336507
@@ -147,11 +141,17 @@ def test_gRPC_fb_queryImagePrecise(grpc_channel, project_setup):
         grpc_channel,
         proj_uuid,
         camera_intrinsics_uuid,
-        gRPC_fb_sendImages.generate_image_ressources(8),
-        8 * [ts],
+        gRPC_fb_sendImages.generate_image_ressources(1),
+        1 * [ts],
     )
 
+    # make sure the frustum is above the query cube
     trans = (-0.5, -0.5, 1.5)
+
+    # this is equivalent to a Euler XYZ rotation with:
+    #   X = 225°
+    #   Y = 0°
+    #   Z = -45°
     rot = (-0.354, 0.854, -0.354, 0.146)
     send_tf(grpc_channel, proj_uuid, ts, trans, rot)
 
@@ -178,3 +178,51 @@ def test_gRPC_fb_queryImagePrecise(grpc_channel, project_setup):
     assert sorted(
         sent_images, key=lambda img: img["header"]["uuid_msgs"]
     ) == sorted(queried_images, key=lambda img: img["header"]["uuid_msgs"])
+
+
+# this test should detect no intersection with the precise method
+# but would fail with the AABB approximation
+def test_gRPC_fb_queryImagePreciseNoIntersect(grpc_channel, project_setup):
+    _, proj_uuid = project_setup
+
+    timestamp_secs = 1661336507
+    timestamp_nanos = 1245
+
+    ts = (timestamp_secs, timestamp_nanos)
+
+    camera_intrinsics_uuid = send_simple_camintrinsics(grpc_channel, proj_uuid)
+
+    sent_images = gRPC_fb_sendImages.send_images(
+        grpc_channel,
+        proj_uuid,
+        camera_intrinsics_uuid,
+        gRPC_fb_sendImages.generate_image_ressources(1),
+        1 * [ts],
+    )
+
+    trans = (-2.3, 2, 1)
+    rot = (1, 0, 0, 0)
+    send_tf(grpc_channel, proj_uuid, ts, trans, rot)
+
+    builder = flatbuffers.Builder(1024)
+
+    verts = [
+        createPoint2d(builder, *p) for p in [(-1, 1), (-1, 3), (-2, 3), (-2, 1)]
+    ]
+
+    polygon = createPolygon2D(builder, height=2, z=-0.5, vertices=verts)
+
+    queried_images = gRPC_fb_queryImages.query_images_raw(
+        builder, grpc_channel, proj_uuid, polygon2d=polygon
+    )
+
+    sent_images = [
+        fb_flatc_dict(img, SchemaFileNames.IMAGE) for img in sent_images
+    ]
+
+    queried_images = [
+        fb_flatc_dict(img, SchemaFileNames.IMAGE) for img in queried_images
+    ]
+
+    assert len(sent_images) > 0
+    assert len(queried_images) == 0

--- a/tests/python/gRPC/images/test_gRPC_fb_queryImagePrecise.py
+++ b/tests/python/gRPC/images/test_gRPC_fb_queryImagePrecise.py
@@ -127,7 +127,7 @@ def send_tf(
     return serialized_tf
 
 
-def test_gRPC_fb_queryImagePreciseIntersect(grpc_channel, project_setup):
+def test_queryImagePreciseIntersect(grpc_channel, project_setup):
     _, proj_uuid = project_setup
 
     timestamp_secs = 1661336507
@@ -182,7 +182,7 @@ def test_gRPC_fb_queryImagePreciseIntersect(grpc_channel, project_setup):
 
 # this test should detect no intersection with the precise method
 # but would fail with the AABB approximation
-def test_gRPC_fb_queryImagePreciseNoIntersect(grpc_channel, project_setup):
+def test_queryImagePreciseNoIntersect(grpc_channel, project_setup):
     _, proj_uuid = project_setup
 
     timestamp_secs = 1661336507

--- a/tests/python/gRPC/images/test_gRPC_fb_queryImagePrecise.py
+++ b/tests/python/gRPC/images/test_gRPC_fb_queryImagePrecise.py
@@ -1,0 +1,180 @@
+# test file for
+#   gRPC_fb_sendImages.py
+#   gRPC_fb_queryImages.py
+
+from typing import Tuple
+from uuid import uuid4
+
+import flatbuffers
+from grpc import Channel
+from gRPC.images import gRPC_fb_queryImages, gRPC_fb_sendImages
+from quaternion import quaternion as create_quat
+from seerep.fb import (
+    camera_intrinsics_service_grpc_fb as camera_intrinsic_service,
+)
+from seerep.fb import tf_service_grpc_fb as tf_service
+from seerep.util.fb_helper import (
+    createCameraIntrinsics,
+    createHeader,
+    createPoint2d,
+    createPolygon2D,
+    createQuaternion,
+    createRegionOfInterest,
+    createTimeStamp,
+    createTransform,
+    createTransformStamped,
+    createVector3,
+)
+from seerep.util.fb_to_dict import SchemaFileNames, fb_flatc_dict
+
+
+def send_simple_camintrinsics(
+    grpc_channel: Channel, project_uuid: str, frame_id: str = "camera"
+) -> str:
+    """
+    Create a simple Camera intrinsics with the Frustum in the form of
+    a square pyramid with a side length and a height of 1.
+
+    Returns:
+        str: The uuid of the created camera intrinsics.
+    """
+    fbb = flatbuffers.Builder()
+    camera_intrinsic_service_stub = (
+        camera_intrinsic_service.CameraIntrinsicsServiceStub(grpc_channel)
+    )
+    timestamp = createTimeStamp(fbb, 0, 0)
+    ci_uuid = str(uuid4())
+    header = createHeader(fbb, timestamp, frame_id, project_uuid, ci_uuid)
+    roi = createRegionOfInterest(fbb, 0, 0, 0, 0, False)
+
+    distortion_matrix: list[float] = [4, 5, 6, 7, 8, 9, 10, 11, 12]
+    rect_matrix: list[float] = [4, 5, 6, 7, 8, 9, 10, 11, 12]
+    # important for frustum calculations are the indices 0 and 4
+    # the frustum calculation can be found in
+    # seerep_hdf5/seerep_hdf5_core/src/hdf5_core_image.cpp
+    intrins_matrix: list[float] = [1, 5, 6, 7, 1, 9, 10, 11, 12]
+    proj_matrix: list[float] = [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+
+    ci_height = 1
+    ci_width = 1
+
+    max_view_dist = 1
+
+    cameraintrinsics = createCameraIntrinsics(
+        fbb,
+        header,
+        ci_height,
+        ci_width,
+        "plumb_bob",
+        distortion_matrix,
+        intrins_matrix,
+        rect_matrix,
+        proj_matrix,
+        4,
+        5,
+        roi,
+        max_view_dist,
+    )
+    fbb.Finish(cameraintrinsics)
+    camera_intrinsic_service_stub.TransferCameraIntrinsics(bytes(fbb.Output()))
+    return ci_uuid
+
+
+def send_tf(
+    grpc_channel: Channel,
+    project_uuid: str,
+    timestamp: Tuple[int, int],
+    translation: Tuple[float, float, float],
+    quaternion: Tuple[float, float, float, float],
+    frame_id: str = "map",
+    child_frame_id="camera",
+) -> bytes:
+    """
+    send a frame_id -> child_frame_id transform.
+
+    Args:
+        grpc_channel (Channel): The grpc_channel to a SEEREP server.
+        project_uuid (str): The project target for the transformations.
+        timestamp (Tuple[int, int]): The timestamp for the sent tf.
+        translation (Tuple[float, float, float]): the translation vector
+            in the form (x, y, z)
+        quaternion (int): the quaternion representing the orientation
+            of the tf in (w, x, y, z)
+        frame_id (str): The parent frame for the transformations.
+        child_frame_id (str): The child frame for the transformations.
+
+    Return:
+        the serialized tf object
+    """
+    builder = flatbuffers.Builder(1024)
+
+    secs, nanos = timestamp
+    ts = createTimeStamp(builder, secs, nanos)
+
+    header = createHeader(builder, ts, frame_id, project_uuid, str(uuid4()))
+
+    # make sure the frustum is above the query cube
+    trans = createVector3(builder, translation)
+
+    # this is equivalent to a Euler XYZ rotation with:
+    #   X = 225°
+    #   Y = 0°
+    #   Z = -45°
+    quat = createQuaternion(builder, create_quat(*quaternion))
+
+    tf = createTransform(builder, trans, quat)
+    tfs = createTransformStamped(builder, child_frame_id, header, tf)
+
+    builder.Finish(tfs)
+    serialized_tf = bytes(builder.Output())
+    tf_service.TfServiceStub(grpc_channel).TransferTransformStamped(
+        iter([serialized_tf])
+    )
+    return serialized_tf
+
+
+def test_gRPC_fb_queryImagePrecise(grpc_channel, project_setup):
+    _, proj_uuid = project_setup
+
+    timestamp_secs = 1661336507
+    timestamp_nanos = 1245
+
+    ts = (timestamp_secs, timestamp_nanos)
+
+    camera_intrinsics_uuid = send_simple_camintrinsics(grpc_channel, proj_uuid)
+
+    sent_images = gRPC_fb_sendImages.send_images(
+        grpc_channel,
+        proj_uuid,
+        camera_intrinsics_uuid,
+        gRPC_fb_sendImages.generate_image_ressources(8),
+        8 * [ts],
+    )
+
+    trans = (-0.5, -0.5, 1.5)
+    rot = (-0.354, 0.854, -0.354, 0.146)
+    send_tf(grpc_channel, proj_uuid, ts, trans, rot)
+
+    builder = flatbuffers.Builder(1024)
+
+    verts = [
+        createPoint2d(builder, *p) for p in [(0, 0), (1, 0), (1, 1), (0, 1)]
+    ]
+
+    polygon = createPolygon2D(builder, height=1, z=0, vertices=verts)
+
+    queried_images = gRPC_fb_queryImages.query_images_raw(
+        builder, grpc_channel, proj_uuid, polygon2d=polygon
+    )
+
+    sent_images = [
+        fb_flatc_dict(img, SchemaFileNames.IMAGE) for img in sent_images
+    ]
+
+    queried_images = [
+        fb_flatc_dict(img, SchemaFileNames.IMAGE) for img in queried_images
+    ]
+
+    assert sorted(
+        sent_images, key=lambda img: img["header"]["uuid_msgs"]
+    ) == sorted(queried_images, key=lambda img: img["header"]["uuid_msgs"])

--- a/tests/python/gRPC/pointcloud/test_gRPC_fb_queryPCPrecise.py
+++ b/tests/python/gRPC/pointcloud/test_gRPC_fb_queryPCPrecise.py
@@ -1,0 +1,245 @@
+# test file for
+#   gRPC_fb_queryPointCloud.py
+#   gRPC_fb_sendPointCloud.py
+from typing import List, Sequence, Tuple, Union
+from uuid import uuid4
+
+import flatbuffers
+import numpy as np
+from grpc import Channel
+from quaternion import quaternion as create_quat
+from seerep.fb import (
+    PointCloud2,
+)
+from seerep.fb import point_cloud_service_grpc_fb as pointCloudService
+from seerep.fb import tf_service_grpc_fb as tf_service
+from seerep.util.fb_helper import (
+    addToPointFieldVector,
+    create_label,
+    create_label_category,
+    createHeader,
+    createPoint2d,
+    createPointFields,
+    createPolygon2D,
+    createQuaternion,
+    createQuery,
+    createTimeStamp,
+    createTransform,
+    createTransformStamped,
+    createVector3,
+)
+from seerep.util.fb_to_dict import SchemaFileNames, fb_flatc_dict
+
+
+class Point3:
+    def __init__(self, x: float, y: float, z: float):
+        self.x = x
+        self.y = y
+        self.z = z
+
+
+def create_point_cloud_aabb(
+    builder,
+    header,
+    aabb_point1: Point3,
+    aabb_point2: Point3,
+    num_labels: int = 1,
+):
+    """Creates a flatbuffers point cloud message in form of a AABB
+    using min_point and max_point"""
+    pointFields = createPointFields(builder, ["x", "y", "z", "rgba"], 7, 4, 1)
+    pointFieldsVector = addToPointFieldVector(builder, pointFields)
+
+    # create labels
+    labelsStrings = [f"Label{i}" for i in range(num_labels)]
+    instance_uuids = [str(uuid4()) for _ in range(num_labels)]
+
+    labels = []
+    for i in range(len(labelsStrings)):
+        labels.append(
+            create_label(
+                builder=builder,
+                label=labelsStrings[i],
+                label_id=1,
+                instance_uuid=instance_uuids[i],
+                instance_id=5,
+            )
+        )
+    labelsCategory = []
+    labelsCategory.append(
+        create_label_category(
+            builder=builder,
+            labels=labels,
+            datumaro_json="a very valid datumaro json",
+            category="category Z",
+        )
+    )
+
+    PointCloud2.StartLabelsVector(builder, len(labelsCategory))
+    for label in labelsCategory:
+        builder.PrependUOffsetTRelative(label)
+    labelsCatOffset = builder.EndVector()
+
+    # Note: rgb field is float, for simplification
+    pointsBox = [[]]
+    x_min = min(aabb_point1.x, aabb_point2.x)
+    y_min = min(aabb_point1.y, aabb_point2.y)
+    z_min = min(aabb_point1.z, aabb_point2.z)
+    x_max = max(aabb_point1.x, aabb_point2.x)
+    y_max = max(aabb_point1.y, aabb_point2.y)
+    z_max = max(aabb_point1.y, aabb_point2.y)
+    # for x in range(int(x_min), int(x_max) + 1, 1):
+    #     for y in range(int(y_min), int(y_max) + 1, 1):
+    #         for z in range(int(z_min), int(z_max) + 1, 1):
+    #             pointsBox[0].append([x, y, z, 0])
+    # also include the minimal and maximal bounding point
+    pointsBox[0].append([x_min, y_min, z_min, 0])
+    pointsBox[0].append([x_max, y_max, z_max, 0])
+    points = np.array(pointsBox).astype(np.float32)
+
+    pointsVector = builder.CreateByteVector(points.tobytes())
+
+    # add all data into the flatbuffers point cloud message
+    PointCloud2.Start(builder)
+    PointCloud2.AddHeader(builder, header)
+    PointCloud2.AddHeight(builder, points.shape[0])
+    PointCloud2.AddWidth(builder, points.shape[1])
+    PointCloud2.AddIsBigendian(builder, True)
+    PointCloud2.AddPointStep(builder, 16)
+    PointCloud2.AddRowStep(builder, points.shape[1] * 16)
+    PointCloud2.AddFields(builder, pointFieldsVector)
+    PointCloud2.AddData(builder, pointsVector)
+    PointCloud2.AddLabels(builder, labelsCatOffset)
+    return PointCloud2.End(builder)
+
+
+def send_pcs(
+    grpc_channel: Channel,
+    pcs: Union[int, Sequence[int], bytearray, Sequence[bytearray]],
+) -> List[bytearray]:
+    """sends a serialized pointcloud flatbuffers message"""
+    if (
+        type(pcs) is not int
+        and type(pcs) is not bytes
+        and (type(pcs) is not bytearray)
+    ):
+        if len(pcs) > 0 and type(pcs[0]) is int:
+            pcs = [bytes(pc) for pc in pcs]
+    elif type(pcs) is int or type(pcs) is bytearray:
+        pcs = [bytes(pcs)]
+    else:
+        pcs = [pcs]
+
+    stub = pointCloudService.PointCloudServiceStub(grpc_channel)
+    stub.TransferPointCloud2(iter(pcs))
+    return pcs
+
+
+def send_tf(
+    grpc_channel: Channel,
+    project_uuid: str,
+    timestamp: Tuple[int, int],
+    translation: Tuple[float, float, float],
+    quaternion: Tuple[float, float, float, float],
+    frame_id: str = "map",
+    child_frame_id="camera",
+) -> bytes:
+    """
+    send a frame_id -> child_frame_id transform.
+
+    Args:
+        grpc_channel (Channel): The grpc_channel to a SEEREP server.
+        project_uuid (str): The project target for the transformations.
+        timestamp (Tuple[int, int]): The timestamp for the sent tf.
+        translation (Tuple[float, float, float]): the translation vector
+            in the form (x, y, z)
+        quaternion (int): the quaternion representing the orientation
+            of the tf in (w, x, y, z)
+        frame_id (str): The parent frame for the transformations.
+        child_frame_id (str): The child frame for the transformations.
+
+    Return:
+        the serialized tf object
+    """
+    builder = flatbuffers.Builder(1024)
+
+    secs, nanos = timestamp
+    ts = createTimeStamp(builder, secs, nanos)
+
+    header = createHeader(builder, ts, frame_id, project_uuid, str(uuid4()))
+
+    trans = createVector3(builder, translation)
+    quat = createQuaternion(builder, create_quat(*quaternion))
+
+    tf = createTransform(builder, trans, quat)
+    tfs = createTransformStamped(builder, child_frame_id, header, tf)
+
+    builder.Finish(tfs)
+    serialized_tf = bytes(builder.Output())
+    tf_service.TfServiceStub(grpc_channel).TransferTransformStamped(
+        iter([serialized_tf])
+    )
+    return serialized_tf
+
+
+def test_queryPCPreciseNoIntersect(grpc_channel, project_setup):
+    _, proj_uuid = project_setup
+
+    builder = flatbuffers.Builder()
+    pcl_stub = pointCloudService.PointCloudServiceStub(grpc_channel)
+
+    timestamp_secs = 1661336507
+    timestamp_nanos = 1245
+
+    ts_obj = createTimeStamp(builder, timestamp_secs, timestamp_nanos)
+
+    header = createHeader(builder, ts_obj, "pc_test", proj_uuid, str(uuid4()))
+
+    pc_msg = create_point_cloud_aabb(
+        builder, header, Point3(0, 0, 0), Point3(3, 2, 2)
+    )
+    builder.Finish(pc_msg)
+    sent_pcs = send_pcs(grpc_channel, builder.Output())
+
+    translation = (-4, -4, -2)
+    # This is equivalent to XYZ Euler:
+    #   X = 45°
+    #   Y = 0°
+    #   Z = 0°
+    quaternion = (0.924, 0.383, 0, 0)
+    send_tf(
+        grpc_channel,
+        proj_uuid,
+        (timestamp_secs, timestamp_nanos),
+        translation,
+        quaternion,
+        child_frame_id="pc_test",
+    )
+
+    builder = flatbuffers.Builder()
+    # build the query
+    verts = [
+        createPoint2d(builder, *p)
+        for p in [(-4, -3), (-2, -3), (-2, -1), (-4, -1)]
+    ]
+    polygon = createPolygon2D(builder, height=2, z=0.5, vertices=verts)
+    query = createQuery(builder, polygon2d=polygon)
+    builder.Finish(query)
+    queried_pcs = pcl_stub.GetPointCloud2(bytes(builder.Output()))
+
+    # convert the sent/queried pcs
+    sent_pcs = sorted(
+        [fb_flatc_dict(pcl, SchemaFileNames.POINT_CLOUD_2) for pcl in sent_pcs],
+        key=lambda pc: pc["header"]["uuid_msgs"],
+    )
+
+    queried_pcs = sorted(
+        [
+            fb_flatc_dict(pcl, SchemaFileNames.POINT_CLOUD_2)
+            for pcl in queried_pcs
+        ],
+        key=lambda pc: pc["header"]["uuid_msgs"],
+    )
+
+    assert len(queried_pcs) == 0
+    assert len(sent_pcs) == 1


### PR DESCRIPTION
Changelog:
- Adds new spatial checking function `checkPartialIntersectionWithZExtrudedPolygon` for `Image` and `Pointcloud` datatypes. It utilizes CGALs `do_intersect` function to check whether two 3D objects with arbitrary pose are intersecting
- 3 new tests for the new check (sketched in the images at the end)
- fix a bug where the maximum for AABB point coordinates is not set properly, when coordinates have negative values

The new tests visualized:
For the Pointcloud test (test_queryPCPreciseNoIntersect):
The cube is the query and the rotated box is the pointcloud.
![test_queryPCPreciseNoIntersect](https://github.com/user-attachments/assets/a29c4f52-ecaa-4814-bde3-e8f0ab502795)
For the image test (test_queryImagePreciseIntersect, test_queryImagePreciseNoIntersect), the cube is the query and the pyramid the camera frustum:
With Intersection.
![test_queryImagePreciseIntersect](https://github.com/user-attachments/assets/154910ff-5fbf-4f28-8100-acd6052a3493)
Without Intersection.
![test_queryImagePreciseNoIntersect](https://github.com/user-attachments/assets/4d4814b4-0881-4650-abc5-5ec4e03986b1)